### PR TITLE
fix(triggers): fix handling of blank regex in docker registry triggers

### DIFF
--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/DockerEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/DockerEventMonitorSpec.groovy
@@ -187,6 +187,44 @@ class DockerEventMonitorSpec extends Specification implements RetrofitStubs {
   }
 
   @Unroll
+  def "triggers a pipeline that has an enabled docker trigger with empty string for regex"() {
+    given:
+    def pipeline = createPipelineWith(trigger)
+    pipelineCache.getPipelines() >> [pipeline]
+
+    when:
+    monitor.processEvent(objectMapper.convertValue(event, Event))
+
+    then:
+    1 * subscriber.call({ it.id == pipeline.id })
+
+    where:
+    trigger                               | field
+    enabledDockerTrigger.withTag("")  | "regex tag"
+
+    event = createDockerEvent("2")
+  }
+
+  @Unroll
+  def "triggers a pipeline that has an enabled docker trigger with only whitespace for regex"() {
+    given:
+    def pipeline = createPipelineWith(trigger)
+    pipelineCache.getPipelines() >> [pipeline]
+
+    when:
+    monitor.processEvent(objectMapper.convertValue(event, Event))
+
+    then:
+    1 * subscriber.call({ it.id == pipeline.id })
+
+    where:
+    trigger                               | field
+    enabledDockerTrigger.withTag(" \t")  | "regex tag"
+
+    event = createDockerEvent("2")
+  }
+
+  @Unroll
   def "does not trigger a pipeline that has an enabled docker trigger with regex"() {
     given:
     def pipeline = createPipelineWith(trigger)


### PR DESCRIPTION
When you remove a previously existing regex from the trigger in the
UI, deck keeps a tag field with an empty string for the value in the
json. This arrives as non null to the DockerEventMonitor, which  causes
the trigger to not fire for any new tag until you manually update the
pipeline json to remove the field. This change makes the logic more
resilient to malformed input. Blank or empty tag regex doesn't make
sense so it should behave the same as when the regex is null.


