### PR TITLE
feat(pubsub): Enforce expected artifacts in triggers.

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -18,11 +18,13 @@ package com.netflix.spinnaker.echo.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import lombok.Builder;
 import lombok.ToString;
 import lombok.Value;
 import lombok.experimental.Wither;
 
+import java.util.List;
 import java.util.Map;
 
 @JsonDeserialize(builder = Trigger.TriggerBuilder.class)
@@ -73,6 +75,7 @@ public class Trigger {
   String secret;
   String subscriptionName;
   String pubsubType;
+  List<Artifact> expectedArtifacts;
 
   public Trigger atBuildNumber(final int buildNumber) {
     return this.toBuilder()

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.echo.model.Trigger
 import com.netflix.spinnaker.echo.model.pubsub.MessageDescription
 import com.netflix.spinnaker.echo.model.pubsub.PubsubType
 import com.netflix.spinnaker.echo.model.trigger.*
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import retrofit.RetrofitError
 import retrofit.client.Response
 
@@ -84,13 +85,14 @@ trait RetrofitStubs {
     return res
   }
 
-  PubsubEvent createPubsubEvent(PubsubType pubsubType, String subscriptionName) {
+  PubsubEvent createPubsubEvent(PubsubType pubsubType, String subscriptionName, List<Artifact> artifacts) {
     def res = new PubsubEvent()
 
     def description = MessageDescription.builder()
         .pubsubType(pubsubType)
         .ackDeadlineMillis(10000)
         .subscriptionName(subscriptionName)
+        .artifacts(artifacts)
         .build()
 
     def content = new PubsubEvent.Content()


### PR DESCRIPTION
Triggers can specify expected artifacts. This change ensures that at least one of the artifacts parsed from the message satisfies each expected artifact specified in the Trigger.