### PR TITLE
fix(email): handle link/executionId replacement in custom email body

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgent.groovy
@@ -99,7 +99,10 @@ class EmailNotificationAgent extends AbstractEventNotificationAgent {
   private void sendMessage(String[] email, String[] cc, Event event, String title, String type, String status, String link, String customMessage, String customBody) {
     String body
     if (customBody) {
-      body = new MarkdownToHtmlFormatter().convert(customBody)
+      String interpolated = customBody
+        .replace("{{executionId}}", (String) event.content?.execution?.id ?: "")
+        .replace("{{link}}", link ?: "")
+      body = new MarkdownToHtmlFormatter().convert(interpolated)
     } else {
       Template template = configuration.getTemplate(type == 'stage' ? 'stage.ftl' : 'pipeline.ftl', "UTF-8")
       body = FreeMarkerTemplateUtils.processTemplateIntoString(

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/HipchatNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/HipchatNotificationAgent.groovy
@@ -86,10 +86,10 @@ class HipchatNotificationAgent extends AbstractEventNotificationAgent {
         }"""
 
       String customMessage = event.content?.context?.customMessage
-      if (customMessage && event.content?.execution?.id) {
+      if (customMessage) {
         message = customMessage
-          .replace("{{executionId}}", (String) event.content.execution.id)
-          .replace("{{link}}", link)
+          .replace("{{executionId}}", (String) event.content.execution?.id ?: "")
+          .replace("{{link}}", link ?: "")
       }
 
       hipchatService.sendMessage(

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
@@ -87,10 +87,10 @@ class SlackNotificationAgent extends AbstractEventNotificationAgent {
       }
 
       String customMessage = event.content?.context?.customMessage
-      if (customMessage && event.content?.execution?.id) {
+      if (customMessage) {
         body = customMessage
-          .replace("{{executionId}}", (String) event.content.execution.id)
-          .replace("{{link}}", link)
+          .replace("{{executionId}}", (String) event.content.execution?.id ?: "")
+          .replace("{{link}}", link ?: "")
       }
 
       String address = preference.address.startsWith('#') ? preference.address : "#${preference.address}"

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgentSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgentSpec.groovy
@@ -157,6 +157,7 @@ class EmailNotificationAgentSpec extends Specification {
     stageName = "foo-stage"
     event = new Event(content: [context: [customSubject: customSubject,
                                           customBody: customBody,
-                                          stageDetails: [name: "foo-stage"]], execution: [name: "foo-pipeline"]])
+                                          stageDetails: [name: "foo-stage"]],
+                                execution: [id: "abc", name: "foo-pipeline"]])
   }
 }


### PR DESCRIPTION
I put this in Slack and HipChat, but forgot about email. Classic.

Also adding guards around checking for `execution.id`, and allowing `link` replacement, even if `execution.id` is not available.