### PR TITLE
feat(notifications): support markdown in slack/email notifications

### DIFF
--- a/echo-notifications/echo-notifications.gradle
+++ b/echo-notifications/echo-notifications.gradle
@@ -26,5 +26,6 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-mail:${spinnaker.version('springBoot')}"
     compile "org.springframework.boot:spring-boot-starter-freemarker:${spinnaker.version('springBoot')}"
     compile "org.jsoup:jsoup:1.8.2"
+    compile "com.atlassian.commonmark:commonmark:0.9.0"
     testCompile "com.icegreen:greenmail:1.4.0"
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/email/EmailNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/email/EmailNotificationService.groovy
@@ -64,7 +64,7 @@ class EmailNotificationService implements NotificationService {
 
   void send(String[] to, String[] cc, String subject, String text) {
     MimeMessage message = javaMailSender.createMimeMessage()
-    MimeMessageHelper helper = new MimeMessageHelper(message)
+    MimeMessageHelper helper = new MimeMessageHelper(message, false, "utf-8")
 
     if (to) {
       helper.setTo(to)
@@ -76,7 +76,7 @@ class EmailNotificationService implements NotificationService {
 
     if (to || cc) {
       helper.setFrom(from)
-      helper.setText(text)
+      message.setContent(text, "text/html")
       helper.setSubject(subject)
 
       javaMailSender.send(message)

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/NotificationTemplateEngine.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/NotificationTemplateEngine.groovy
@@ -20,9 +20,11 @@ import com.google.common.annotations.VisibleForTesting
 import com.netflix.spinnaker.echo.api.Notification
 import freemarker.template.Configuration
 import freemarker.template.Template
-import freemarker.template.TemplateNotFoundException
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
+import org.commonmark.node.Node
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
 import org.jsoup.Jsoup
 import org.jsoup.examples.HtmlToPlainText
 import org.springframework.beans.factory.annotation.Autowired
@@ -44,9 +46,10 @@ class NotificationTemplateEngine {
         FreeMarkerTemplateUtils.processTemplateIntoString(
             template,
             [
-                baseUrl     : spinnakerUrl,
-                notification: notification,
-                htmlToText  : new HtmlToPlainTextFormatter()
+                baseUrl         : spinnakerUrl,
+                notification    : notification,
+                htmlToText      : new HtmlToPlainTextFormatter(),
+                markdownToHtml  : new MarkdownToHtmlFormatter()
             ]
         )
     }
@@ -87,5 +90,15 @@ class NotificationTemplateEngine {
         String convert(String content) {
             return htmlToPlainText.getPlainText(Jsoup.parse(content))
         }
+    }
+
+    static class MarkdownToHtmlFormatter {
+      private final Parser parser = Parser.builder().build()
+      private final HtmlRenderer renderer = HtmlRenderer.builder().build()
+
+      String convert(String content) {
+        Node document = parser.parse(content)
+        return renderer.render(document)
+      }
     }
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackMessage.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackMessage.groovy
@@ -37,7 +37,8 @@ class SlackMessage {
         [
           fallback: body,
           text: body,
-          color: color
+          color: color,
+          mrkdwn_in: ["text"]
         ]
       ]).toString()
   }

--- a/echo-notifications/src/main/resources/templates/manualJudgment/body-email.ftl
+++ b/echo-notifications/src/main/resources/templates/manualJudgment/body-email.ftl
@@ -1,6 +1,7 @@
+<html>
 <#if (notification.additionalContext.instructions)??>
-Instructions:
-${htmlToText.convert(notification.additionalContext.instructions)}
+<b>Instructions:</b>
+${markdownToHtml.convert(notification.additionalContext.instructions)}
 
 </#if>
 For more details, please visit:
@@ -13,3 +14,4 @@ ${baseUrl}/#/applications/${notification.source.application}/executions/details/
 <#else>
 ${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}
 </#if>
+</html>

--- a/echo-notifications/src/main/resources/templates/manualJudgment/body-slack.ftl
+++ b/echo-notifications/src/main/resources/templates/manualJudgment/body-slack.ftl
@@ -9,7 +9,7 @@ Stage ${notification.additionalContext.stageName} for ${notification.source.appl
 </#if>
 
 <#if (notification.additionalContext.instructions)??>
-Instructions:
+*Instructions:*
 ${htmlToText.convert(notification.additionalContext.instructions)}
 
 </#if>

--- a/echo-notifications/src/main/resources/templates/manualJudgmentContinue/body-email.ftl
+++ b/echo-notifications/src/main/resources/templates/manualJudgmentContinue/body-email.ftl
@@ -1,5 +1,5 @@
 <#if (notification.additionalContext.message)??>
-${htmlToText.convert(notification.additionalContext.message)}
+${markdownToHtml.convert(notification.additionalContext.message)}
 </#if>
 <#if (notification.additionalContext.judgmentInput)??>
 Judgment '${htmlToText.convert(notification.additionalContext.judgmentInput)}' was selected.

--- a/echo-notifications/src/main/resources/templates/manualJudgmentStop/body-email.ftl
+++ b/echo-notifications/src/main/resources/templates/manualJudgmentStop/body-email.ftl
@@ -1,5 +1,5 @@
 <#if (notification.additionalContext.message)??>
-${htmlToText.convert(notification.additionalContext.message)}
+${markdownToHtml.convert(notification.additionalContext.message)}
 </#if>
 
 For more details, please visit:

--- a/echo-notifications/src/main/resources/templates/pipeline.ftl
+++ b/echo-notifications/src/main/resources/templates/pipeline.ftl
@@ -1,4 +1,4 @@
-<#if message??>${message}</#if>
+<#if message??>${markdownToHtml.convert(message)}</#if>
 To see more details, please visit:
 
 ${url}/#/applications/${application}/${link}/${executionId}

--- a/echo-notifications/src/main/resources/templates/stage.ftl
+++ b/echo-notifications/src/main/resources/templates/stage.ftl
@@ -1,4 +1,4 @@
-<#if message??>${message}</#if>
+<#if message??>${markdownToHtml.convert(message)}</#if>
 To see more details, please visit:
 
 ${url}/#/applications/${application}/executions/details/${executionId}

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/ManualJudgmentTemplateTest.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/ManualJudgmentTemplateTest.groovy
@@ -52,7 +52,7 @@ class ManualJudgmentTemplateTest extends Specification {
         expected = '''\
         Stage stage-name for testapp's exe-name pipeline build 12345 is awaiting manual judgment.
 
-        Instructions:
+        *Instructions:*
         Do the thing <http://foo>
 
         For more details, please visit:
@@ -76,7 +76,7 @@ class ManualJudgmentTemplateTest extends Specification {
         expected = '''\
         Stage stage-name for testapp's exe-name pipeline is awaiting manual judgment.
 
-        Instructions:
+        *Instructions:*
         Do the thing <http://foo>
 
         For more details, please visit:


### PR DESCRIPTION
Not much going on here - just bringing in the [commonmark-java](https://github.com/atlassian/commonmark-java) parser to convert markdown to HTML and setting the email message type.

This allows us to render instructions on manual judgment stages in basically the same format in emails as we do in the UI.

Also allowing markdown in Slack messages (it's already supported by Slack, just need to enable it in the message attachment text). Slack only supports a [subset of markdown](https://api.slack.com/docs/message-formatting#message_formatting), but it'll be something users can work through.

@tomaslin PTAL