### PR TITLE
fix(triggers): fix NPE regression on BuildEventMonitor.

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/BuildEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/BuildEventMonitor.java
@@ -112,6 +112,6 @@ public class BuildEventMonitor extends TriggerMonitor {
   }
 
   private boolean isBuildTrigger(Trigger trigger) {
-    return Arrays.stream(BUILD_TRIGGER_TYPES).anyMatch(triggerType -> trigger.getType().equals(triggerType));
+    return Arrays.stream(BUILD_TRIGGER_TYPES).anyMatch(triggerType -> triggerType.equals(trigger.getType()));
   }
 }


### PR DESCRIPTION
travis trigger check switched the comparison on trigger.getType to not be null safe
