### PR TITLE
feat(rest): extensible JSON payloads for Spinnaker events

### DIFF
--- a/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/config/RestProperties.groovy
+++ b/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/config/RestProperties.groovy
@@ -36,6 +36,7 @@ class RestProperties {
   static class RestEndpointConfiguration {
     String eventName
     String fieldName
+    String template
     Boolean wrap = false
     @NotEmpty
     String url

--- a/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/events/RestEventTemplateEngine.groovy
+++ b/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/events/RestEventTemplateEngine.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.events
+
+import groovy.util.logging.Slf4j
+import org.springframework.stereotype.Component
+import com.fasterxml.jackson.databind.ObjectMapper
+
+interface RestEventTemplateEngine {
+    Map render(String template, Map eventMap)
+}
+
+
+@Component
+@Slf4j
+class SimpleEventTemplateEngine implements RestEventTemplateEngine {
+
+    ObjectMapper objectMapper = new ObjectMapper()
+
+    Map render(String templateString, Map eventMap) {
+        String renderedResult = templateString.replace('${event}', objectMapper.writeValueAsString(eventMap))
+        return objectMapper.readValue(renderedResult, Map)
+    }
+}

--- a/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/RestEventListenerSpec.groovy
+++ b/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/RestEventListenerSpec.groovy
@@ -34,7 +34,29 @@ class RestEventListenerSpec extends Specification {
     listener.eventName = 'defaultEvent'
     listener.fieldName = 'defaultField'
     listener.restUrls = new RestUrls()
+    listener.restEventTemplateEngine = new SimpleEventTemplateEngine()
     restService = Mock(RestService)
+  }
+
+  void 'render template when template is set'() {
+    given:
+    listener.restUrls.services = [
+      [
+        client: restService,
+        config: [
+          template: '{"myCustomEventField":${event}}',
+          wrap    : true
+        ]
+      ]
+    ]
+
+    when:
+    listener.processEvent(event)
+
+    then:
+    1 * restService.recordEvent({
+      it.myCustomEventField == listener.mapper.convertValue(event, Map)
+    })
   }
 
   void 'wraps events when wrap is set'() {

--- a/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/SimpleEventTemplateSpec.groovy
+++ b/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/SimpleEventTemplateSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.events
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+class SimpleEventTemplateSpec extends Specification {
+
+  @Subject
+  RestEventTemplateEngine restEventTemplateEngine = new SimpleEventTemplateEngine()
+  Map event = [
+    'content': [
+      'action': 'resize asg'
+    ],
+    'details': [
+      'user': 'anonymous'
+    ]
+  ]
+
+  void 'renders template with event map'() {
+    given:
+    def template = '{"myEventField":${event}}'
+
+    when:
+    Map renderedResult = restEventTemplateEngine.render(template, event)
+
+    then:
+    renderedResult == [
+      'myEventField': event
+    ]
+  }
+}


### PR DESCRIPTION
When configuring webhooks in Echo, it only supports two types of payloads:
```
{ "content":[..], "details":[..]}
```
or using the `wrap` property which forces the payload to have a field called `eventName`.   This PR introduces a new config property called `template` which allows a user to specify a simple string template.  Currently the only string that will be interpolated is `${event}`.  Below is an example of a rest endpoint configured with a template.

```
rest:
  endpoints:
    - wrap: true
      url: https://events.spinnaker.myteam.net/
      template: '{"myCustomEventFieldName":${event}}'
```

Note that the template must be valid JSON _after_ the interpolation.  The template will contain the event and the entire content details will be placed in `${event}` such that a rendered template will look like:

```
"myCustomEventFieldName": {
    "details": { ... },
    "content": { ... }
}
```