### PR TITLE
fix(rest) - fixes the tokens used for the rest templates

### DIFF
--- a/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/events/RestEventTemplateEngine.groovy
+++ b/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/events/RestEventTemplateEngine.groovy
@@ -32,7 +32,7 @@ class SimpleEventTemplateEngine implements RestEventTemplateEngine {
     ObjectMapper objectMapper = new ObjectMapper()
 
     Map render(String templateString, Map eventMap) {
-        String renderedResult = templateString.replace('${event}', objectMapper.writeValueAsString(eventMap))
+        String renderedResult = templateString.replace('{{event}}', objectMapper.writeValueAsString(eventMap))
         return objectMapper.readValue(renderedResult, Map)
     }
 }

--- a/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/RestEventListenerSpec.groovy
+++ b/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/RestEventListenerSpec.groovy
@@ -44,7 +44,7 @@ class RestEventListenerSpec extends Specification {
       [
         client: restService,
         config: [
-          template: '{"myCustomEventField":${event}}',
+          template: '{"myCustomEventField":{{event}} }',
           wrap    : true
         ]
       ]

--- a/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/SimpleEventTemplateSpec.groovy
+++ b/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/SimpleEventTemplateSpec.groovy
@@ -34,7 +34,7 @@ class SimpleEventTemplateSpec extends Specification {
 
   void 'renders template with event map'() {
     given:
-    def template = '{"myEventField":${event}}'
+    def template = '{ "myEventField":{{event}} }'
 
     when:
     Map renderedResult = restEventTemplateEngine.render(template, event)


### PR DESCRIPTION
This fixes a bug where templating tokens used for rest endpoints collides with Spring based properties.   It currently uses `${event}` although this causes the `/resolvedEnv` endpoint to return the following error:

```
rest.endpoints[0].template":"Exception occurred: Could not resolve placeholder 'event' in string value \"{\"event\":${event}}\"
```

The changes below will instead use double braces  as tokens so a valid configuration will look like the following: 

```
rest:
  endpoints:
    - wrap: true
      url: https://events.spinnaker.myteam.net/
      template: '{"myCustomEventFieldName":{{event}} }'
```