### PR TITLE
feat(core): Allow configurable headers for rest endpoints

### DIFF
--- a/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/config/RestProperties.groovy
+++ b/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/config/RestProperties.groovy
@@ -41,6 +41,8 @@ class RestProperties {
     String url
     String username
     String password
+    Map<String, String> headers
+    String headersFile
     Boolean flatten = false
 
   }

--- a/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/config/RestConfigSpec.groovy
+++ b/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/config/RestConfigSpec.groovy
@@ -1,0 +1,86 @@
+package com.netflix.spinnaker.echo.config
+
+import retrofit.RequestInterceptor
+import retrofit.RestAdapter
+import spock.lang.Specification
+import spock.lang.Subject
+
+class RestConfigSpec extends Specification {
+
+  @Subject
+  config = new RestConfig()
+
+  def request = Mock(RequestInterceptor.RequestFacade)
+  def EmptyHeadersFile = Mock(RestConfig.HeadersFromFile)
+  def attacher = new RestConfig.RequestInterceptorAttacher() {
+    RequestInterceptor interceptor
+    @Override
+    public void attach(RestAdapter.Builder builder, RequestInterceptor interceptor) {
+      this.interceptor = interceptor
+    }
+  }
+
+  void configureRestServices(RestProperties.RestEndpointConfiguration endpoint, RestConfig.HeadersFromFile headersFromFile) {
+    RestProperties restProperties =  new RestProperties(endpoints: [endpoint])
+    config.restServices(restProperties, config.retrofitClient(), config.retrofitLogLevel("BASIC"), attacher, headersFromFile)
+  }
+
+  void "Generate basic auth header"() {
+    given:
+    RestProperties.RestEndpointConfiguration endpoint = new RestProperties.RestEndpointConfiguration(
+      url: "http://localhost:9090",
+      username: "testuser",
+      password: "testpassword")
+    configureRestServices(endpoint, EmptyHeadersFile)
+
+    when:
+    attacher.interceptor.intercept(request)
+
+    then:
+    1 * request.addHeader("Authorization", "Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk")
+    0 * request.addHeader(_, _)
+  }
+
+  void "'Authorization' header over generated basic auth header"() {
+    given:
+    RestProperties.RestEndpointConfiguration endpoint = new RestProperties.RestEndpointConfiguration(
+      url: "http://localhost:9090",
+      username: "testuser",
+      password: "testpassword",
+      headers: ["Authorization": "FromConfig"])
+    configureRestServices(endpoint, EmptyHeadersFile)
+
+    when:
+    attacher.interceptor.intercept(request)
+
+    then:
+    1 * request.addHeader("Authorization", "FromConfig")
+    0 * request.addHeader(_, _)
+  }
+
+  void "'Authorization' headerFile over all others"() {
+    given:
+    RestProperties.RestEndpointConfiguration endpoint = new RestProperties.RestEndpointConfiguration(
+      url: "http://localhost:9090",
+      username: "testuser",
+      password: "testpassword",
+      headers: ["Authorization": "FromConfig"],
+      headersFile: "/testfile")
+    RestConfig.HeadersFromFile headersFromFile = new RestConfig.HeadersFromFile() {
+      @Override
+      Map<String, String> headers(String path) {
+        return [
+          "Authorization": "FromFile"
+        ]
+      }
+    }
+    configureRestServices(endpoint, headersFromFile)
+
+    when:
+    attacher.interceptor.intercept(request)
+
+    then:
+    1 * request.addHeader("Authorization", "FromFile")
+    0 * request.addHeader(_, _)
+  }
+}


### PR DESCRIPTION
This feature started because I needed to be able to set the Authorization header in order to send events to Splunk.

This PR will allow you to set headers in two ways.

1. Directly in `echo-local.yml`:
```yaml
rest:
  enabled: true
  endpoints:
    - wrap: false
      url: http://www.example.com
      headers:
        Authorization: Splunk MYSECRETKEYHERE
```

2. In a file that contains the headers you want to include:
```yaml
rest:
  enabled: true
  endpoints:
    - wrap: false
      url: http://www.example.com
      headersFile: /mnt/mysecrets/splunkKey
```
where `/mnt/mysecrets/splunkKey` looks like:
```
Authorization: Splunk MYSECRETKEYHERE
```

In the examples above, I only used the `Authorization` header. However, you can specify any header you want. 

If there are conflicts with headers then the header in the `headersFile` will be used over what is in the `headers` field. If username/password fields are present in `echo-local.yml` and an Authorization header is specified, then the Authorization header will override the basic auth header created from the username/password.