### PR TITLE
feat(webhooks): Support artifacts

### DIFF
--- a/echo-core/echo-core.gradle
+++ b/echo-core/echo-core.gradle
@@ -22,4 +22,7 @@ dependencies {
     compile spinnaker.dependency('logstashEncoder')
     testCompile spinnaker.dependency('spockSpring')
     testCompile spinnaker.dependency('springTest')
+
+    // TODO(jacobkiefer): Add jinjava to spinnaker-dependencies.
+    compile 'com.hubspot.jinjava:jinjava:2.2.3'
 }

--- a/echo-core/src/main/groovy/com/netflix/spinnaker/echo/artifacts/MessageArtifactTranslator.java
+++ b/echo-core/src/main/groovy/com/netflix/spinnaker/echo/artifacts/MessageArtifactTranslator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.echo.pubsub.utils;
+package com.netflix.spinnaker.echo.artifacts;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,7 +43,7 @@ public class MessageArtifactTranslator {
   private static final TypeReference<List<Artifact>> artifactListReference = new TypeReference<List<Artifact>>() {};
 
   public MessageArtifactTranslator(String templatePath) {
-    if (!StringUtils.isEmpty(templatePath)) {
+    if (StringUtils.isNotEmpty(templatePath)) {
       try {
         jinjaTemplate = new String(Files.readAllBytes(Paths.get(templatePath)));
       } catch (IOException ioe) {
@@ -62,9 +62,13 @@ public class MessageArtifactTranslator {
   }
 
   private String jinjaTransform(ObjectMapper mapper, String messagePayload) {
-    Jinjava jinja = new Jinjava();
-    Map context = readMapValue(mapper, messagePayload);
-    return jinja.render(jinjaTemplate, context);
+    if (StringUtils.isEmpty(jinjaTemplate)) {
+      return messagePayload;
+    } else {
+      Jinjava jinja = new Jinjava();
+      Map context = readMapValue(mapper, messagePayload);
+      return jinja.render(jinjaTemplate, context);
+    }
   }
 
   private Map readMapValue(ObjectMapper mapper, String messagePayload) {

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pipelinetriggers.artifacts;
+
+import com.netflix.spinnaker.echo.model.Pipeline;
+import com.netflix.spinnaker.echo.model.Trigger;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class ArtifactMatcher {
+  public static Boolean anyArtifactsMatchExpected(List<Artifact> messageArtifacts, Trigger trigger, Pipeline pipeline) {
+    List<String> expectedArtifactIds = trigger.getExpectedArtifactIds();
+    List<ExpectedArtifact> expectedArtifacts = pipeline.getExpectedArtifacts()
+        .stream()
+        .filter(e -> expectedArtifactIds.contains(e.getId()))
+        .collect(Collectors.toList());
+
+    if (expectedArtifactIds == null || expectedArtifactIds.isEmpty()) {
+      return true;
+    }
+
+    if (messageArtifacts.size() > expectedArtifactIds.size()) {
+      log.warn("Parsed message artifacts (size {}) greater than expected artifacts (size {}), continuing trigger anyway", messageArtifacts.size(), expectedArtifactIds.size());
+    }
+
+    Predicate<Artifact> expectedArtifactMatch = a -> expectedArtifacts
+        .stream()
+        .anyMatch(e -> e.matches(a));
+    return messageArtifacts.stream().anyMatch(expectedArtifactMatch);
+  }
+}

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.echo.model.Trigger;
 import com.netflix.spinnaker.echo.model.trigger.WebhookEvent;
 import com.netflix.spinnaker.echo.model.trigger.TriggerEvent;
 import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache;
+import com.netflix.spinnaker.echo.pipelinetriggers.artifacts.ArtifactMatcher;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -30,6 +32,8 @@ import org.springframework.stereotype.Component;
 import rx.Observable;
 import rx.functions.Action1;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -103,8 +107,15 @@ public class WebhookEventMonitor extends TriggerMonitor {
                isConstraintInPayload(trigger.getConstraints(), event.getPayload())
             )
 
-        );
-
+        ) &&
+          // note this returns true when no artifacts are expected
+          ArtifactMatcher.anyArtifactsMatchExpected(
+              (List<Artifact>) event
+                  .getPayload()
+                  .getOrDefault("artifacts", new ArrayList<Artifact>()),
+              trigger,
+              pipeline
+          );
   }
 
   /**

--- a/echo-pubsub/src/test/groovy/com/netflix/spinnaker/echo/pubsub/utils/MessageArtifactTranslatorSpec.groovy
+++ b/echo-pubsub/src/test/groovy/com/netflix/spinnaker/echo/pubsub/utils/MessageArtifactTranslatorSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.echo.pubsub.utils
 
+import com.netflix.spinnaker.echo.artifacts.MessageArtifactTranslator
 import spock.lang.Specification
 import spock.lang.Subject
 

--- a/echo-web/config/echo.yml
+++ b/echo-web/config/echo.yml
@@ -19,3 +19,8 @@ search:
 management.health.mail.enabled: false
 
 spring.freemarker.enabled: false
+
+webhooks:
+  artifacts:
+    enabled: false
+    sources: []

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/config/WebhookConfig.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/config/WebhookConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-dependencies {
-  compile project(':echo-core')
-  compile project(':echo-model')
-  compile project(':echo-pipelinetriggers')
+package com.netflix.spinnaker.echo.config;
 
-  spinnaker.group("bootWeb")
-  spinnaker.group("spockBase")
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 
-  compile spinnaker.dependency("groovy")
-  compile spinnaker.dependency("guava")
-  compile spinnaker.dependency("jedis")
-  compile spinnaker.dependency("korkJedisTest")
-
-  compile 'com.google.cloud:google-cloud-pubsub:0.21.1-beta'
+@Configuration
+@ConditionalOnProperty("webhooks.artifacts.enabled")
+@EnableConfigurationProperties(WebhookProperties.class)
+public class WebhookConfig {
 }

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/config/WebhookProperties.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/config/WebhookProperties.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.config;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@ConfigurationProperties(prefix = "webhooks.artifacts")
+public class WebhookProperties {
+  @Valid
+  private List<WebhookArtifactTranslator> sources = new ArrayList<>();
+
+  public String getTemplatePathForSource(String source) {
+    return sources.stream()
+        .filter(s -> s.getSource().equals(source))
+        .map(WebhookArtifactTranslator::getTemplatePath)
+        .findAny()
+        .orElse(null);
+  }
+
+  @Data
+  @NoArgsConstructor
+  public static class WebhookArtifactTranslator {
+    @NotEmpty
+    private String source;
+
+    @NotEmpty
+    private String templatePath;
+  }
+}


### PR DESCRIPTION
The result of this is that if someone POSTs to `$GATE_URL/webhooks/artifacts/<source>` with either

1. `"artifacts": []` specified in the payload, or
2. an artifact transforming jinja template registered for `<source>`.

The artifacts will be injected into any pipelines that declare that webhook (and have matching expected artifacts) as a trigger.

This is useful, because with (1) external systems can either explicitly say which artifacts they want to trigger pipelines with, or, any sort of "push" based trigger system with (2) can have their output converted into something Spinnaker understands without us having to supply code for it.

For example, look at the message format in [quay's notification guide](https://docs.quay.io/guides/notifications.html).

A user (or really us, for common cases like this) can supply a jinja template like:

```jinja
[
{% for tag in updated_tags %}
{
  "type": "docker/image",
  "name": "{{ docker_url }}"
  "reference": "{{ docker_url }}:{{ tag }}"
  "version": "{{ tag }}"
} {% if not loop.last %} , {% endif %}
{% endfor %}
]
```

for the source `quay`, and then configure quay to send push notifications to `$GATE_URL/webhooks/artifact/quay`.

```yaml
# echo.yml
webhooks:
  artifacts:
    enabled: true
    sources:
    - source: quay
      templatePath: /path/to/above/jinja-file # in the future some might ship with spinnaker
```

In their pipeline, they would register this "expected artifact": 
![quay](https://user-images.githubusercontent.com/4874941/32995503-6f84feea-cd43-11e7-85b2-4779738582a7.png)

and add a "webhook" trigger that requires that artifact to be present. Now only changes to images matching that tag will be allowed to trigger their pipeline, and any stage that understands how to deploy a docker image will be able to do so.
