### PR TITLE
Load properties straight into Spring Boot

### DIFF
--- a/echo-web/src/main/groovy/com/netflix/spinnaker/echo/Application.groovy
+++ b/echo-web/src/main/groovy/com/netflix/spinnaker/echo/Application.groovy
@@ -16,13 +16,11 @@
 
 package com.netflix.spinnaker.echo
 
-import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.web.SpringBootServletInitializer
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
-
 /**
  * Application entry point.
  */
@@ -39,22 +37,12 @@ class Application extends SpringBootServletInitializer {
         'spring.profiles.active': "${System.getProperty('netflix.environment', 'test')},local"
     ]
 
-    static {
-        applyDefaults()
-    }
-
-    static void applyDefaults() {
-        DEFAULT_PROPS.each { k, v ->
-            System.setProperty(k, System.getProperty(k, v))
-        }
-    }
-
     static void main(String... args) {
-        SpringApplication.run this, args
+        new SpringApplicationBuilder().properties(DEFAULT_PROPS).sources(Application).run(args)
     }
 
     @Override
     SpringApplicationBuilder configure(SpringApplicationBuilder builder) {
-        builder.sources(Application)
+        builder.properties(DEFAULT_PROPS).sources(Application)
     }
 }


### PR DESCRIPTION
The current mechanism of writing default propeties straight into the environment breaks the Spring property lifecycle, making it impossible to override certain settings. This path does what's intended, load the default properties into the Spring Boot application builder while still allowing overrides.
