### PR TITLE
PR for review: Adds support for starting a pipeline from a webhook POST.

### DIFF
--- a/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/Event.groovy
+++ b/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/Event.groovy
@@ -24,4 +24,5 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 public class Event {
   Metadata details
   Map content
+  Map payload
 }

--- a/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/WebhookEvent.groovy
+++ b/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/WebhookEvent.groovy
@@ -16,9 +16,11 @@
 
 package com.netflix.spinnaker.echo.model.trigger
 
-import com.netflix.spinnaker.echo.model.Metadata
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import groovy.transform.Canonical
 
-abstract class TriggerEvent {
-  Metadata details
-  Map payload
+@Canonical
+@JsonIgnoreProperties(ignoreUnknown = true)
+class WebhookEvent extends TriggerEvent {
+  public static final String TYPE = "WEBHOOK"
 }

--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -22,18 +22,20 @@ import lombok.Builder;
 import lombok.ToString;
 import lombok.Value;
 import lombok.experimental.Wither;
+import java.util.Map;
 
 @JsonDeserialize(builder = Trigger.TriggerBuilder.class)
 @Builder
 @Wither
-@ToString(of = {"type", "master", "job", "cronExpression", "source", "project", "slug", "registry", "repository", "tag"}, includeFieldNames = false)
+@ToString(of = {"type", "master", "job", "cronExpression", "source", "project", "slug", "registry", "repository", "tag", "constraints"}, includeFieldNames = false)
 @Value
 public class Trigger {
   public enum Type {
     CRON("cron"),
     GIT("git"),
     JENKINS("jenkins"),
-    DOCKER("docker");
+    DOCKER("docker"),
+    WEBHOOK("webhook");
 
     private final String type;
 
@@ -63,17 +65,23 @@ public class Trigger {
   String repository;
   String tag;
   String digest;
+  Map constraints;
+
 
   public Trigger atBuildNumber(final int buildNumber) {
-    return new Trigger(enabled, id, type, master, job, buildNumber, propertyFile, cronExpression, source, project, slug, null, registry, repository, null, digest);
+    return new Trigger(enabled, id, type, master, job, buildNumber, propertyFile, cronExpression, source, project, slug, null, registry, repository, null, digest, null);
   }
 
   public Trigger atHash(final String hash) {
-    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, hash, registry, repository, null, digest);
+    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, hash, registry, repository, null, digest, null);
   }
 
   public Trigger atTag(final String tag) {
-    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, null, registry, repository, tag, digest);
+    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, null, registry, repository, tag, digest, null);
+  }
+
+  public Trigger atConstraints(final Map constraints) {
+    return new Trigger(enabled, id, type, master, job, null, propertyFile, cronExpression, source, project, slug, null, registry, repository, tag, null, constraints);
   }
 
   @JsonPOJOBuilder(withPrefix = "")

--- a/echo-pipelinetriggers/echo-pipelinetriggers.gradle
+++ b/echo-pipelinetriggers/echo-pipelinetriggers.gradle
@@ -27,4 +27,8 @@ dependencies {
   compile spinnaker.dependency("okHttp")
   compile spinnaker.dependency("eurekaClient")
   compile spinnaker.dependency("kork")
+
+  compile group: 'org.codehaus.groovy', name: 'groovy', version: "2.4.5"
+  testCompile "org.spockframework:spock-core:1.0-groovy-2.4"
+
 }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/DockerEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/DockerEventMonitor.java
