### PR TITLE
Support the ping events from github webhooks

### DIFF
--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy
@@ -50,10 +50,15 @@ class WebhooksController {
         }
       }
       if (source == 'github') {
-        event.content.hash = postedEvent.after
-        event.content.branch = postedEvent.ref.replace('refs/heads/', '')
-        event.content.repoProject = postedEvent.repository.owner.name
-        event.content.slug = postedEvent.repository.name
+        if (event.content.hook_id) {
+          log.info("Webook ping received from github hook_id=${event.content.hook_id} repository=${event.content.repository.full_name}")
+          sendEvent = false
+        } else {
+          event.content.hash = postedEvent.after
+          event.content.branch = postedEvent.ref.replace('refs/heads/', '')
+          event.content.repoProject = postedEvent.repository.owner.name
+          event.content.slug = postedEvent.repository.name
+        }
       }
     }
 

--- a/echo-webhooks/src/test/groovy/com/netflix/spinnaker/echo/controllers/WebhooksControllerSpec.groovy
+++ b/echo-webhooks/src/test/groovy/com/netflix/spinnaker/echo/controllers/WebhooksControllerSpec.groovy
@@ -43,4 +43,23 @@ class WebhooksControllerSpec extends Specification {
 
   }
 
+  void 'handles initial github ping'() {
+    given:
+    WebhooksController controller = new WebhooksController()
+    controller.propagator = Mock(EventPropagator)
+
+    when:
+    controller.forwardEvent(
+      'git',
+      'github',
+      [
+        'hook_id': 1337,
+        'repository' : ['full_name': 'org/repo']
+      ]
+    )
+
+    then:
+    0 * controller.propagator.processEvent(_)
+  }
+
 }


### PR DESCRIPTION
Github ships a ping request when you set up webhook, this results in an error using echo.
This PR addresses this issue.

https://developer.github.com/enterprise/2.8/webhooks/#ping-event

![screen shot 2017-01-13 at 16 17 31](https://cloud.githubusercontent.com/assets/842541/21935112/6cbaa948-d9ac-11e6-88b2-f373625662e4.png)
