### PR TITLE
feat(slack): allow ad-hoc message publishing via Slack

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
@@ -73,12 +73,10 @@ class SlackNotificationAgent extends AbstractEventNotificationAgent {
         body = """Stage ${event.content?.context?.stageDetails.name} for """
       }
 
+      String link = "${spinnakerUrl}/#/applications/${application}/${config.type == 'stage' ? 'executions/details' : config.link }/${event.content?.execution?.id}"
+
       body +=
-        """${WordUtils.capitalize(application)}'s <${
-          spinnakerUrl
-        }/#/applications/${application}/${
-          config.type == 'stage' ? 'executions/details' : config.link
-        }/${event.content?.execution?.id}|${
+        """${WordUtils.capitalize(application)}'s <${link}|${
           event.content?.execution?.name ?: event.content?.execution?.description
         }>${buildInfo}${config.type == 'task' ? 'task' : 'pipeline'} ${status == 'starting' ? 'is' : 'has'} ${
           status == 'complete' ? 'completed successfully' : status
@@ -86,6 +84,13 @@ class SlackNotificationAgent extends AbstractEventNotificationAgent {
 
       if (preference.message?."$config.type.$status"?.text) {
         body += "\n\n" + preference.message."$config.type.$status".text
+      }
+
+      String customMessage = event.content?.context?.customMessage
+      if (customMessage && event.content?.execution?.id) {
+        body = customMessage
+          .replace("{{executionId}}", (String) event.content.execution.id)
+          .replace("{{link}}", link)
       }
 
       String address = preference.address.startsWith('#') ? preference.address : "#${preference.address}"


### PR DESCRIPTION
Allows an entirely custom message to be passed through to Echo via the stage context. I'm exposing two variables with a simple substitution feature: 
* `{{executionId}}` (since that is not known when launching the pipeline)
* `{{link}}` (since that could be useful for deep linking and kind of a pain to construct)

This lets us do things like this:
<img width="625" alt="screen shot 2017-10-24 at 7 27 39 pm" src="https://user-images.githubusercontent.com/73450/31977380-794eb0b2-b8f1-11e7-82e1-613b7a5a25d7.png">
by adding this to the stage JSON:
```javascript
{
  "customMessage": "Fast property update: rolling out property abcd to us-central-1 (step 2 of 3) | <http://localhost:9000/#/applications/deck/properties/{{executionId}}?tab=rollouts&refId=3|link>"
}
```

I'd like to play around with this a bit more and, if it makes sense, add similar functionality to the other notification types (maybe just email).