### PR TITLE
Update logrotate file permissions

### DIFF
--- a/echo-web/echo-web.gradle
+++ b/echo-web/echo-web.gradle
@@ -127,6 +127,7 @@ ospackage {
         into('/etc/logrotate.d')
         user = 'root'
         permissionGroup = 'root'
+        fileMode = 0644
         fileType = CONFIG | NOREPLACE
     }
 


### PR DESCRIPTION
This change will fix problems where logrotate ignores
/etc/logrotate.d/echo due to 'bad file mode.'

For Spinnaker issue [#904](https://github.com/spinnaker/spinnaker/issues/904)