### PR TITLE
Add Webhook trigger to echo: PR for code review

### DIFF
--- a/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/Metadata.groovy
+++ b/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/Metadata.groovy
@@ -23,7 +23,6 @@ package com.netflix.spinnaker.echo.model
 class Metadata {
     String source
     String type
-    String category
     String created = new Date().time
     String organization
     String project

--- a/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/Metadata.groovy
+++ b/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/Metadata.groovy
@@ -23,7 +23,7 @@ package com.netflix.spinnaker.echo.model
 class Metadata {
     String source
     String type
-    String triggeredBy
+    String category
     String created = new Date().time
     String organization
     String project

--- a/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/Metadata.groovy
+++ b/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/Metadata.groovy
@@ -23,6 +23,7 @@ package com.netflix.spinnaker.echo.model
 class Metadata {
     String source
     String type
+    String triggeredBy
     String created = new Date().time
     String organization
     String project

--- a/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/TriggerEvent.groovy
+++ b/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/TriggerEvent.groovy
@@ -20,4 +20,5 @@ import com.netflix.spinnaker.echo.model.Metadata
 
 abstract class TriggerEvent {
   Metadata details
+  Map payload
 }

--- a/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/WebhookEvent.groovy
+++ b/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/WebhookEvent.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.model.trigger
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import groovy.transform.Canonical
+
+@Canonical
+@JsonIgnoreProperties(ignoreUnknown = true)
+class WebhookEvent extends TriggerEvent {
+  public static final String TYPE = "WEBHOOK"
+
+  Content content
+
+  @Canonical
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class Content {
+    String type
+    String source
+
+  }
+}

--- a/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/WebhookEvent.groovy
+++ b/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/WebhookEvent.groovy
@@ -23,15 +23,4 @@ import groovy.transform.Canonical
 @JsonIgnoreProperties(ignoreUnknown = true)
 class WebhookEvent extends TriggerEvent {
   public static final String TYPE = "WEBHOOK"
-
-  Content content
-
-  @Canonical
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  static class Content {
-    String type
-    String category
-    String source
-
-  }
 }

--- a/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/WebhookEvent.groovy
+++ b/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/WebhookEvent.groovy
@@ -30,6 +30,7 @@ class WebhookEvent extends TriggerEvent {
   @JsonIgnoreProperties(ignoreUnknown = true)
   static class Content {
     String type
+    String category
     String source
 
   }

--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -33,7 +33,8 @@ public class Trigger {
     CRON("cron"),
     GIT("git"),
     JENKINS("jenkins"),
-    DOCKER("docker");
+    DOCKER("docker"),
+    WEBHOOK("webhook");
 
     private final String type;
 

--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -27,7 +27,7 @@ import java.util.Map;
 @JsonDeserialize(builder = Trigger.TriggerBuilder.class)
 @Builder
 @Wither
-@ToString(of = {"type", "master", "job", "cronExpression", "source", "project", "slug", "registry", "repository", "tag", "extras"}, includeFieldNames = false)
+@ToString(of = {"type", "master", "job", "cronExpression", "source", "project", "slug", "registry", "repository", "tag"}, includeFieldNames = false)
 @Value
 public class Trigger {
   public enum Type {
@@ -65,7 +65,7 @@ public class Trigger {
   String repository;
   String tag;
   String digest;
-  Map extras;
+  Map constraints;
 
 
   public Trigger atBuildNumber(final int buildNumber) {
@@ -80,8 +80,8 @@ public class Trigger {
     return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, null, registry, repository, tag, digest, null);
   }
 
-  public Trigger atExtras(final Map extras) {
-    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, null, registry, repository, tag, null, extras);
+  public Trigger atConstraints(final Map constraints) {
+    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, null, registry, repository, tag, null, constraints);
   }
 
   @JsonPOJOBuilder(withPrefix = "")

--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -22,11 +22,12 @@ import lombok.Builder;
 import lombok.ToString;
 import lombok.Value;
 import lombok.experimental.Wither;
+import java.util.Map;
 
 @JsonDeserialize(builder = Trigger.TriggerBuilder.class)
 @Builder
 @Wither
-@ToString(of = {"type", "master", "job", "cronExpression", "source", "project", "slug", "registry", "repository", "tag", "category"}, includeFieldNames = false)
+@ToString(of = {"type", "master", "job", "cronExpression", "source", "project", "slug", "registry", "repository", "tag", "extras"}, includeFieldNames = false)
 @Value
 public class Trigger {
   public enum Type {
@@ -64,7 +65,8 @@ public class Trigger {
   String repository;
   String tag;
   String digest;
-  String category;
+  Map extras;
+
 
   public Trigger atBuildNumber(final int buildNumber) {
     return new Trigger(enabled, id, type, master, job, buildNumber, propertyFile, cronExpression, source, project, slug, null, registry, repository, null, digest, null);
@@ -78,8 +80,8 @@ public class Trigger {
     return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, null, registry, repository, tag, digest, null);
   }
 
-  public Trigger inCategory(final String type, final String category, final String source) {
-    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, null, registry, repository, tag, null, category);
+  public Trigger atExtras(final Map extras) {
+    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, null, registry, repository, tag, null, extras);
   }
 
   @JsonPOJOBuilder(withPrefix = "")

--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -27,7 +27,7 @@ import java.util.Map;
 @JsonDeserialize(builder = Trigger.TriggerBuilder.class)
 @Builder
 @Wither
-@ToString(of = {"type", "master", "job", "cronExpression", "source", "project", "slug", "registry", "repository", "tag"}, includeFieldNames = false)
+@ToString(of = {"type", "master", "job", "cronExpression", "source", "project", "slug", "registry", "repository", "tag", "constraints"}, includeFieldNames = false)
 @Value
 public class Trigger {
   public enum Type {

--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -26,7 +26,7 @@ import lombok.experimental.Wither;
 @JsonDeserialize(builder = Trigger.TriggerBuilder.class)
 @Builder
 @Wither
-@ToString(of = {"type", "master", "job", "cronExpression", "source", "project", "slug", "registry", "repository", "tag"}, includeFieldNames = false)
+@ToString(of = {"type", "master", "job", "cronExpression", "source", "project", "slug", "registry", "repository", "tag", "category"}, includeFieldNames = false)
 @Value
 public class Trigger {
   public enum Type {
@@ -64,17 +64,22 @@ public class Trigger {
   String repository;
   String tag;
   String digest;
+  String category;
 
   public Trigger atBuildNumber(final int buildNumber) {
-    return new Trigger(enabled, id, type, master, job, buildNumber, propertyFile, cronExpression, source, project, slug, null, registry, repository, null, digest);
+    return new Trigger(enabled, id, type, master, job, buildNumber, propertyFile, cronExpression, source, project, slug, null, registry, repository, null, digest, null);
   }
 
   public Trigger atHash(final String hash) {
-    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, hash, registry, repository, null, digest);
+    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, hash, registry, repository, null, digest, null);
   }
 
   public Trigger atTag(final String tag) {
-    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, null, registry, repository, tag, digest);
+    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, null, registry, repository, tag, digest, null);
+  }
+
+  public Trigger inCategory(final String type, final String category, final String source) {
+    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, null, registry, repository, tag, null, category);
   }
 
   @JsonPOJOBuilder(withPrefix = "")

--- a/echo-pipelinetriggers/echo-pipelinetriggers.gradle
+++ b/echo-pipelinetriggers/echo-pipelinetriggers.gradle
@@ -27,4 +27,8 @@ dependencies {
   compile spinnaker.dependency("okHttp")
   compile spinnaker.dependency("eurekaClient")
   compile spinnaker.dependency("kork")
+
+  compile group: 'org.codehaus.groovy', name: 'groovy', version: "2.4.5"
+  testCompile group: 'org.spockframework', name: 'spock-groovy', version: "2.4"
+
 }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/DockerEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/DockerEventMonitor.java
@@ -94,8 +94,8 @@ public class DockerEventMonitor extends TriggerMonitor {
     String repository = dockerEvent.getContent().getRepository();
     String tag = dockerEvent.getContent().getTag();
     return trigger -> trigger.getType().equals(TRIGGER_TYPE) &&
-      trigger.getRegistry().equals(registry) &&
       trigger.getRepository().equals(repository) &&
+      trigger.getRegistry().equals(registry) &&
       (trigger.getTag() == null || trigger.getTag().equals(tag));
   }
 

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pipelinetriggers.monitor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.echo.model.Event;
+import com.netflix.spinnaker.echo.model.Pipeline;
+import com.netflix.spinnaker.echo.model.Trigger;
+import com.netflix.spinnaker.echo.model.trigger.WebhookEvent;
+import com.netflix.spinnaker.echo.model.trigger.TriggerEvent;
+import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache;
+import lombok.NonNull;
+import lombok.extern.java.Log;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import rx.Observable;
+import rx.functions.Action1;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+@Component @Slf4j
+public class WebhookEventMonitor extends TriggerMonitor {
+
+  public static final String TRIGGER_TYPE = "webhook";
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private final PipelineCache pipelineCache;
+
+  @Autowired
+  public WebhookEventMonitor(@NonNull PipelineCache pipelineCache,
+                             @NonNull Action1<Pipeline> subscriber,
+                             @NonNull Registry registry) {
+    super(subscriber, registry);
+    this.pipelineCache = pipelineCache;
+  }
+
+  @Override
+  public void processEvent(Event event) {
+    super.validateEvent(event);
+    log.info("In processEvent " +  event.getDetails().getType());
+    log.info("In processEvent " + event.getDetails().getSource());
+    log.info("In processEvent " + event.getDetails().getTriggeredBy());
+    if (event.getDetails().getTriggeredBy() == null ||
+        !event.getDetails().getTriggeredBy().equalsIgnoreCase(WebhookEvent.TYPE)) {
+      return;
+    }
+
+    WebhookEvent webhookEvent = objectMapper.convertValue(event, WebhookEvent.class);
+    Observable.just(webhookEvent)
+      .doOnNext(this::onEchoResponse)
+      .subscribe(triggerEachMatchFrom(pipelineCache.getPipelines()));
+  }
+
+  @Override
+  protected boolean isSuccessfulTriggerEvent(final TriggerEvent event) {
+//    WebhookEvent webhookEvent = (WebhookEvent) event;
+//    String type = webhookEvent.getContent().getDigest();
+//    return digest != null && !digest.isEmpty();
+    return true;
+  }
+
+  @Override
+  protected Function<Trigger, Pipeline> buildTrigger(Pipeline pipeline, TriggerEvent event) {
+    //WebhookEvent webhookEvent = (WebhookEvent) event;
+    log.info("In buildTrigger " +  event.getDetails().getType());
+    log.info("In buildTrigger " +  event.getDetails().getSource());
+    return trigger -> pipeline.withTrigger(trigger.atTag(null));
+  }
+
+  @Override
+  protected boolean isValidTrigger(final Trigger trigger) {
+    log.info("In isValidTrigger " +  trigger.getType());
+    log.info("In isValidTrigger " +  trigger.getSource());
+    return trigger.isEnabled() &&
+      (
+        (//TRIGGER_TYPE.equals(trigger.getType()) &&
+          trigger.getType() != null &&
+          trigger.getSource() != null)
+      );
+  }
+
+  @Override
+  protected Predicate<Trigger> matchTriggerFor(final TriggerEvent event) {
+    WebhookEvent webhookEvent = (WebhookEvent) event;
+    String type = webhookEvent.getContent().getType();
+    String source = webhookEvent.getContent().getSource();
+
+    log.info("In matchTriggerFor " +  webhookEvent.getContent().getType());
+    log.info("In matchTriggerFor " +  webhookEvent.getContent().getSource());
+
+    return trigger -> trigger.getType().equals(TRIGGER_TYPE) &&
+      trigger.getType().equals(type) &&
+      trigger.getSource().equals(source);
+  }
+
+  protected void onMatchingPipeline(Pipeline pipeline) {
+    super.onMatchingPipeline(pipeline);
+    val id = registry.createId("pipelines.triggered")
+      .withTag("application", pipeline.getApplication())
+      .withTag("name", pipeline.getName());
+//    id.withTag("imageId", pipeline.getTrigger().getRegistry() + "/" +
+//      pipeline.getTrigger().getRepository() + ":" +
+//      pipeline.getTrigger().getTag());
+    registry.counter(id).increment();
+  }
+}
+

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
@@ -26,6 +26,9 @@ trait RetrofitStubs {
   final Trigger disabledStashTrigger = new Trigger(false, null, 'git', 'master', 'job', null, null, null, 'stash', 'project', 'slug', null, null, null, null, null)
   final Trigger enabledDockerTrigger = new Trigger(true, null, 'docker', null, null, null, null, null, null, null, null, null, 'registry', 'repository', 'tag', null)
   final Trigger disabledDockerTrigger = new Trigger(false, null, 'git', null, null, null, null, null, null, null, null, null, 'registry', 'repository', 'tag', null)
+  final Trigger enabledGenericBuildTrigger = new Trigger(true, null, 'teamcity', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger disabledGenericBuildTrigger = new Trigger(false, null, 'teamcity', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger nonGenericBuildTrigger = new Trigger(true, null, 'not teamcity', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null)
 
   private nextId = new AtomicInteger(1)
 

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.echo.model.Metadata
 import com.netflix.spinnaker.echo.model.trigger.BuildEvent
 import com.netflix.spinnaker.echo.model.trigger.DockerEvent
 import com.netflix.spinnaker.echo.model.trigger.GitEvent
+import com.netflix.spinnaker.echo.model.trigger.WebhookEvent
 import com.netflix.spinnaker.echo.model.Trigger
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -26,9 +27,9 @@ trait RetrofitStubs {
   final Trigger disabledStashTrigger = new Trigger(false, null, 'git', 'master', 'job', null, null, null, 'stash', 'project', 'slug', null, null, null, null, null)
   final Trigger enabledDockerTrigger = new Trigger(true, null, 'docker', null, null, null, null, null, null, null, null, null, 'registry', 'repository', 'tag', null)
   final Trigger disabledDockerTrigger = new Trigger(false, null, 'git', null, null, null, null, null, null, null, null, null, 'registry', 'repository', 'tag', null)
-  final Trigger enabledGenericBuildTrigger = new Trigger(true, null, 'teamcity', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null)
-  final Trigger disabledGenericBuildTrigger = new Trigger(false, null, 'teamcity', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null)
-  final Trigger nonGenericBuildTrigger = new Trigger(true, null, 'not teamcity', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger enabledWebhookTrigger = new Trigger(true, null, 'webhook', null, null, null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger disabledWebhookTrigger = new Trigger(false, null, 'webhook', null, null, null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger nonWebhookTrigger = new Trigger(true, null, 'not webhook', null, null, null, null, null, null, null, null, null, null, null, null, null)
 
   private nextId = new AtomicInteger(1)
 
@@ -55,6 +56,13 @@ trait RetrofitStubs {
     def res = new DockerEvent()
     res.content = new DockerEvent.Content("registry", "repository", "tag", "sha")
     res.details = new Metadata([type: DockerEvent.TYPE, source: "spock"])
+    return res
+  }
+
+  WebhookEvent createWebhookEvent() {
+    def res = new WebhookEvent()
+    res.details = new Metadata([type: "someType", source: "myCIServer"])
+    res.payload = [ "application" : "myApplicationName" ];
     return res
   }
 

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
@@ -20,16 +20,20 @@ import static retrofit.RetrofitError.httpError
 trait RetrofitStubs {
 
   final String url = "http://echo"
-  final Trigger enabledJenkinsTrigger = new Trigger(true, null, 'jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null)
-  final Trigger disabledJenkinsTrigger = new Trigger(false, null, 'jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null)
-  final Trigger nonJenkinsTrigger = new Trigger(true, null, 'not jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null)
-  final Trigger enabledStashTrigger = new Trigger(true, null, 'git', null, null, null, null, null, 'stash', 'project', 'slug', null, null, null, null, null)
-  final Trigger disabledStashTrigger = new Trigger(false, null, 'git', 'master', 'job', null, null, null, 'stash', 'project', 'slug', null, null, null, null, null)
-  final Trigger enabledDockerTrigger = new Trigger(true, null, 'docker', null, null, null, null, null, null, null, null, null, 'registry', 'repository', 'tag', null)
-  final Trigger disabledDockerTrigger = new Trigger(false, null, 'git', null, null, null, null, null, null, null, null, null, 'registry', 'repository', 'tag', null)
+  final Trigger enabledJenkinsTrigger = new Trigger(true, null, 'jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger disabledJenkinsTrigger = new Trigger(false, null, 'jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger nonJenkinsTrigger = new Trigger(true, null, 'not jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger enabledStashTrigger = new Trigger(true, null, 'git', null, null, null, null, null, 'stash', 'project', 'slug', null, null, null, null, null, null)
+  final Trigger disabledStashTrigger = new Trigger(false, null, 'git', 'master', 'job', null, null, null, 'stash', 'project', 'slug', null, null, null, null, null, null)
+  final Trigger enabledDockerTrigger = new Trigger(true, null, 'docker', null, null, null, null, null, null, null, null, null, 'registry', 'repository', 'tag', null, null)
+  final Trigger disabledDockerTrigger = new Trigger(false, null, 'git', null, null, null, null, null, null, null, null, null, 'registry', 'repository', 'tag', null, null)
   final Trigger enabledWebhookTrigger = new Trigger(true, null, 'webhook', null, null, null, null, null, null, null, null, null, null, null, null, null)
   final Trigger disabledWebhookTrigger = new Trigger(false, null, 'webhook', null, null, null, null, null, null, null, null, null, null, null, null, null)
-  final Trigger nonWebhookTrigger = new Trigger(true, null, 'not webhook', null, null, null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger nonWebhookTrigger = Trigger.builder().enabled(true).source('not webhook').build()
+  final Trigger webhookTriggerWithConstraints = Trigger.builder().enabled(true).source('webhook').constraints([ "application": "myApplicationName", "pipeline": "myPipeLineName" ]).build()
+  final Trigger webhookTriggerWithoutConstraints = Trigger.builder().enabled(true).source('webhook').constraints().build()
+  final Trigger teamcityTriggerWithConstraints = Trigger.builder().enabled(true).source('teamcity').constraints([ "application": "myApplicationName", "pipeline": "myPipeLineName" ]).build()
+  final Trigger teamcityTriggerWithoutConstraints = Trigger.builder().enabled(true).source('teamcity').constraints().build()
 
   private nextId = new AtomicInteger(1)
 
@@ -59,10 +63,10 @@ trait RetrofitStubs {
     return res
   }
 
-  WebhookEvent createWebhookEvent() {
+  WebhookEvent createWebhookEvent(String type) {
     def res = new WebhookEvent()
-    res.details = new Metadata([type: "someType", source: "myCIServer"])
-    res.payload = [ "application" : "myApplicationName" ];
+    res.details = new Metadata([type: type, source: "myCIServer"])
+    res.payload = [ application : "myApplicationName" ];
     return res
   }
 

--- a/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineConfigsPollingAgentSpec.groovy
+++ b/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineConfigsPollingAgentSpec.groovy
@@ -36,7 +36,7 @@ class PipelineConfigsPollingAgentSpec extends Specification {
 
     void 'when a new pipeline trigger is added, a scheduled action instance is registered with an id same as the trigger id'() {
         given:
-        Trigger trigger = new Trigger(true, null, 'cron', null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, null, 'cron', null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null, null)
         Pipeline pipeline = buildPipeline([trigger])
         pipelineCache.getPipelines() >> [pipeline]
         actionsOperator.getActionInstances() >> []
@@ -54,7 +54,7 @@ class PipelineConfigsPollingAgentSpec extends Specification {
 
     void 'when an existing pipeline trigger is disabled, corresponding scheduled action is also disabled'() {
         given:
-        Trigger trigger = new Trigger(false, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(false, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null, null)
         Pipeline pipeline = buildPipeline([trigger])
         ActionInstance actionInstance = buildScheduledAction(trigger.id, '* 0/30 * * * ? *', true)
         pipelineCache.getPipelines() >> [pipeline]
@@ -74,7 +74,7 @@ class PipelineConfigsPollingAgentSpec extends Specification {
 
     void 'when an existing disabled pipeline trigger is enabled, corresponding scheduled action is also enabled'() {
         given:
-        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null, null)
         Pipeline pipeline = buildPipeline([trigger])
         ActionInstance actionInstance = buildScheduledAction(trigger.id, '* 0/30 * * * ? *', false)
         pipelineCache.getPipelines() >> [pipeline]
@@ -111,7 +111,7 @@ class PipelineConfigsPollingAgentSpec extends Specification {
 
     void 'when an existing pipeline trigger is updated, corresponding scheduled action is also updated'() {
         given:
-        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/45 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/45 * * * ? *', null, null, null, null, null, null, null, null, null)
         Pipeline pipeline = buildPipeline([trigger])
         ActionInstance actionInstance = buildScheduledAction('t1', '* 0/30 * * * ? *', true)
         pipelineCache.getPipelines() >> [pipeline]
@@ -130,7 +130,7 @@ class PipelineConfigsPollingAgentSpec extends Specification {
 
     void 'when an existing pipeline trigger is updated but is still disabled, corresponding scheduled action is NOT updated'() {
         given:
-        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/45 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/45 * * * ? *', null, null, null, null, null, null, null, null, null)
         Pipeline pipeline = buildPipeline([trigger])
         ActionInstance actionInstance = buildScheduledAction('t1', '* 0/30 * * * ? *', false)
         pipelineCache.getPipelines() >> [pipeline]
@@ -149,7 +149,7 @@ class PipelineConfigsPollingAgentSpec extends Specification {
 
     void 'with no changes to pipeline trigger, no scheduled actions are updated for that pipeline'() {
         given:
-        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null, null)
         Pipeline pipeline = buildPipeline([trigger])
         ActionInstance actionInstance = buildScheduledAction('t1', '* 0/30 * * * ? *', true)
         pipelineCache.getPipelines() >> [pipeline]

--- a/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineTriggerActionConverterSpec.groovy
+++ b/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineTriggerActionConverterSpec.groovy
@@ -41,7 +41,7 @@ class PipelineTriggerActionConverterSpec extends Specification {
 
     void 'toParameters() should return an equivalent map of parameters'() {
         setup:
-        Trigger trigger = new Trigger(true, '123-456', 'cron', null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, '123-456', 'cron', null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null, null)
 
         when:
         Map parameters = PipelineTriggerConverter.toParameters(pipeline, trigger, 'America/New_York')
@@ -84,7 +84,7 @@ class PipelineTriggerActionConverterSpec extends Specification {
 
     void 'toScheduledAction() should return an equivalent valid ActionInstance'() {
         setup:
-        Trigger trigger = new Trigger(true, '123-456', 'cron', null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, '123-456', 'cron', null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null, null)
 
         when:
         ActionInstance actionInstance = PipelineTriggerConverter.toScheduledAction(pipeline, trigger, 'America/Los_Angeles')

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy
@@ -59,6 +59,9 @@ class WebhooksController {
         event.content.repoProject = postedEvent.repository.owner.name
         event.content.slug = postedEvent.repository.name
       }
+    } else if (type == 'build'){
+      //event.details.application = postedEvent.
+
     }
 
     log.info("Webhook ${source}:${type}:${event.content}")

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy
@@ -21,12 +21,7 @@ import com.netflix.spinnaker.echo.model.Event
 import com.netflix.spinnaker.echo.model.Metadata
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RestController
-import com.netflix.spinnaker.echo.model.trigger.WebhookEvent
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @Slf4j
@@ -69,4 +64,19 @@ class WebhooksController {
     }
   }
 
+  @RequestMapping(value = '/webhooks/{type}', method = RequestMethod.POST)
+  void forwardEvent(@PathVariable String type, @RequestBody Map postedEvent) {
+    Event event = new Event()
+    event.details = new Metadata()
+    event.details.type = type
+    event.content = postedEvent
+
+    if (event.content.source != null){
+      event.details.source = event.content.source;
+    }
+
+    log.info("Webhook ${type}:${event.details.source}:${event.content}")
+
+    propagator.processEvent(event)
+  }
 }

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy
@@ -69,39 +69,4 @@ class WebhooksController {
     }
   }
 
-  @RequestMapping(value = '/webhooks/trigger/{category}/{source}', method = RequestMethod.POST)
-  void forwardWebHookEvent(@PathVariable String category, @PathVariable String source, @RequestBody Map postedEvent) {
-    Event event = new Event()
-    boolean sendEvent = true
-    event.details = new Metadata()
-    event.details.type = WebhookEvent.TYPE
-    event.details.category = category
-    event.details.source = source
-    event.content = postedEvent
-
-    if (category == 'git') {
-      if (source == 'stash') {
-        event.content.hash = postedEvent.refChanges?.first().toHash
-        event.content.branch = postedEvent.refChanges?.first().refId.replace('refs/heads/', '')
-        event.content.repoProject = postedEvent.repository.project.key
-        event.content.slug = postedEvent.repository.slug
-        if (event.content.hash.toString().startsWith('000000000')) {
-          sendEvent = false
-        }
-      }
-      if (source == 'github') {
-        event.content.hash = postedEvent.after
-        event.content.branch = postedEvent.ref.replace('refs/heads/', '')
-        event.content.repoProject = postedEvent.repository.owner.name
-        event.content.slug = postedEvent.repository.name
-      }
-    }
-
-    log.info("Webhook ${WebhookEvent.TYPE}:${category}:${source}::${event.content}")
-
-    if (sendEvent) {
-      propagator.processEvent(event)
-    }
-  }
-
 }


### PR DESCRIPTION
This PR is not ready to merge yet. It's for review only.

The main point of discussion is probably that I added a  "category" to the Trigger.
This is because the EventListener in echo usually checks the "type" of the trigger.
The initial proposal by @tomaslin was for the webhook URL to contain the type and source, but makes it difficult to determine that the trigger should only fire for webhook triggers, not any trigger.

I have added a new webhooks end point:   /webhooks/trigger/{category}/{source}
This is because in the WebHookEvent monitor, it made sense to first check that the event was triggered by the webhook POST, not just any "type".

Otherwise, it would be possible to create a Webhook trigger in Deck with a type of Cron or Jenkins and it would allow webhooks to emulate other trigger types. I wasn't really sure this was a good plan or not, but am happy to hear other views. Perhaps this is the power of the webhook endpoint and provides a way to trigger other random triggers intentionally. I just thought it would be too easy to trigger them unintentionally, which would be confusing.