### PR TITLE
do not fire triggers if pipeline is disabled

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
@@ -46,6 +46,9 @@ import java.util.Map;
   boolean parallel;
 
   @JsonProperty
+  boolean disabled;
+
+  @JsonProperty
   boolean limitConcurrent;
 
   @JsonProperty

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/TriggerMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/TriggerMonitor.java
@@ -90,7 +90,7 @@ abstract class TriggerMonitor implements EchoEventListener {
   protected Func1<Pipeline, Optional<Pipeline>> withMatchingTrigger(final TriggerEvent event) {
     val triggerPredicate = matchTriggerFor(event);
     return pipeline -> {
-      if (pipeline.getTriggers() == null) {
+      if (pipeline.getTriggers() == null || pipeline.isDisabled()) {
         return Optional.empty();
       } else {
         return pipeline.getTriggers()


### PR DESCRIPTION
Working on the ability to disable pipelines...

Is this all we'd need to do to stop triggering if `disabled: true` is set on the pipeline config?

@tomaslin @cfieber @ajordens PTAL