### PR TITLE
Adding in-memory scheduler compensation job

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaService.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaService.java
@@ -16,29 +16,61 @@
 
 package com.netflix.spinnaker.echo.pipelinetriggers.orca;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.netflix.spinnaker.echo.model.Pipeline;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import retrofit.http.Body;
 import retrofit.http.Header;
+import retrofit.http.GET;
 import retrofit.http.POST;
+import retrofit.http.Query;
 import rx.Observable;
+
+import java.util.Collection;
 
 public interface OrcaService {
   @POST("/orchestrate")
-  Observable<Response> trigger(@Body Pipeline pipeline);
+  Observable<TriggerResponse> trigger(@Body Pipeline pipeline);
 
   @POST("/orchestrate")
-  Observable<Response> trigger(@Body Pipeline pipeline, @Header(AuthenticatedRequest.SPINNAKER_USER) String runAsUser);
+  Observable<TriggerResponse> trigger(@Body Pipeline pipeline, @Header(AuthenticatedRequest.SPINNAKER_USER) String runAsUser);
 
-  class Response {
+  @GET("/pipelines")
+  Observable<Collection<PipelineResponse>> getLatestPipelineExecutions(@Query("pipelineConfigIds") Collection<String> pipelineIds);
+
+
+  class TriggerResponse {
     private String ref;
 
-    public Response() {
+    public TriggerResponse() {
       // do nothing
     }
 
     public String getRef() {
       return ref;
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  class PipelineResponse {
+    private String id;
+    private String pipelineConfigId;
+    private Long startTime;
+
+    public PipelineResponse() {
+      // do nothing
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getPipelineConfigId() {
+      return pipelineConfigId;
+    }
+
+    public Long getStartTime() {
+      return startTime;
     }
   }
 }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
@@ -1,9 +1,7 @@
 package com.netflix.spinnaker.echo.pipelinetriggers.orca;
 
-import javax.annotation.PostConstruct;
 import com.netflix.spinnaker.echo.model.Pipeline;
-import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService;
-import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService.Response;
+import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService.TriggerResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,6 +9,8 @@ import org.springframework.boot.actuate.metrics.CounterService;
 import org.springframework.stereotype.Component;
 import rx.Observable;
 import rx.functions.Action1;
+
+import javax.annotation.PostConstruct;
 
 /**
  * Triggers a {@link Pipeline} by invoking _Orca_.
@@ -50,7 +50,7 @@ public class PipelineInitiator implements Action1<Pipeline> {
         runAsUser = pipeline.getTrigger().getRunAsUser();
       }
 
-      Observable<OrcaService.Response> response;
+      Observable<OrcaService.TriggerResponse> response;
       if (runAsUser != null && !runAsUser.isEmpty()) {
         response = orca.trigger(pipeline, pipeline.getTrigger().getRunAsUser());
       } else {
@@ -62,7 +62,7 @@ public class PipelineInitiator implements Action1<Pipeline> {
     }
   }
 
-  private void onOrcaResponse(Response response) {
+  private void onOrcaResponse(TriggerResponse response) {
     log.info("Triggered pipeline {}", response.getRef());
   }
 

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/MissedPipelineTriggerCompensationJob.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/MissedPipelineTriggerCompensationJob.groovy
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.scheduler.actions.pipeline.impl
+
+import com.netflix.spinnaker.echo.model.Pipeline
+import com.netflix.spinnaker.echo.model.Trigger
+import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache
+import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService
+import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService.PipelineResponse
+import com.netflix.spinnaker.echo.pipelinetriggers.orca.PipelineInitiator
+import groovy.util.logging.Slf4j
+import org.quartz.CronExpression
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.actuate.metrics.CounterService
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.context.ApplicationListener
+import org.springframework.context.event.ContextRefreshedEvent
+import org.springframework.stereotype.Component
+import rx.Observable
+import rx.Scheduler
+import rx.Subscription
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+
+/**
+ * Finds and executes all pipeline triggers that should have run in the last configured time window during startup.
+ * This job will wait until the {@link com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache} has run prior to
+ * finding any missed triggers.
+ */
+@ConditionalOnExpression('${scheduler.enabled:false && scheduler.compensationJob.enabled:false}')
+@Component
+@Slf4j
+class MissedPipelineTriggerCompensationJob implements ApplicationListener<ContextRefreshedEvent> {
+
+  final static int POLLING_INTERVAL_SECONDS = 5
+
+  final Scheduler scheduler
+  final PipelineCache pipelineCache
+  final OrcaService orcaService
+  final CounterService counter
+  final PipelineInitiator pipelineInitiator
+  final DateContext dateContext
+
+  transient Subscription subscription
+
+  @Autowired
+  MissedPipelineTriggerCompensationJob(Scheduler scheduler,
+                                       PipelineCache pipelineCache,
+                                       OrcaService orcaService,
+                                       PipelineInitiator pipelineInitiator,
+                                       CounterService counter,
+                                       @Value('${scheduler.compensationJob.windowMs:1800000}') long compensationWindowMs,
+                                       @Value('${scheduler.cron.timezone:America/Los_Angeles}') String timeZoneId) {
+    this(scheduler, pipelineCache, orcaService, pipelineInitiator, counter, compensationWindowMs, timeZoneId, null)
+  }
+
+  MissedPipelineTriggerCompensationJob(Scheduler scheduler,
+                                       PipelineCache pipelineCache,
+                                       OrcaService orcaService,
+                                       PipelineInitiator pipelineInitiator,
+                                       CounterService counter,
+                                       @Value('${scheduler.compensationJob.windowMs:1800000}') long compensationWindowMs,
+                                       @Value('${scheduler.cron.timezone:America/Los_Angeles}') String timeZoneId,
+                                       DateContext dateContext) {
+    this.scheduler = scheduler
+    this.pipelineCache = pipelineCache
+    this.orcaService = orcaService
+    this.pipelineInitiator = pipelineInitiator
+    this.counter = counter
+    this.dateContext = dateContext ?: DateContext.fromCompensationWindow(timeZoneId, compensationWindowMs)
+  }
+
+  @Override
+  void onApplicationEvent(ContextRefreshedEvent event) {
+    if (subscription == null) {
+      subscription = Observable.interval(POLLING_INTERVAL_SECONDS, TimeUnit.SECONDS, scheduler)
+        .doOnNext { onPipelineCacheAwait(it) }
+        .flatMap { tick -> Observable.just(pipelineCache.pipelines) }
+        .doOnError { onPipelineCacheError(it) }
+        .retry()
+        .subscribe { List<Pipeline> pipelines ->
+          if (pipelines.size() == 0) {
+            return
+          }
+          triggerMissedExecutions(pipelines)
+          subscription.unsubscribe()
+        }
+    }
+  }
+
+  void onPipelineCacheAwait(long tick) {
+    log.info('Waiting for pipeline cache to fill')
+  }
+
+  void onPipelineCacheError(Throwable t) {
+    log.error("Error waiting for pipeline cache: ${t.message}")
+  }
+
+  void triggerMissedExecutions(List<Pipeline> pipelines) {
+    log.info('Looking for missed pipeline executions from cron triggers')
+
+    pipelines = pipelines.findAll { !it.disabled }
+    List<Trigger> triggers = getEnabledCronTriggers(pipelines)
+
+    List<String> ids = getPipelineConfigIds(pipelines, triggers)
+    orcaService.getLatestPipelineExecutions(ids)
+      .subscribe({
+        onOrcaResponse(it, pipelines, triggers)
+      }, { onOrcaError(it) })
+  }
+
+  void onOrcaResponse(Collection<PipelineResponse> response, List<Pipeline> pipelines, List<Trigger> triggers) {
+    triggers.each { trigger ->
+      Pipeline pipeline = pipelines.find { it.triggers*.id.contains(trigger.id) }
+      List<Date> executions = response.findAll { it.pipelineConfigId == pipeline.id }.collect {
+        // A null value is valid; a pipeline that hasn't started won't get re-triggered.
+        it.startTime != null ? new Date(it.startTime) : null
+      }
+
+      if (executions.size() == 0) {
+        return
+      }
+
+      def lastExecution = executions.first()
+      if (lastExecution == null) {
+        return
+      }
+
+      def expr = new CronExpression(trigger.cronExpression)
+      expr.timeZone = dateContext.timeZone
+
+      if (missedExecution(expr, lastExecution, dateContext.triggerWindowFloor, dateContext.now)) {
+        log.info("Triggering missed execution on pipeline application:${pipeline.application}, pipelineConfigId:${pipeline.id}")
+        pipelineInitiator.call(pipeline)
+      }
+    }
+  }
+
+  void onOrcaError(Throwable error) {
+    log.error("Error retrieving latest pipeline executions", error)
+    counter.increment('orca.errors')
+  }
+
+  static List<Trigger> getEnabledCronTriggers(List<Pipeline> pipelines) {
+    (List<Trigger>) pipelines
+      .collect { it.triggers }
+      .flatten()
+      .findAll { Trigger it -> it && it.enabled && it.type == Trigger.Type.CRON.toString() }
+  }
+
+  /**
+   * Missed executions are calculated by any `lastExecution` being between `now` and `now - windowFloor`.
+   */
+  static boolean missedExecution(CronExpression expr, Date lastExecution, Date windowFloor, Date now) {
+    // Quartz works at the minute-level, so given 12:00:00, the next "valid" time will be 12:00:01. Without
+    // bumping the lastExecution to the next invalid time, we would double-trigger timely cron executions.
+    lastExecution = expr.getNextInvalidTimeAfter(lastExecution)
+
+    if (lastExecution.before(windowFloor)) {
+      // The last execution is past the point of no return, as far as the compensation job is concerned.
+      return false
+    }
+
+    def nextExecution = expr.getNextValidTimeAfter(lastExecution)
+    while (true) {
+      if (nextExecution.after(windowFloor)) {
+        break
+      }
+      nextExecution = expr.getNextValidTimeAfter(nextExecution)
+    }
+
+    return nextExecution.before(now)
+  }
+
+  static List<String> getPipelineConfigIds(List<Pipeline> pipelines, List<Trigger> cronTriggers) {
+    pipelines.findAll { pipeline ->
+      !pipeline.disabled && cronTriggers.find { pipeline.triggers?.contains(it) }
+    }.collect { it.id }
+  }
+
+  static class DateContext {
+    TimeZone timeZone
+    Date triggerWindowFloor
+    Date now
+
+    static DateContext fromCompensationWindow(String timeZoneId, long compensationWindowMs) {
+      Clock clock = Clock.system(ZoneId.of(timeZoneId))
+      TimeZone tz = TimeZone.getTimeZone(clock.zone)
+      Date triggerWindowFloor = Date.from(Instant.now(clock).minus(compensationWindowMs, ChronoUnit.MILLIS))
+      Date now = Date.from(Instant.now(clock))
+      return new DateContext(timeZone: tz, triggerWindowFloor: triggerWindowFloor, now: now)
+    }
+  }
+}

--- a/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/MissedPipelineTriggerCompensationJobSpec.groovy
+++ b/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/MissedPipelineTriggerCompensationJobSpec.groovy
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.scheduler.actions.pipeline
+
+import com.netflix.spinnaker.echo.model.Pipeline
+import com.netflix.spinnaker.echo.model.Trigger
+import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache
+import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService
+import com.netflix.spinnaker.echo.pipelinetriggers.orca.PipelineInitiator
+import com.netflix.spinnaker.echo.scheduler.actions.pipeline.impl.MissedPipelineTriggerCompensationJob
+import org.quartz.CronExpression
+import org.springframework.boot.actuate.metrics.CounterService
+import rx.schedulers.Schedulers
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.Clock
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+
+class MissedPipelineTriggerCompensationJobSpec extends Specification {
+  def scheduler = Schedulers.test()
+  def pipelineCache = Mock(PipelineCache)
+  def orcaService = Mock(OrcaService)
+  def pipelineInitiator = Mock(PipelineInitiator)
+  def counterService = Stub(CounterService)
+
+  def 'should trigger pipelines for all missed executions'() {
+    given:
+    def pipelines = [
+      pipelineBuilder('1').disabled(false).triggers([
+        new Trigger.TriggerBuilder().id('1').type(Trigger.Type.CRON.toString()).cronExpression('* 0/30 * * * ? *').enabled(true).build(),
+        new Trigger.TriggerBuilder().id('2').type(Trigger.Type.JENKINS.toString()).enabled(true).build()
+      ]).build(),
+      pipelineBuilder('2').disabled(true).triggers([
+        new Trigger.TriggerBuilder().id('3').type(Trigger.Type.CRON.toString()).cronExpression('* 0/30 * * * ? *').enabled(true).build()
+      ]).build(),
+      pipelineBuilder('3').disabled(false).triggers([
+        new Trigger.TriggerBuilder().id('4').type(Trigger.Type.JENKINS.toString()).enabled(true).build()
+      ]).build(),
+      pipelineBuilder('4').disabled(false).triggers([
+        new Trigger.TriggerBuilder().id('5').type(Trigger.Type.CRON.toString()).cronExpression('* 0/30 * * * ? *').enabled(false).build()
+      ]).build()
+    ]
+
+    and:
+    def dateContext = new MissedPipelineTriggerCompensationJob.DateContext(
+      timeZone: TimeZone.getTimeZone('America/Los_Angeles'),
+      triggerWindowFloor: getDateOffset(0),
+      now: getDateOffset(50)
+    )
+    def compensationJob = new MissedPipelineTriggerCompensationJob(scheduler, pipelineCache, orcaService, pipelineInitiator, counterService, 30000, 'America/Los_Angeles', dateContext)
+
+    when:
+    compensationJob.triggerMissedExecutions(pipelines)
+
+    then:
+    1 * orcaService.getLatestPipelineExecutions(_) >> {
+      rx.Observable.just([
+        new OrcaService.PipelineResponse(pipelineConfigId: '1', startTime: getDateOffset(0).time),
+        new OrcaService.PipelineResponse(pipelineConfigId: '2', startTime: getDateOffset(0).time),
+        new OrcaService.PipelineResponse(pipelineConfigId: '3', startTime: getDateOffset(0).time),
+        new OrcaService.PipelineResponse(pipelineConfigId: '3', startTime: null),
+        new OrcaService.PipelineResponse(pipelineConfigId: '4', startTime: getDateOffset(0).time),
+        new OrcaService.PipelineResponse(pipelineConfigId: '4', startTime: getDateOffset(30).time)
+      ])
+    }
+    1 * pipelineInitiator.call((Pipeline) pipelines[0])
+    0 * _
+  }
+
+  def 'should no-op with no missed executions'() {
+    given:
+    def pipelines = [
+      pipelineBuilder('1').disabled(false).triggers([
+        new Trigger.TriggerBuilder().id('1').type(Trigger.Type.CRON.toString()).cronExpression('* 0/30 * * * ? *').enabled(true).build()
+      ]).build(),
+      pipelineBuilder('2').disabled(false).triggers([
+        new Trigger.TriggerBuilder().id('2').type(Trigger.Type.CRON.toString()).cronExpression('* 0/30 * * * ? *').enabled(true).build()
+      ]).build()
+    ]
+
+    and:
+    def dateContext = new MissedPipelineTriggerCompensationJob.DateContext(
+      timeZone: TimeZone.getTimeZone('America/Los_Angeles'),
+      triggerWindowFloor: getDateOffset(0),
+      now: getDateOffset(0)
+    )
+    def compensationJob = new MissedPipelineTriggerCompensationJob(scheduler, pipelineCache, orcaService, pipelineInitiator, counterService, 30000, 'America/Los_Angeles', dateContext)
+
+    when:
+    compensationJob.triggerMissedExecutions(pipelines)
+
+    then:
+    1 * orcaService.getLatestPipelineExecutions(_) >> {
+      rx.Observable.just([
+        new OrcaService.PipelineResponse(pipelineConfigId: '1', startTime: getDateOffset(0).time)
+      ])
+    }
+    0 * pipelineInitiator.call(_)
+    0 * _
+  }
+
+  def 'should use only enabled cron triggers'() {
+    given:
+    def pipelines = [
+      pipelineBuilder('1').triggers([
+        new Trigger.TriggerBuilder().id('1').type(Trigger.Type.CRON.toString()).enabled(true).build(),
+        new Trigger.TriggerBuilder().id('2').type(Trigger.Type.CRON.toString()).enabled(false).build()
+      ]).build(),
+      pipelineBuilder('2').build(),
+      pipelineBuilder('3').triggers([
+        new Trigger.TriggerBuilder().id('3').enabled(true).build(),
+        new Trigger.TriggerBuilder().id('4').enabled(false).build(),
+        new Trigger.TriggerBuilder().id('5').type(Trigger.Type.CRON.toString()).enabled(true).build()
+      ]).build()
+    ]
+
+    when:
+    def result = MissedPipelineTriggerCompensationJob.getEnabledCronTriggers(pipelines)
+
+    then:
+    result.collect { it.id } == ['1', '5']
+  }
+
+  @Unroll
+  def 'should evaluate missed executions only in window'() {
+    given:
+    def clock = Clock.systemDefaultZone()
+
+    def expr = new CronExpression(cronExpression)
+    expr.timeZone = TimeZone.getTimeZone(clock.zone)
+
+    def lastExecution = getDateOffset(lastExecutionMinutes)
+    def windowFloor = getDateOffset(windowFloorMinutes)
+    def now = getDateOffset(nowMinutes)
+
+    when:
+    def result = MissedPipelineTriggerCompensationJob.missedExecution(expr, lastExecution, windowFloor, now)
+
+    then:
+    result == missedExecution
+
+    where:
+    // windowFloorMinutes is a little weird: This is the time marker the windowFloor is located at.
+    // If we had a `now` of 40 and our `windowFloorMs = 1800000` (30m), `windowFloorMinutes` would be `10`.
+    cronExpression     | lastExecutionMinutes | windowFloorMinutes | nowMinutes || missedExecution
+    '* 0/30 * * * ? *' | 0                    | 0                  | 0          || false  // lastExecution was now and floor is now; no missed execution
+    '* 0/30 * * * ? *' | 0                    | 30                 | 90         || false  // lastExecution was 90 minutes ago, floor is at 30m mark; no missed execution
+    '* 0/30 * * * ? *' | 30                   | 9                  | 39         || false  // lastExecution was 9 minutes ago, floor is at 9m mark; no missed execution
+    '* 0/30 * * * ? *' | 60                   | 30                 | 60         || false  // lastExecution was now, floor 30m mark; no missed execution (maybe redundant case)
+    '* 0/30 * * * ? *' | 30                   | 0                  | 70         || true   // lastExecution was 40 minutes ago, floor is at 0m mark; missed execution (60m)
+  }
+
+  def 'should find pipeline config ids for pipeline executions'() {
+    given:
+    def triggers = [
+      new Trigger.TriggerBuilder().enabled(true).cronExpression('* 0/30 * * * ? *').build(),
+      new Trigger.TriggerBuilder().enabled(true).cronExpression('* 0/30 * * * ? *').build()
+    ]
+    def pipelines = [
+      pipelineBuilder('1').disabled(false).build(),
+      pipelineBuilder('2').disabled(true).triggers([triggers[0]]).build(),
+      pipelineBuilder('3').disabled(false).triggers([triggers[1]]).build()
+    ]
+
+    when:
+    def configIds = MissedPipelineTriggerCompensationJob.getPipelineConfigIds(pipelines, triggers)
+
+    then:
+    configIds == ['3']
+  }
+
+  Pipeline.PipelineBuilder pipelineBuilder(String id) {
+    new Pipeline.PipelineBuilder().id(id).name("pipeline${id}").application('myapp')
+  }
+
+  Date getDateOffset(int minutesOffset) {
+    def clock = Clock.systemDefaultZone()
+    Date.from(Instant.now(clock).truncatedTo(ChronoUnit.HOURS).plusMillis(TimeUnit.MINUTES.toMillis(minutesOffset)))
+  }
+}


### PR DESCRIPTION
Enables performing deployments or restarts with the in-memory scheduler so that it will execute any missed cron executions. Can be configured as below.

```
scheduler:
  enabled: true
  compensationJob:
    enabled: true
    windowMs: 30000 # optional
```

The compensation job will ignore any missed executions that fall below the configured time window.

@spinnaker/netflix-reviewers @duftler PTAL