### PR TITLE
(core) Align email subject for manual judgment with that of other sta…

### DIFF
--- a/echo-notifications/src/main/resources/templates/manualJudgment/body-email.vm
+++ b/echo-notifications/src/main/resources/templates/manualJudgment/body-email.vm
@@ -4,4 +4,12 @@ $htmlToText.convert($notification.additionalContext.instructions)
 #end
 For more details, please visit:
 
+#if($notification.additionalContext.stageId && !$notification.additionalContext.stageId.empty)
+#if($notification.additionalContext.restrictExecutionDuringTimeWindow)
+$baseUrl/#/applications/$notification.source.application/executions/details/$notification.source.executionId?stage=$notification.additionalContext.stageId&step=1
+#else
+$baseUrl/#/applications/$notification.source.application/executions/details/$notification.source.executionId?stage=$notification.additionalContext.stageId
+#end
+#else
 $baseUrl/#/applications/$notification.source.application/executions/details/$notification.source.executionId
+#end

--- a/echo-notifications/src/main/resources/templates/manualJudgment/subject.vm
+++ b/echo-notifications/src/main/resources/templates/manualJudgment/subject.vm
@@ -1,1 +1,9 @@
-Spinnaker application '$notification.source.application' is awaiting manual judgment
+#if( $notification.additionalContext.pipelineName && !$notification.additionalContext.pipelineName.empty )
+#if( $notification.additionalContext.buildNumber && !$notification.additionalContext.buildNumber.empty )
+Stage $notification.additionalContext.stageName for $notification.source.application's $notification.additionalContext.pipelineName pipeline build #$notification.additionalContext.buildNumber is awaiting manual judgment
+#else
+Stage $notification.additionalContext.stageName for $notification.source.application's $notification.additionalContext.pipelineName pipeline is awaiting manual judgment
+#end
+#else
+Stage $notification.additionalContext.stageName for $notification.source.application is awaiting manual judgment
+#end


### PR DESCRIPTION
…ge notification emails.
(core) Flesh out included link for manual judgment notification email such that it takes the user directly to the stage and step awaiting input.
(core) Both changes are tolerant of earlier orca-sent notifications that do not include the additional attributes.