@@ -94,8 +94,8 @@ public class DockerEventMonitor extends TriggerMonitor {
     String repository = dockerEvent.getContent().getRepository();
     String tag = dockerEvent.getContent().getTag();
     return trigger -> trigger.getType().equals(TRIGGER_TYPE) &&
-      trigger.getRegistry().equals(registry) &&
       trigger.getRepository().equals(repository) &&
+      trigger.getRegistry().equals(registry) &&
       (trigger.getTag() == null || trigger.getTag().equals(tag));
   }
 

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pipelinetriggers.monitor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.echo.model.Event;
+import com.netflix.spinnaker.echo.model.Pipeline;
+import com.netflix.spinnaker.echo.model.Trigger;
+import com.netflix.spinnaker.echo.model.trigger.WebhookEvent;
+import com.netflix.spinnaker.echo.model.trigger.TriggerEvent;
+import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import rx.Observable;
+import rx.functions.Action1;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+@Component @Slf4j
+public class WebhookEventMonitor extends TriggerMonitor {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private final PipelineCache pipelineCache;
+
+  @Autowired
+  public WebhookEventMonitor(@NonNull PipelineCache pipelineCache,
+                             @NonNull Action1<Pipeline> subscriber,
+                             @NonNull Registry registry) {
+    super(subscriber, registry);
+    this.pipelineCache = pipelineCache;
+  }
+
+  @Override
+  public void processEvent(Event event) {
+    super.validateEvent(event);
+    if (event.getDetails().getType() == null) {
+      return;
+    }
+
+    /* Need to create WebhookEvent, since TriggerEvent is abstract */
+    WebhookEvent webhookEvent = objectMapper.convertValue(event, WebhookEvent.class);
+    webhookEvent.setDetails(event.getDetails());
+    webhookEvent.setPayload(event.getContent());
+
+    Observable.just(webhookEvent)
+      .doOnNext(this::onEchoResponse)
+      .subscribe(triggerEachMatchFrom(pipelineCache.getPipelines()));
+  }
+
+  @Override
+  protected boolean isSuccessfulTriggerEvent(final TriggerEvent event) {
+    return true;
+  }
+
+  @Override
+  protected Function<Trigger, Pipeline> buildTrigger(Pipeline pipeline, TriggerEvent event) {
+    return trigger -> pipeline.withTrigger(trigger.atConstraints(event.getPayload()));
+  }
+
+  @Override
+  protected boolean isValidTrigger(final Trigger trigger) {
+    boolean valid =  trigger.isEnabled() &&
+      (
+          trigger.getType() != null
+      );
+
+    return valid;
+  }
+
+  @Override
+  protected Predicate<Trigger> matchTriggerFor(final TriggerEvent event) {
+    String type = event.getDetails().getType();
+
+    return trigger ->
+      trigger.getType().equals(type) &&
+        (
+          // The Constraints in the Trigger could be null. That's OK.
+          trigger.getConstraints() == null ||
+
+            // If the Constraints are present, check that there are equivalents in the webhook payload.
+            (  trigger.getConstraints() != null &&
+               isConstraintInPayload(trigger.getConstraints(), event.getPayload())
+            )
+
+        );
+
+  }
+
+  /**
+   * Check that there is a key in the payload for each constraint declared in a Trigger.
+   * Also check that if there is a value for a given key, that the value matches the value in the payload.
+   * @param constraints A map of constraints configured in the Trigger (eg, created in Deck).
+   * @param payload A map of the payload contents POST'd in the Webhook.
+   * @return Whether every key (and value if applicable) in the constraints map is represented in the payload.
+     */
+  protected boolean isConstraintInPayload(final Map constraints, final Map payload) {
+    for (Object key : constraints.keySet()) {
+      if (!payload.containsKey(key) || payload.get(key) == null) {
+        log.info("Webhook trigger ignored. Item " + key.toString() + " was not found in payload");
+        return false;
+      }
+      if (!constraints.get(key).equals("") && (!constraints.get(key).equals(payload.get(key)))){
+        log.info("Webhook trigger ignored. Value of item " + key.toString() + " in payload does not match constraint");
+        return false;
+      }
+    }
+    return true;
+  }
+
+  protected void onMatchingPipeline(Pipeline pipeline) {
+    super.onMatchingPipeline(pipeline);
+    val id = registry.createId("pipelines.triggered")
+      .withTag("application", pipeline.getApplication())
+      .withTag("name", pipeline.getName());
+    id.withTag("type", pipeline.getTrigger().getType());
+    registry.counter(id).increment();
+  }
+}
+

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.echo.model.Metadata
 import com.netflix.spinnaker.echo.model.trigger.BuildEvent
 import com.netflix.spinnaker.echo.model.trigger.DockerEvent
 import com.netflix.spinnaker.echo.model.trigger.GitEvent
