### PR TITLE
add connectionPool configuration that seems to soothe the OkHttpClient

### DIFF
--- a/echo-web/src/main/groovy/com/netflix/spinnaker/echo/config/Front50Config.groovy
+++ b/echo-web/src/main/groovy/com/netflix/spinnaker/echo/config/Front50Config.groovy
@@ -19,6 +19,7 @@
 package com.netflix.spinnaker.echo.config
 
 import com.netflix.spinnaker.config.OkHttpClientConfiguration
+import com.squareup.okhttp.ConnectionPool
 import com.squareup.okhttp.OkHttpClient
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -42,9 +43,21 @@ class Front50Config {
   @Autowired
   OkHttpClientConfiguration okHttpClientConfig
 
+  @Value('${okHttpClient.connectionPool.maxIdleConnections:5}')
+  int maxIdleConnections
+
+  @Value('${okHttpClient.connectionPool.keepAliveDurationMs:300000}')
+  int keepAliveDurationMs
+
+  @Value('${okHttpClient.retryOnConnectionFailure:true}')
+  boolean retryOnConnectionFailure
+
   @Bean
   OkHttpClient okHttpClient() {
-    return okHttpClientConfig.create()
+    def cli = okHttpClientConfig.create()
+    cli.connectionPool = new ConnectionPool(maxIdleConnections, keepAliveDurationMs)
+    cli.retryOnConnectionFailure = retryOnConnectionFailure
+    return cli
   }
 
   @Bean


### PR DESCRIPTION
the spring config around retrofit is a horrible horrible mess in this app due to the way it has
frankensteined together all the previous services, but this config change should only be
necessary for the connections to front50 and orca where it will get picked up

@spinnaker/netflix-reviewers FYI