### PR TITLE
event names in rest were being passed as groovy strings as opposed to…

### DIFF
--- a/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/events/RestEventListener.groovy
+++ b/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/events/RestEventListener.groovy
@@ -53,7 +53,7 @@ class RestEventListener implements EchoEventListener {
         Map sentEvent = eventAsMap
         if (service.config.wrap) {
           sentEvent = [
-            "eventName": "${service.config.eventName ?: eventName}",
+            "eventName": "${service.config.eventName ?: eventName}" as String,
           ]
           sentEvent["${service.config.fieldName ?: fieldName}" as String] = eventAsMap
         }


### PR DESCRIPTION
… java strings