+import com.netflix.spinnaker.echo.model.trigger.WebhookEvent
 import com.netflix.spinnaker.echo.model.Trigger
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -19,13 +20,20 @@ import static retrofit.RetrofitError.httpError
 trait RetrofitStubs {
 
   final String url = "http://echo"
-  final Trigger enabledJenkinsTrigger = new Trigger(true, null, 'jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null)
-  final Trigger disabledJenkinsTrigger = new Trigger(false, null, 'jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null)
-  final Trigger nonJenkinsTrigger = new Trigger(true, null, 'not jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null)
-  final Trigger enabledStashTrigger = new Trigger(true, null, 'git', null, null, null, null, null, 'stash', 'project', 'slug', null, null, null, null, null)
-  final Trigger disabledStashTrigger = new Trigger(false, null, 'git', 'master', 'job', null, null, null, 'stash', 'project', 'slug', null, null, null, null, null)
-  final Trigger enabledDockerTrigger = new Trigger(true, null, 'docker', null, null, null, null, null, null, null, null, null, 'registry', 'repository', 'tag', null)
-  final Trigger disabledDockerTrigger = new Trigger(false, null, 'git', null, null, null, null, null, null, null, null, null, 'registry', 'repository', 'tag', null)
+  final Trigger enabledJenkinsTrigger = new Trigger(true, null, 'jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger disabledJenkinsTrigger = new Trigger(false, null, 'jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger nonJenkinsTrigger = new Trigger(true, null, 'not jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger enabledStashTrigger = new Trigger(true, null, 'git', null, null, null, null, null, 'stash', 'project', 'slug', null, null, null, null, null, null)
+  final Trigger disabledStashTrigger = new Trigger(false, null, 'git', 'master', 'job', null, null, null, 'stash', 'project', 'slug', null, null, null, null, null, null)
+  final Trigger enabledDockerTrigger = new Trigger(true, null, 'docker', null, null, null, null, null, null, null, null, null, 'registry', 'repository', 'tag', null, null)
+  final Trigger disabledDockerTrigger = new Trigger(false, null, 'git', null, null, null, null, null, null, null, null, null, 'registry', 'repository', 'tag', null, null)
+  final Trigger enabledWebhookTrigger = new Trigger(true, null, 'webhook', null, null, null, null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger disabledWebhookTrigger = new Trigger(false, null, 'webhook', null, null, null, null, null, null, null, null, null, null, null, null, null, null)
+  final Trigger nonWebhookTrigger = Trigger.builder().enabled(true).type('not webhook').build()
+  final Trigger webhookTriggerWithConstraints = Trigger.builder().enabled(true).type('webhook').constraints([ "application": "myApplicationName", "pipeline": "myPipeLineName" ]).build()
+  final Trigger webhookTriggerWithoutConstraints = Trigger.builder().enabled(true).type('webhook').constraints().build()
+  final Trigger teamcityTriggerWithConstraints = Trigger.builder().enabled(true).type('teamcity').constraints([ "application": "myApplicationName", "pipeline": "myPipeLineName" ]).build()
+  final Trigger teamcityTriggerWithoutConstraints = Trigger.builder().enabled(true).type('teamcity').constraints().build()
 
   private nextId = new AtomicInteger(1)
 
@@ -52,6 +60,13 @@ trait RetrofitStubs {
     def res = new DockerEvent()
     res.content = new DockerEvent.Content("registry", "repository", "tag", "sha")
     res.details = new Metadata([type: DockerEvent.TYPE, source: "spock"])
+    return res
+  }
+
+  WebhookEvent createWebhookEvent(String type) {
+    def res = new WebhookEvent()
+    res.details = new Metadata([type: type, source: "myCIServer"])
+    res.payload = [ application : "myApplicationName" ];
     return res
   }
 

--- a/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineConfigsPollingAgentSpec.groovy
+++ b/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineConfigsPollingAgentSpec.groovy
@@ -36,7 +36,7 @@ class PipelineConfigsPollingAgentSpec extends Specification {
 
     void 'when a new pipeline trigger is added, a scheduled action instance is registered with an id same as the trigger id'() {
         given:
-        Trigger trigger = new Trigger(true, null, 'cron', null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, null, 'cron', null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null, null)
         Pipeline pipeline = buildPipeline([trigger])
         pipelineCache.getPipelines() >> [pipeline]
         actionsOperator.getActionInstances() >> []
@@ -54,7 +54,7 @@ class PipelineConfigsPollingAgentSpec extends Specification {
 
     void 'when an existing pipeline trigger is disabled, corresponding scheduled action is also disabled'() {
         given:
-        Trigger trigger = new Trigger(false, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(false, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null, null)
         Pipeline pipeline = buildPipeline([trigger])
         ActionInstance actionInstance = buildScheduledAction(trigger.id, '* 0/30 * * * ? *', true)
         pipelineCache.getPipelines() >> [pipeline]
@@ -74,7 +74,7 @@ class PipelineConfigsPollingAgentSpec extends Specification {
 
     void 'when an existing disabled pipeline trigger is enabled, corresponding scheduled action is also enabled'() {
         given:
-        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null, null)
         Pipeline pipeline = buildPipeline([trigger])
         ActionInstance actionInstance = buildScheduledAction(trigger.id, '* 0/30 * * * ? *', false)
         pipelineCache.getPipelines() >> [pipeline]
@@ -111,7 +111,7 @@ class PipelineConfigsPollingAgentSpec extends Specification {
 
     void 'when an existing pipeline trigger is updated, corresponding scheduled action is also updated'() {
         given:
-        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/45 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/45 * * * ? *', null, null, null, null, null, null, null, null, null)
         Pipeline pipeline = buildPipeline([trigger])
         ActionInstance actionInstance = buildScheduledAction('t1', '* 0/30 * * * ? *', true)
         pipelineCache.getPipelines() >> [pipeline]
@@ -130,7 +130,7 @@ class PipelineConfigsPollingAgentSpec extends Specification {
 
     void 'when an existing pipeline trigger is updated but is still disabled, corresponding scheduled action is NOT updated'() {
         given:
-        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/45 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/45 * * * ? *', null, null, null, null, null, null, null, null, null)
         Pipeline pipeline = buildPipeline([trigger])
         ActionInstance actionInstance = buildScheduledAction('t1', '* 0/30 * * * ? *', false)
         pipelineCache.getPipelines() >> [pipeline]
@@ -149,7 +149,7 @@ class PipelineConfigsPollingAgentSpec extends Specification {
 
     void 'with no changes to pipeline trigger, no scheduled actions are updated for that pipeline'() {
         given:
-        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, 't1', Trigger.Type.CRON.toString(), null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null, null)
         Pipeline pipeline = buildPipeline([trigger])
         ActionInstance actionInstance = buildScheduledAction('t1', '* 0/30 * * * ? *', true)
         pipelineCache.getPipelines() >> [pipeline]

--- a/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineTriggerActionConverterSpec.groovy
+++ b/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineTriggerActionConverterSpec.groovy
@@ -41,7 +41,7 @@ class PipelineTriggerActionConverterSpec extends Specification {
 
     void 'toParameters() should return an equivalent map of parameters'() {
         setup:
-        Trigger trigger = new Trigger(true, '123-456', 'cron', null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, '123-456', 'cron', null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null, null)
 
         when:
         Map parameters = PipelineTriggerConverter.toParameters(pipeline, trigger, 'America/New_York')
@@ -84,7 +84,7 @@ class PipelineTriggerActionConverterSpec extends Specification {
 
     void 'toScheduledAction() should return an equivalent valid ActionInstance'() {
         setup:
-        Trigger trigger = new Trigger(true, '123-456', 'cron', null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null)
+        Trigger trigger = new Trigger(true, '123-456', 'cron', null, null, null, null, '* 0/30 * * * ? *', null, null, null, null, null, null, null, null, null)
 
         when:
         ActionInstance actionInstance = PipelineTriggerConverter.toScheduledAction(pipeline, trigger, 'America/Los_Angeles')

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy
@@ -21,11 +21,7 @@ import com.netflix.spinnaker.echo.model.Event
 import com.netflix.spinnaker.echo.model.Metadata
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @Slf4j
@@ -61,11 +57,26 @@ class WebhooksController {
       }
     }
 
-    log.info("Webhook ${source}:${type}:${event.content}")
+    log.info("Webhook ${type}:${source}:${event.content}")
 
     if (sendEvent) {
       propagator.processEvent(event)
     }
   }
 
+  @RequestMapping(value = '/webhooks/{type}', method = RequestMethod.POST)
+  void forwardEvent(@PathVariable String type, @RequestBody Map postedEvent) {
+    Event event = new Event()
+    event.details = new Metadata()
+    event.details.type = type
+    event.content = postedEvent
+
+    if (event.content.source != null) {
+      event.details.source = event.content.source;
+    }
+
+    log.info("Webhook ${type}:${event.details.source}:${event.content}")
+
+    propagator.processEvent(event)
+  }
 }


### PR DESCRIPTION
Note: This is a new PR to replace #81 

Webhook support expects a JSON payload in the POST.
This JSON is a map of items. These items are compared
to a map of "constraints" in the Trigger configuration.

If all the constraints have matching items in the payload
map, the pipeline trigger fires.

Constraints that have a name and value must have an exact
match in the webhook payload.
Constraints that have a name but the value is an empty string
are considered met as long as there is an item in the payload
with the same name, regardless of the value of the item in the
payload JSON.