### PR TITLE
treat from timestamp as exclusive

### DIFF
--- a/echo-cassandra/src/main/groovy/com/netflix/spinnaker/echo/cassandra/TimeSeriesRepository.groovy
+++ b/echo-cassandra/src/main/groovy/com/netflix/spinnaker/echo/cassandra/TimeSeriesRepository.groovy
@@ -72,7 +72,7 @@ class TimeSeriesRepository implements ApplicationListener<ContextRefreshedEvent>
     }
 
     List<Map> eventsByType(String type, long startTime) {
-        def result = runQuery """SELECT keys_and_values, inserted_time FROM events_time_series WHERE inserted_time >= ${startTime} and type = '${type}';"""
+        def result = runQuery """SELECT keys_and_values, inserted_time FROM events_time_series WHERE inserted_time > ${startTime} and type = '${type}';"""
 
         result.result.rows.collect {
             Map event = mapper.readValue(it.columns.getColumnByName('keys_and_values').stringValue, Map)


### PR DESCRIPTION
Tick stores the timestamp of the last event it processed and then uses that on the next poll which ends up in this query. Because it's currently using `>=` Tick will always get the last event of the previous poll as the first of the next poll. It feels hacky to make Tick send _ms+1_.
