### PR TITLE
docker: Avoid duplicate triggers

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/DockerEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/DockerEventMonitor.java
@@ -96,7 +96,8 @@ public class DockerEventMonitor extends TriggerMonitor {
     return trigger -> trigger.getType().equals(TRIGGER_TYPE) &&
       trigger.getRepository().equals(repository) &&
       trigger.getRegistry().equals(registry) &&
-      (trigger.getTag() == null || trigger.getTag().equals(tag));
+      ((trigger.getTag() == null && !tag.equals("latest"))
+        || trigger.getTag() != null && trigger.getTag().equals(tag));
   }
 
   protected void onMatchingPipeline(Pipeline pipeline) {


### PR DESCRIPTION
@duftler When a tag isn't specified, don't trigger on changes to "latest", since 1. specifying "latest" as the source tag is anti-pattern, and 2. this will cause duplicate builds when "latest" is a valid tag, and a change to separate tag was pushed (and expected).