### PR TITLE
triggers: fix webhook bug

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
@@ -37,6 +37,8 @@ import java.util.function.Predicate;
 @Component @Slf4j
 public class WebhookEventMonitor extends TriggerMonitor {
 
+  public static final String TRIGGER_TYPE = "webhook";
+
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   private final PipelineCache pipelineCache;
@@ -80,7 +82,7 @@ public class WebhookEventMonitor extends TriggerMonitor {
   protected boolean isValidTrigger(final Trigger trigger) {
     boolean valid =  trigger.isEnabled() &&
       (
-          trigger.getType() != null
+          TRIGGER_TYPE.equals(trigger.getType())
       );
 
     return valid;


### PR DESCRIPTION
The webhook trigger added in https://github.com/spinnaker/echo/pull/85 never verified that the trigger type was correct, but only that the incoming trigger type matched that of an arbitrary registered trigger. The result is that with this code, an incoming jenkins trigger would kick off every jenkins triggered pipeline once, and the correct jenkins triggered pipeline a second time. I'm guessing this wasn't caught since that code was never released.

@spinnaker/reviewers PTAL