### PR TITLE
Add BitBucket support

### DIFF
--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/BuildEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/BuildEventMonitorSpec.groovy
@@ -127,6 +127,7 @@ class BuildEventMonitorSpec extends Specification implements RetrofitStubs {
     disabledJenkinsTrigger                  | "disabled"
     nonJenkinsTrigger                       | "non-Jenkins"
     enabledStashTrigger                     | "stash"
+    enabledBitBucketTrigger                 | "bitbucket"
     enabledJenkinsTrigger.withMaster("FOO") | "different master"
     enabledJenkinsTrigger.withJob("FOO")    | "different job"
 

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
@@ -25,6 +25,8 @@ trait RetrofitStubs {
   final Trigger nonJenkinsTrigger = new Trigger(true, null, 'not jenkins', 'master', 'job', null, null, null, null, null, null, null, null, null, null, null, null,null, null, null)
   final Trigger enabledStashTrigger = new Trigger(true, null, 'git', null, null, null, null, null, 'stash', 'project', 'slug', null, null, null, null, null, null,null, null, null)
   final Trigger disabledStashTrigger = new Trigger(false, null, 'git', 'master', 'job', null, null, null, 'stash', 'project', 'slug', null, null, null, null, null, null,null, null, null)
+  final Trigger enabledBitBucketTrigger = new Trigger(true, null, 'git', null, null, null, null, null, 'bitbucket', 'project', 'slug', null, null, null, null, null, null,null, null, null)
+  final Trigger disabledBitBucketTrigger = new Trigger(false, null, 'git', 'master', 'job', null, null, null, 'bitbucket', 'project', 'slug', null, null, null, null, null, null,null, null, null)
 
   final Trigger enabledGithubTrigger = new Trigger(true, null, 'git', null, null, null, null, null, 'github', 'project', 'slug', null, null, null, null, null, null,null, null, null)
 
@@ -52,10 +54,10 @@ trait RetrofitStubs {
     return res
   }
 
-  GitEvent createGitEvent() {
+  GitEvent createGitEvent(String eventSource) {
     def res = new GitEvent()
     res.content = new GitEvent.Content("project", "slug", "hash", "master")
-    res.details = new Metadata([type: GitEvent.TYPE, source: "stash"])
+    res.details = new Metadata([type: GitEvent.TYPE, source: eventSource])
     return res
   }
 


### PR DESCRIPTION
PR [#153](https://github.com/spinnaker/igor/pull/153) has been opened against Igor.

PR's are being opened against Deck and Gate.

BitBucket Server (a.k.a. Stash) support already exists. This adds BitBucket Cloud support of pipeline triggers based on BitBucket webhooks and provides Orca the ability to retrieve a list of commits from BitBucket as part of it's GetCommits stage.