### PR TITLE
Specify remaining gradle config to enable buildDeb.

### DIFF
--- a/echo-web/echo-web.gradle
+++ b/echo-web/echo-web.gradle
@@ -80,6 +80,19 @@ sourceSets {
     }
 }
 
+jar {
+    doFirst {
+        exclude "${rootProject.name}.yml"
+    }
+}
+
+startScripts {
+    doLast {
+        unixScript.text = unixScript.text.replace('CLASSPATH=$APP_HOME', 'CLASSPATH=$APP_HOME/config:$APP_HOME')
+        windowsScript.text = windowsScript.text.replace('set CLASSPATH=', 'set CLASSPATH=%APP_HOME%\\config;')
+    }
+}
+
 applicationName = 'echo'
 applicationDefaultJvmArgs = ["-Djava.security.egd=file:/dev/./urandom"]
 applicationDistribution.from(project.file('config')) {


### PR DESCRIPTION
Only use jamm when bootRunning or testing to enable embedded cassandra. Same change as here: https://github.com/spinnaker/mayo/commit/836b8e39dac4bcf0daa111eaf29f220bbf3ad295
@tomaslin please review.
