### PR TITLE
feat(pubsub): Adds first pass at Google pubsub client.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ allprojects {
         exclude group: 'javax.servlet', module: 'servlet-api'
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
         exclude group: 'org.slf4j', module: 'slf4j-simple'
+        resolutionStrategy {
+            force 'com.google.guava:guava:20.0'
+        }
     }
 }
 

--- a/echo-pubsub/echo-pubsub.gradle
+++ b/echo-pubsub/echo-pubsub.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-include 'echo-core', 'echo-model', 'echo-web', 'echo-notifications', 'echo-pipelinetriggers', 'echo-scheduler', 'echo-rest', 'echo-webhooks', 'echo-pubsub'
+dependencies {
+  compile project(':echo-core')
+  compile project(':echo-model')
 
-rootProject.name = 'echo'
+  spinnaker.group("bootWeb")
+  spinnaker.group("spockBase")
 
-def setBuildFile(project) {
-    project.buildFileName = "${project.name}.gradle"
-    project.children.each {
-        setBuildFile(it)
-    }
-}
+  compile spinnaker.dependency("groovy")
+  compile spinnaker.dependency("guava")
+  compile spinnaker.dependency("jedis")
 
-rootProject.children.each {
-    setBuildFile it
+  compile 'com.google.cloud:google-cloud-pubsub:0.21.1-beta'
 }

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/EchoPubsubConfigurationProperties.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/EchoPubsubConfigurationProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.config;
+
+import lombok.Data;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+@ConfigurationProperties
+class EchoPubsubConfigurationProperties {
+
+  @Data
+  static class RedisProperties {
+    private String connection = "redis://localhost:6379";
+    private Integer timeout = 2000;
+  }
+
+  @Getter
+  @NestedConfigurationProperty
+  private final RedisProperties redis = new RedisProperties();
+}

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/JedisConfig.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/JedisConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import redis.clients.jedis.JedisPool;
+
+import java.net.URI;
+
+@Configuration
+public class JedisConfig {
+
+  @Bean
+  JedisPool jedisPool(EchoPubsubConfigurationProperties echoPubsubConfigurationProperties) {
+    EchoPubsubConfigurationProperties.RedisProperties redis = echoPubsubConfigurationProperties.getRedis();
+    return new JedisPool(URI.create(redis.getConnection()), redis.getTimeout());
+  }
+}

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/PubsubConfig.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/PubsubConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.config;
+
+import com.netflix.spinnaker.echo.pubsub.PubsubSubscribers;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(EchoPubsubConfigurationProperties.class)
+public class PubsubConfig {
+
+  @Bean
+  PubsubSubscribers pubsubSubscribers() {
+    return new PubsubSubscribers();
+  }
+}

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/google/GooglePubsubConfig.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/google/GooglePubsubConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.config.google;
+
+import com.netflix.spinnaker.echo.pubsub.PubsubMessageHandler;
+import com.netflix.spinnaker.echo.pubsub.PubsubSubscribers;
+import com.netflix.spinnaker.echo.pubsub.google.GooglePubsubSubscriber;
+import com.netflix.spinnaker.echo.pubsub.model.PubsubSubscriber;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@Slf4j
+@ConditionalOnProperty("pubsub.google.enabled")
+@EnableConfigurationProperties(GooglePubsubProperties.class)
+public class GooglePubsubConfig {
+
+  @Autowired
+  private PubsubSubscribers pubsubSubscribers;
+
+  @Autowired
+  private PubsubMessageHandler pubsubMessageHandler;
+
+  @Valid
+  @Autowired
+  private GooglePubsubProperties googlePubsubProperties;
+
+  @PostConstruct
+  void googlePubsubSubscribers() {
+    log.info("Creating Google Pubsub Subscribers");
+    List<PubsubSubscriber> newSubscribers = new ArrayList<>();
+    googlePubsubProperties.getSubscriptions().forEach((GooglePubsubProperties.GooglePubsubSubscription subscription) -> {
+      String name = subscription.getName();
+      String project = subscription.getProject();
+      String jsonPath = subscription.getJsonPath();
+
+      log.info("Bootstrapping Google Pubsub Subscriber listening to topic: {subscription.name} in project: {subscription.project}",
+          subscription.getName(),
+          subscription.getProject());
+      GooglePubsubSubscriber subscriber = GooglePubsubSubscriber
+          .buildSubscriber(name, project, jsonPath, subscription.getAckDeadlineSeconds(), pubsubMessageHandler);
+
+      newSubscribers.add(subscriber);
+    });
+    pubsubSubscribers.putAll(newSubscribers);
+  }
+}

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/google/GooglePubsubProperties.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/google/GooglePubsubProperties.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.config.google;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Data
+@ConfigurationProperties(prefix = "pubsub.google")
+public class GooglePubsubProperties {
+
+  @Valid
+  private List<GooglePubsubSubscription> subscriptions;
+
+  @Data
+  @NoArgsConstructor
+  public static class GooglePubsubSubscription {
+
+    @NotEmpty
+    private String project;
+
+    @NotEmpty
+    private String name;
+
+    @NotNull
+    private Integer ackDeadlineSeconds = 10;
+
+    // Not required since topics can be public.
+    private String jsonPath;
+  }
+}

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/kafka/KafkaConfig.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/kafka/KafkaConfig.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
-include 'echo-core', 'echo-model', 'echo-web', 'echo-notifications', 'echo-pipelinetriggers', 'echo-scheduler', 'echo-rest', 'echo-webhooks', 'echo-pubsub'
+package com.netflix.spinnaker.echo.config.kafka;
 
-rootProject.name = 'echo'
-
-def setBuildFile(project) {
-    project.buildFileName = "${project.name}.gradle"
-    project.children.each {
-        setBuildFile(it)
-    }
-}
-
-rootProject.children.each {
-    setBuildFile it
+public class KafkaConfig {
 }

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/kafka/KafkaProperties.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/kafka/KafkaProperties.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
-include 'echo-core', 'echo-model', 'echo-web', 'echo-notifications', 'echo-pipelinetriggers', 'echo-scheduler', 'echo-rest', 'echo-webhooks', 'echo-pubsub'
+package com.netflix.spinnaker.echo.config.kafka;
 
-rootProject.name = 'echo'
-
-def setBuildFile(project) {
-    project.buildFileName = "${project.name}.gradle"
-    project.children.each {
-        setBuildFile(it)
-    }
-}
-
-rootProject.children.each {
-    setBuildFile it
+public class KafkaProperties {
 }

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/PollingMonitor.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/PollingMonitor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pubsub;
+
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+/**
+ * An interface for monitors which rely on polling.
+ */
+public interface PollingMonitor extends ApplicationListener<ContextRefreshedEvent> {
+  void onApplicationEvent(ContextRefreshedEvent event);
+
+  String getName();
+
+  boolean isInService();
+
+  Long getLastPoll();
+
+  int getPollInterval();
+}

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandler.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pubsub;
+
+import com.netflix.spinnaker.echo.pubsub.model.MessageAcknowledger;
+import com.netflix.spinnaker.echo.pubsub.model.MessageInstanceDescription;
+import com.netflix.spinnaker.echo.pubsub.model.PubsubType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import javax.annotation.PostConstruct;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+/**
+ * Shared cache of received and handled pubsub messages to synchronize clients.
+ */
+@Service
+@Slf4j
+public class PubsubMessageHandler {
+
+  @Autowired
+  private JedisPool jedisPool;
+
+  private MessageDigest digest;
+
+  private static final String SET_IF_NOT_EXIST = "NX";
+  private static final String SET_EXPIRE_TIME_MILLIS = "PX";
+  private static final String SUCCESS = "OK";
+
+  @PostConstruct
+  void postConstruct() {
+    try {
+      digest = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException nsa) {
+      log.error(nsa.getMessage());
+    }
+  }
+
+  public void handleMessage(MessageInstanceDescription description,
+                            MessageAcknowledger acknowledger,
+                            String identifier) {
+    String messageKey = makeKey(description.getMessagePayload(), description.getPubsubType(), description.getSubscriptionName());
+
+    if (!acquireMessageLock(messageKey, identifier, description.getAckDeadlineMillis())) {
+      acknowledger.nack();
+      return;
+    }
+
+    acknowledger.ack();
+    postEvent(description);
+    setMessageHandled(messageKey, identifier, description.getRetentionDeadlineMillis());
+  }
+
+  private Boolean acquireMessageLock(String messageKey, String identifier, Long ackDeadlineMillis) {
+    try (Jedis resource = jedisPool.getResource()) {
+      String response = resource.set(messageKey, identifier, SET_IF_NOT_EXIST, SET_EXPIRE_TIME_MILLIS, ackDeadlineMillis);
+      return SUCCESS.equals(response);
+    }
+  }
+
+  private void setMessageHandled(String messageKey, String identifier, Long retentionDeadlineMillis) {
+    try (Jedis resource = jedisPool.getResource()) {
+      resource.psetex(messageKey, retentionDeadlineMillis, identifier);
+    }
+  }
+
+  private String makeKey(String messagePayload, PubsubType pubsubType, String subscription) {
+    digest.reset();
+    digest.update(messagePayload.getBytes());
+    String messageHash = new String(Base64.getEncoder().encode(digest.digest()));
+    return String.format("%s:echo-pubsub:%s:%s", pubsubType.toString(), subscription, messageHash);
+  }
+
+
+  private void postEvent(MessageInstanceDescription description) {
+    // TODO(jacobkiefer): Process this event.
+    log.info("Processed Google pubsub event with payload {}", description.getMessagePayload());
+  }
+}

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubSubscribers.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubSubscribers.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pubsub;
+
+import com.netflix.spinnaker.echo.pubsub.model.PubsubSubscriber;
+import com.netflix.spinnaker.echo.pubsub.model.PubsubType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PubsubSubscribers {
+  private List<PubsubSubscriber> subscribers = new ArrayList<>();
+
+  public void putAll(List< PubsubSubscriber> newEntries) {
+    subscribers.addAll(newEntries);
+  }
+
+  public List<PubsubSubscriber> subscribersMatchingType(PubsubType pubsubType) {
+    return subscribers
+        .stream()
+        .filter(subscriber -> subscriber.pubsubType().equals(pubsubType))
+        .collect(Collectors.toList());
+  }
+}

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GoogleMessageAcknowledger.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GoogleMessageAcknowledger.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pubsub.google;
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.netflix.spinnaker.echo.pubsub.model.MessageAcknowledger;
+
+public class GoogleMessageAcknowledger implements MessageAcknowledger {
+
+  private AckReplyConsumer consumer;
+
+  public GoogleMessageAcknowledger(AckReplyConsumer consumer) {
+    this.consumer = consumer;
+  }
+
+  @Override
+  public void ack() {
+    consumer.ack();
+  }
+
+  @Override
+  public void nack() {
+    consumer.nack();
+  }
+}

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubMonitor.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubMonitor.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pubsub.google;
+
+import com.netflix.spinnaker.echo.pubsub.PollingMonitor;
+import com.netflix.spinnaker.echo.pubsub.PubsubSubscribers;
+import com.netflix.spinnaker.echo.pubsub.model.PubsubSubscriber;
+import com.netflix.spinnaker.echo.pubsub.model.PubsubType;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PreDestroy;
+
+/**
+ * Monitors Google Cloud Pubsub subscriptions.
+ */
+@Slf4j
+@Service
+@Async
+@ConditionalOnProperty("pubsub.google.enabled")
+public class GooglePubsubMonitor implements PollingMonitor {
+
+  private Long lastPoll;
+
+  @Getter
+  private final String name = "GooglePubsubMonitor";
+
+  @Autowired
+  private PubsubSubscribers pubsubSubscribers;
+
+  @PreDestroy
+  private void closeAsyncConnections() {
+    log.info("Closing async connections for Google Pubsub subscribers");
+    pubsubSubscribers
+        .subscribersMatchingType(PubsubType.GOOGLE)
+        .parallelStream()
+        .forEach(this::closeConnection);
+  }
+
+  @Override
+  public void onApplicationEvent(ContextRefreshedEvent event) {
+    // TODO(jacobkiefer): Register Echo as enabled on startup.
+    log.info("Starting async connections for Google Pubsub subscribers");
+    pubsubSubscribers
+        .subscribersMatchingType(PubsubType.GOOGLE)
+        .parallelStream()
+        .forEach(this::openConnection);
+  }
+
+  private void openConnection(PubsubSubscriber subscriber) {
+    log.info("Opening async connection to {}", subscriber.topic());
+    lastPoll = System.currentTimeMillis();
+
+    GooglePubsubSubscriber googleSubscriber = (GooglePubsubSubscriber) subscriber;
+    googleSubscriber.getSubscriber().startAsync();
+  }
+
+  private void closeConnection(PubsubSubscriber subscriber) {
+    log.info("Closing async connection to {}", subscriber.topic());
+    GooglePubsubSubscriber googleSubscriber = (GooglePubsubSubscriber) subscriber;
+    googleSubscriber.getSubscriber().stopAsync();
+  }
+
+  @Override
+  public boolean isInService() {
+    return true;
+  }
+
+  @Override
+  public Long getLastPoll() {
+    return lastPoll;
+  }
+
+  @Override
+  public int getPollInterval() {
+    return -1;
+  }
+}

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubSubscriber.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubSubscriber.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pubsub.google;
+
+import com.google.api.core.ApiService;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.SubscriptionName;
+import com.netflix.spinnaker.echo.pubsub.PubsubMessageHandler;
+import com.netflix.spinnaker.echo.pubsub.model.MessageInstanceDescription;
+import com.netflix.spinnaker.echo.pubsub.model.PubsubSubscriber;
+import com.netflix.spinnaker.echo.pubsub.model.PubsubType;
+import com.netflix.spinnaker.echo.pubsub.utils.NodeIdentity;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.threeten.bp.Duration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class GooglePubsubSubscriber implements PubsubSubscriber {
+
+  private String name;
+
+  private String project;
+
+  private String topic;
+
+  @Getter
+  private Subscriber subscriber;
+
+  private Integer ackDeadlineSeconds;
+
+  static private final PubsubType pubsubType = PubsubType.GOOGLE;
+
+
+  public GooglePubsubSubscriber(String name, String project, Subscriber subscriber, Integer ackDeadlineSeconds) {
+    this.name = name;
+    this.project = project;
+    this.topic = String.format("projects/%s/topics/%s", project, name);
+    this.subscriber = subscriber;
+    this.ackDeadlineSeconds = ackDeadlineSeconds;
+  }
+
+  @Override
+  public PubsubType pubsubType() {
+    return pubsubType;
+  }
+
+  @Override
+  public String topic() {
+    return topic;
+  }
+
+  public static GooglePubsubSubscriber buildSubscriber(String name,
+                                                       String project,
+                                                       String jsonPath,
+                                                       Integer ackDeadlineSeconds,
+                                                       PubsubMessageHandler pubsubMessageHandler) {
+    Subscriber subscriber;
+    GooglePubsubMessageReceiver messageReceiver = new GooglePubsubMessageReceiver(ackDeadlineSeconds, name, pubsubMessageHandler);
+
+    if (jsonPath != null && !jsonPath.isEmpty()) {
+      Credentials credentials = null;
+      try {
+        credentials = ServiceAccountCredentials.fromStream(new FileInputStream(jsonPath));
+      } catch (IOException e) {
+        log.error("Could not import Google Pubsub json credentials: {}", e.getMessage());
+      }
+      subscriber = Subscriber
+          .defaultBuilder(SubscriptionName.create(project, name), messageReceiver)
+          .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
+          .setMaxAckExtensionPeriod(Duration.ofSeconds(0))
+          .build();
+    } else {
+      subscriber = Subscriber.defaultBuilder(SubscriptionName.create(project, name), messageReceiver).build();
+    }
+
+    subscriber.addListener(new GooglePubsubFailureHandler(), MoreExecutors.directExecutor());
+
+    return new GooglePubsubSubscriber(name, project, subscriber, ackDeadlineSeconds);
+  }
+
+  private static class GooglePubsubMessageReceiver implements MessageReceiver {
+
+    private Integer ackDeadlineSeconds;
+
+    private PubsubMessageHandler pubsubMessageHandler;
+
+    private String subscriptionName;
+
+    private NodeIdentity identity = new NodeIdentity();
+
+    public GooglePubsubMessageReceiver(Integer ackDeadlineSeconds,
+                                       String subscriptionName,
+                                       PubsubMessageHandler pubsubMessageHandler) {
+      this.ackDeadlineSeconds = ackDeadlineSeconds;
+      this.subscriptionName = subscriptionName;
+      this.pubsubMessageHandler = pubsubMessageHandler;
+    }
+
+    @Override
+    public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+      String messagePayload = message.getData().toStringUtf8();
+      log.debug("Received message with payload: {}", messagePayload);
+
+      MessageInstanceDescription description = MessageInstanceDescription.builder()
+          .subscriptionName(subscriptionName)
+          .messagePayload(messagePayload)
+          .pubsubType(pubsubType)
+          .ackDeadlineMillis(5 * TimeUnit.SECONDS.toMillis(ackDeadlineSeconds)) // Set a high upper bound on message processing time.
+          .retentionDeadlineMillis(TimeUnit.DAYS.toMillis(7)) // Expire key after max retention time, which is 7 days.
+          .build();
+      GoogleMessageAcknowledger acknowledger = new GoogleMessageAcknowledger(consumer);
+      pubsubMessageHandler.handleMessage(description, acknowledger, identity.getIdentity());
+    }
+  }
+
+  private static class GooglePubsubFailureHandler extends ApiService.Listener {
+    @Override
+    public void failed(ApiService.State from, Throwable failure) {
+      log.error("Google Pubsub listener failure caused by {}", failure.getMessage());
+    }
+  }
+}

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/kafka/KafkaMonitor.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/kafka/KafkaMonitor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
-include 'echo-core', 'echo-model', 'echo-web', 'echo-notifications', 'echo-pipelinetriggers', 'echo-scheduler', 'echo-rest', 'echo-webhooks', 'echo-pubsub'
+package com.netflix.spinnaker.echo.pubsub.kafka;
 
-rootProject.name = 'echo'
-
-def setBuildFile(project) {
-    project.buildFileName = "${project.name}.gradle"
-    project.children.each {
-        setBuildFile(it)
-    }
-}
-
-rootProject.children.each {
-    setBuildFile it
+public class KafkaMonitor {
 }

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/kafka/KafkaSubscriber.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/kafka/KafkaSubscriber.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
-include 'echo-core', 'echo-model', 'echo-web', 'echo-notifications', 'echo-pipelinetriggers', 'echo-scheduler', 'echo-rest', 'echo-webhooks', 'echo-pubsub'
+package com.netflix.spinnaker.echo.pubsub.kafka;
 
-rootProject.name = 'echo'
-
-def setBuildFile(project) {
-    project.buildFileName = "${project.name}.gradle"
-    project.children.each {
-        setBuildFile(it)
-    }
-}
-
-rootProject.children.each {
-    setBuildFile it
+public class KafkaSubscriber {
 }

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/model/MessageAcknowledger.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/model/MessageAcknowledger.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-include 'echo-core', 'echo-model', 'echo-web', 'echo-notifications', 'echo-pipelinetriggers', 'echo-scheduler', 'echo-rest', 'echo-webhooks', 'echo-pubsub'
+package com.netflix.spinnaker.echo.pubsub.model;
 
-rootProject.name = 'echo'
+/**
+ * Interface for acknowledging and ignoring messages.
+ */
+public interface MessageAcknowledger {
+  void ack();
 
-def setBuildFile(project) {
-    project.buildFileName = "${project.name}.gradle"
-    project.children.each {
-        setBuildFile(it)
-    }
-}
-
-rootProject.children.each {
-    setBuildFile it
+  void nack();
 }

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/model/MessageInstanceDescription.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/model/MessageInstanceDescription.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,17 +14,25 @@
  * limitations under the License.
  */
 
-include 'echo-core', 'echo-model', 'echo-web', 'echo-notifications', 'echo-pipelinetriggers', 'echo-scheduler', 'echo-rest', 'echo-webhooks', 'echo-pubsub'
+package com.netflix.spinnaker.echo.pubsub.model;
 
-rootProject.name = 'echo'
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-def setBuildFile(project) {
-    project.buildFileName = "${project.name}.gradle"
-    project.children.each {
-        setBuildFile(it)
-    }
-}
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageInstanceDescription {
+  private String subscriptionName;
 
-rootProject.children.each {
-    setBuildFile it
+  private String messagePayload;
+
+  private PubsubType pubsubType;
+
+  private Long ackDeadlineMillis;
+
+  private Long retentionDeadlineMillis;
 }

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/model/PubsubSubscriber.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/model/PubsubSubscriber.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,17 +14,9 @@
  * limitations under the License.
  */
 
-include 'echo-core', 'echo-model', 'echo-web', 'echo-notifications', 'echo-pipelinetriggers', 'echo-scheduler', 'echo-rest', 'echo-webhooks', 'echo-pubsub'
+package com.netflix.spinnaker.echo.pubsub.model;
 
-rootProject.name = 'echo'
-
-def setBuildFile(project) {
-    project.buildFileName = "${project.name}.gradle"
-    project.children.each {
-        setBuildFile(it)
-    }
-}
-
-rootProject.children.each {
-    setBuildFile it
+public interface PubsubSubscriber {
+  PubsubType pubsubType();
+  String topic();
 }

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/model/PubsubType.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/model/PubsubType.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,17 +14,20 @@
  * limitations under the License.
  */
 
-include 'echo-core', 'echo-model', 'echo-web', 'echo-notifications', 'echo-pipelinetriggers', 'echo-scheduler', 'echo-rest', 'echo-webhooks', 'echo-pubsub'
+package com.netflix.spinnaker.echo.pubsub.model;
 
-rootProject.name = 'echo'
+public enum PubsubType {
+  GOOGLE("googlePubsub"),
+  KAFKA("kafka");
 
-def setBuildFile(project) {
-    project.buildFileName = "${project.name}.gradle"
-    project.children.each {
-        setBuildFile(it)
-    }
-}
+  private String type;
 
-rootProject.children.each {
-    setBuildFile it
+  PubsubType(String type) {
+    this.type = type;
+  }
+
+  @Override
+  public String toString() {
+    return this.type;
+  }
 }

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/utils/NodeIdentity.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/utils/NodeIdentity.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pubsub.utils;
+
+import lombok.Getter;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.*;
+import java.util.Collections;
+import java.util.Enumeration;
+
+public class NodeIdentity {
+  public static final String UNKNOWN_HOST = "UnknownHost";
+
+  private String runtimeName;
+  private String hostName;
+  @Getter
+  private String identity;
+
+  public NodeIdentity() {
+    this("www.google.com", 80);
+  }
+
+  public NodeIdentity(String validationAddress, Integer validationPort) {
+    this.runtimeName = ManagementFactory.getRuntimeMXBean().getName();
+    this.hostName = resolveHostname(validationAddress, validationPort);
+    if (!hostName.equals(UNKNOWN_HOST)) {
+      this.identity = String.format("%s:%s", this.hostName, this.runtimeName);
+    }
+  }
+
+  @SuppressWarnings("PMD.EmptyCatchBlock")
+  private static String resolveHostname(String validationHost, int validationPort) {
+    final Enumeration<NetworkInterface> interfaces;
+    try {
+      interfaces = NetworkInterface.getNetworkInterfaces();
+    } catch (SocketException ignored) {
+      return UNKNOWN_HOST;
+    }
+    if (interfaces == null) {
+      return UNKNOWN_HOST;
+    }
+
+    for (NetworkInterface networkInterface : Collections.list(interfaces)) {
+      try {
+        if (networkInterface.isLoopback()) {
+          continue;
+        }
+
+        if (!networkInterface.isUp()) {
+          continue;
+        }
+      } catch (SocketException ignored) {
+        continue;
+      }
+
+      for (InetAddress address : Collections.list(networkInterface.getInetAddresses())) {
+        Socket socket = null;
+        try {
+          socket = new Socket();
+          socket.bind(new InetSocketAddress(address, 0));
+          socket.connect(new InetSocketAddress(validationHost, validationPort), 125);
+          return address.getHostName();
+        } catch (IOException ignored) {
+          //ignored
+        } finally {
+          if (socket != null) {
+            try {
+              socket.close();
+            } catch (IOException ignored) {
+              //ignored
+            }
+          }
+        }
+      }
+    }
+
+    return UNKNOWN_HOST;
+  }
+}

--- a/echo-web/echo-web.gradle
+++ b/echo-web/echo-web.gradle
@@ -16,6 +16,7 @@
 
 ext {
   springConfigLocation = System.getProperty('spring.config.location', "${System.getProperty('user.home')}/.spinnaker/")
+  springProfiles = System.getProperty('spring.profiles.active', "test,local")
   repackage = System.getProperty('springBoot.repackage', "false")
 }
 
@@ -30,6 +31,7 @@ dependencies {
     compile project(':echo-scheduler')
     compile project(':echo-rest')
     compile project(':echo-webhooks')
+    compile project(':echo-pubsub')
     compile spinnaker.dependency('kork')
     compile spinnaker.dependency('korkStackdriver')
     compile spinnaker.dependency('korkWeb')
@@ -46,6 +48,7 @@ tasks.withType(org.springframework.boot.gradle.run.BootRunTask) {
         jvmArgs applicationDefaultJvmArgs.join(" ") + " -javaagent:${jamm}"
     }
     systemProperty('spring.config.location', project.springConfigLocation)
+    systemProperty('spring.profiles.active', project.springProfiles)
 }
 
 test {


### PR DESCRIPTION
Port of https://github.com/spinnaker/igor/pull/182 to java 8 with its own module into Echo. Recapping what this adds:
* Adds relevant pubsub components as a submodule.
* Adds first pass of Google pubsub polling client.
* Provides stubs for necessary Kafka classes.
* Adds pubsub client synchronization via Redis.