### PR TITLE
feat(slack): Support slack incoming webhooks

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 import static net.logstash.logback.argument.StructuredArguments.*
+import static org.apache.commons.lang.WordUtils.capitalize
 
 
 @Slf4j
@@ -70,13 +71,13 @@ class SlackNotificationAgent extends AbstractEventNotificationAgent {
       String body = ''
 
       if (config.type == 'stage') {
-        body = """Stage ${event.content?.context?.stageDetails.name} for """
+        body = """Stage ${event.content?.context?.stageDetails?.name} for """
       }
 
       String link = "${spinnakerUrl}/#/applications/${application}/${config.type == 'stage' ? 'executions/details' : config.link }/${event.content?.execution?.id}"
 
       body +=
-        """${WordUtils.capitalize(application)}'s <${link}|${
+        """${capitalize(application)}'s <${link}|${
           event.content?.execution?.name ?: event.content?.execution?.description
         }>${buildInfo}${config.type == 'task' ? 'task' : 'pipeline'} ${status == 'starting' ? 'is' : 'has'} ${
           status == 'complete' ? 'completed successfully' : status
@@ -95,11 +96,21 @@ class SlackNotificationAgent extends AbstractEventNotificationAgent {
 
       String address = preference.address.startsWith('#') ? preference.address : "#${preference.address}"
 
-      slackService.sendMessage(token, new SlackMessage(body, color).buildMessage(), address, true)
+      def title = getNotificationTitle(config.type, application, status)
+      def response = slackService.sendMessage(token, new SlackMessage(title, body, color), address, true)
+      log.info("Received response from Slack: {} {} for execution id {}. {}",
+        response?.status, response?.reason, event.content?.execution?.id, response?.body)
 
     } catch (Exception e) {
       log.error('failed to send slack message ', e)
     }
+  }
+
+  /**
+   * @return eg. "Pipeline complete for MYWEBAPP"
+   */
+  static String getNotificationTitle(String configType, String application, String status) {
+    "${capitalize(configType)} ${status} for ${application.toUpperCase()}"
   }
 
   @Override

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
@@ -16,10 +16,9 @@
 
 package com.netflix.spinnaker.echo.notification
 import com.netflix.spinnaker.echo.model.Event
-import com.netflix.spinnaker.echo.slack.SlackMessage
+import com.netflix.spinnaker.echo.slack.SlackAttachment
 import com.netflix.spinnaker.echo.slack.SlackService
 import groovy.util.logging.Slf4j
-import org.apache.commons.lang.WordUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -97,7 +96,7 @@ class SlackNotificationAgent extends AbstractEventNotificationAgent {
       String address = preference.address.startsWith('#') ? preference.address : "#${preference.address}"
 
       def title = getNotificationTitle(config.type, application, status)
-      def response = slackService.sendMessage(token, new SlackMessage(title, body, color), address, true)
+      def response = slackService.sendMessage(token, new SlackAttachment(title, body, color), address, true)
       log.info("Received response from Slack: {} {} for execution id {}. {}",
         response?.status, response?.reason, event.content?.execution?.id, response?.body)
 

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackAttachment.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackAttachment.groovy
@@ -17,40 +17,30 @@
 
 package com.netflix.spinnaker.echo.slack
 
-import groovy.json.JsonBuilder
 import groovy.transform.Canonical
 
+/**
+ * This is formatted automatically to JSON when being sent to Slack as an attachment message.
+ */
 @Canonical
-class SlackMessage {
+class SlackAttachment {
 
+  String title
   String text
   String color
   String fallback
-  String title
+
+  // From https://github.com/spinnaker
+  String footer_icon = "https://avatars0.githubusercontent.com/u/7634182?s=200&v=4"
   String footer = "Spinnaker"
-  String footer_icon = "https://avatars0.githubusercontent.com/u/7634182?s=200&v=4" // From https://github.com/spinnaker
+  // Specify which fields Slack should format using markdown
+  List<String> mrkdwn_in = ["text"]
+  // The pretty date will appear in the footer
   long ts = System.currentTimeMillis() / 1000
 
-  public SlackMessage(String title, String text, String color = '#cccccc') {
+  public SlackAttachment(String title, String text, String color = '#cccccc') {
     this.title = title
     this.text = this.fallback = text
     this.color = color
-  }
-
-  /**
-   * To display a message with a colored vertical bar on the left, Slack expects the message to be in an "attachments"
-   * field as a JSON string of an array of objects, e.g.
-   *   [{"fallback":"plain-text summary", "text":"the message to send", "color":"#hexcolor"}]
-   * @return a stringified version of the JSON array containing the attachment
-   */
-  String buildMessage() {
-    new JsonBuilder([
-      [
-        fallback: text,
-        text: text,
-        color: color,
-        mrkdwn_in: ["text"]
-      ]
-    ]).toString()
   }
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackClient.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackClient.groovy
@@ -17,22 +17,25 @@
 
 package com.netflix.spinnaker.echo.slack
 
-import groovy.transform.Canonical
 import retrofit.client.Response
+import retrofit.http.*
 
-@Canonical
-class SlackService {
+interface SlackClient {
 
-  SlackClient slackClient
-  boolean useIncomingWebHook
+  @FormUrlEncoded
+  @POST('/api/chat.postMessage')
+  Response sendMessage(
+    @Query('token') String token,
+    @Field('attachments') String attachments,
+    @Field('channel') String channel,
+    @Field('as_user') boolean asUser)
 
-  Response sendMessage(String token, SlackMessage message, String channel, boolean asUser) {
-    useIncomingWebHook ?
-      slackClient.sendUsingIncomingWebHook(token, new SlackRequest([message], channel)) :
-      slackClient.sendMessage(token, message.buildMessage(), channel, asUser)
-  }
+  /**
+   * Documentation: https://api.slack.com/incoming-webhooks
+   */
+  @POST('/services/{token}')
+  Response sendUsingIncomingWebHook(
+    @Path(value = "token", encode = false) String token,
+    @Body SlackRequest slackRequest)
 
-  boolean useIncomingWebHook() {
-    useIncomingWebHook
-  }
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackMessage.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackMessage.groovy
@@ -23,8 +23,19 @@ import groovy.transform.Canonical
 @Canonical
 class SlackMessage {
 
-  String body
-  String color = '#cccccc'
+  String text
+  String color
+  String fallback
+  String title
+  String footer = "Spinnaker"
+  String footer_icon = "https://avatars0.githubusercontent.com/u/7634182?s=200&v=4" // From https://github.com/spinnaker
+  long ts = System.currentTimeMillis() / 1000
+
+  public SlackMessage(String title, String text, String color = '#cccccc') {
+    this.title = title
+    this.text = this.fallback = text
+    this.color = color
+  }
 
   /**
    * To display a message with a colored vertical bar on the left, Slack expects the message to be in an "attachments"
@@ -34,12 +45,12 @@ class SlackMessage {
    */
   String buildMessage() {
     new JsonBuilder([
-        [
-          fallback: body,
-          text: body,
-          color: color,
-          mrkdwn_in: ["text"]
-        ]
-      ]).toString()
+      [
+        fallback: text,
+        text: text,
+        color: color,
+        mrkdwn_in: ["text"]
+      ]
+    ]).toString()
   }
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
@@ -45,10 +45,10 @@ class SlackNotificationService implements NotificationService {
 
   @Override
   void handle(Notification notification) {
-    def body = notificationTemplateEngine.build(notification, NotificationTemplateEngine.Type.BODY)
+    def text = notificationTemplateEngine.build(notification, NotificationTemplateEngine.Type.BODY)
     notification.to.each {
       String address = it.startsWith('#') ? it : "#${it}"
-      slack.sendMessage(token, new SlackMessage(body).buildMessage(), address, true)
+      slack.sendMessage(token, new SlackMessage("Spinnaker Notification", text), address, true)
     }
   }
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
@@ -48,7 +48,7 @@ class SlackNotificationService implements NotificationService {
     def text = notificationTemplateEngine.build(notification, NotificationTemplateEngine.Type.BODY)
     notification.to.each {
       String address = it.startsWith('#') ? it : "#${it}"
-      slack.sendMessage(token, new SlackMessage("Spinnaker Notification", text), address, true)
+      slack.sendMessage(token, new SlackAttachment("Spinnaker Notification", text), address, true)
     }
   }
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackRequest.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackRequest.groovy
@@ -21,6 +21,6 @@ import groovy.transform.Canonical
 
 @Canonical
 class SlackRequest {
-  List<SlackMessage> attachments
+  List<SlackAttachment> attachments
   String channel
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackRequest.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackRequest.groovy
@@ -18,21 +18,9 @@
 package com.netflix.spinnaker.echo.slack
 
 import groovy.transform.Canonical
-import retrofit.client.Response
 
 @Canonical
-class SlackService {
-
-  SlackClient slackClient
-  boolean useIncomingWebHook
-
-  Response sendMessage(String token, SlackMessage message, String channel, boolean asUser) {
-    useIncomingWebHook ?
-      slackClient.sendUsingIncomingWebHook(token, new SlackRequest([message], channel)) :
-      slackClient.sendMessage(token, message.buildMessage(), channel, asUser)
-  }
-
-  boolean useIncomingWebHook() {
-    useIncomingWebHook
-  }
+class SlackRequest {
+  List<SlackMessage> attachments
+  String channel
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackService.groovy
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.echo.slack
 
+import groovy.json.JsonBuilder
 import groovy.transform.Canonical
 import retrofit.client.Response
 
@@ -26,13 +27,13 @@ class SlackService {
   SlackClient slackClient
   boolean useIncomingWebHook
 
-  Response sendMessage(String token, SlackMessage message, String channel, boolean asUser) {
+  Response sendMessage(String token, SlackAttachment message, String channel, boolean asUser) {
     useIncomingWebHook ?
       slackClient.sendUsingIncomingWebHook(token, new SlackRequest([message], channel)) :
-      slackClient.sendMessage(token, message.buildMessage(), channel, asUser)
+      slackClient.sendMessage(token, toJson(message), channel, asUser)
   }
 
-  boolean useIncomingWebHook() {
-    useIncomingWebHook
+  def static toJson(message) {
+    "[" + new JsonBuilder(message).toPrettyString() + "]"
   }
 }

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/SlackConfigSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/SlackConfigSpec.groovy
@@ -1,0 +1,42 @@
+package com.netflix.spinnaker.echo.config
+
+import com.netflix.spinnaker.echo.slack.SlackMessage
+import com.sun.jndi.toolkit.url.Uri
+import groovy.json.JsonSlurper
+import retrofit.RestAdapter
+import retrofit.client.Client
+import retrofit.client.OkClient
+import retrofit.client.Request
+import retrofit.client.Response
+import retrofit.mime.TypedByteArray
+import retrofit.mime.TypedOutput
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.util.concurrent.BlockingVariable
+
+import static java.util.Collections.emptyList
+import static retrofit.RestAdapter.*
+
+class SlackConfigSpec extends Specification {
+  @Subject SlackConfig slackConfig = new SlackConfig()
+
+  def 'test slack incoming web hook is inferred correctly'() {
+    given:
+
+    when:
+    def useIncomingHook = slackConfig.useIncomingWebHook(token)
+    def endpoint = slackConfig.slackEndpoint(useIncomingHook)
+
+    then:
+    useIncomingHook == expectedUseIncomingWebHook
+    endpoint.url == expectedEndpoint
+
+    where:
+    token                                          | expectedEndpoint          | expectedUseIncomingWebHook
+    "myOldFashionToken"                            | "https://slack.com"       | false
+    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | "https://hooks.slack.com" | true
+    "OLD/FASHION"                                  | "https://slack.com"       | false
+    ""                                             | "https://slack.com"       | false
+    null                                           | "https://slack.com"       | false
+  }
+}

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/SlackConfigSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/SlackConfigSpec.groovy
@@ -1,21 +1,7 @@
 package com.netflix.spinnaker.echo.config
 
-import com.netflix.spinnaker.echo.slack.SlackMessage
-import com.sun.jndi.toolkit.url.Uri
-import groovy.json.JsonSlurper
-import retrofit.RestAdapter
-import retrofit.client.Client
-import retrofit.client.OkClient
-import retrofit.client.Request
-import retrofit.client.Response
-import retrofit.mime.TypedByteArray
-import retrofit.mime.TypedOutput
 import spock.lang.Specification
 import spock.lang.Subject
-import spock.util.concurrent.BlockingVariable
-
-import static java.util.Collections.emptyList
-import static retrofit.RestAdapter.*
 
 class SlackConfigSpec extends Specification {
   @Subject SlackConfig slackConfig = new SlackConfig()

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgentSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgentSpec.groovy
@@ -34,7 +34,7 @@ class SlackNotificationAgentSpec extends Specification {
     given:
     def actualMessage = new BlockingVariable<String>()
     slack.sendMessage(*_) >> { token, message, channel, asUser ->
-      actualMessage.set(message)
+      actualMessage.set(message.buildMessage())
     }
 
     when:
@@ -60,7 +60,7 @@ class SlackNotificationAgentSpec extends Specification {
     given:
     def actualMessage = new BlockingVariable<String>()
     slack.sendMessage(*_) >> { token, message, channel, asUser ->
-      actualMessage.set(message)
+      actualMessage.set(message.buildMessage())
     }
 
     when:
@@ -89,7 +89,7 @@ class SlackNotificationAgentSpec extends Specification {
     given:
     def actualMessage = new BlockingVariable<String>()
     slack.sendMessage(*_) >> { token, message, channel, asUser ->
-      actualMessage.set(message)
+      actualMessage.set(message.buildMessage())
     }
 
     when:

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgentSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgentSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.echo.notification
 
+import com.netflix.spinnaker.echo.slack.SlackAttachment
 import groovy.json.JsonSlurper
 import com.netflix.spinnaker.echo.model.Event
 import com.netflix.spinnaker.echo.slack.SlackService
@@ -32,16 +33,16 @@ class SlackNotificationAgentSpec extends Specification {
   @Unroll
   def "sends correct message for #status status"() {
     given:
-    def actualMessage = new BlockingVariable<String>()
+    def actualMessage = new BlockingVariable<SlackAttachment>()
     slack.sendMessage(*_) >> { token, message, channel, asUser ->
-      actualMessage.set(message.buildMessage())
+      actualMessage.set(message)
     }
 
     when:
     agent.sendNotifications([address: channel], application, event, [type: type, link: "link"], status)
 
     then:
-    new JsonSlurper().parseText(actualMessage.get()).text[0] ==~ expectedMessage
+    actualMessage.get().text ==~ expectedMessage
 
     where:
     status      || expectedMessage
@@ -58,16 +59,16 @@ class SlackNotificationAgentSpec extends Specification {
   @Unroll
   def "appends custom message to #status message if present"() {
     given:
-    def actualMessage = new BlockingVariable<String>()
+    def actualMessage = new BlockingVariable<SlackAttachment>()
     slack.sendMessage(*_) >> { token, message, channel, asUser ->
-      actualMessage.set(message.buildMessage())
+      actualMessage.set(message)
     }
 
     when:
     agent.sendNotifications([address: channel, message: message], application, event, [type: type, link: "link"], status)
 
     then:
-    new JsonSlurper().parseText(actualMessage.get()).text[0] ==~ expectedMessage
+    actualMessage.get().text ==~ expectedMessage
 
     where:
     status      || expectedMessage
@@ -87,16 +88,16 @@ class SlackNotificationAgentSpec extends Specification {
   @Unroll
   def "sends entirely custom message if customMessage field is present, performing text replacement if needed"() {
     given:
-    def actualMessage = new BlockingVariable<String>()
+    def actualMessage = new BlockingVariable<SlackAttachment>()
     slack.sendMessage(*_) >> { token, message, channel, asUser ->
-      actualMessage.set(message.buildMessage())
+      actualMessage.set(message)
     }
 
     when:
     agent.sendNotifications([address: channel], application, event, [type: type], "etc")
 
     then:
-    new JsonSlurper().parseText(actualMessage.get()).text[0] == expectedMessage
+    actualMessage.get().text == expectedMessage
 
     where:
     customMessage        || expectedMessage

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackServiceSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackServiceSpec.groovy
@@ -1,0 +1,65 @@
+package com.netflix.spinnaker.echo.slack
+
+import com.netflix.spinnaker.echo.config.SlackConfig
+import groovy.json.JsonSlurper
+import retrofit.client.Client
+import retrofit.client.Request
+import retrofit.client.Response
+import retrofit.mime.TypedByteArray
+import retrofit.mime.TypedOutput
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.util.concurrent.BlockingVariable
+
+import static java.util.Collections.emptyList
+import static retrofit.Endpoints.newFixedEndpoint
+import static retrofit.RestAdapter.LogLevel
+
+class SlackServiceSpec extends Specification {
+  @Subject mockHttpClient = Mock(Client)
+  @Subject slackConfig = new SlackConfig()
+
+  def 'test sending Slack notification using incoming web hook'() {
+
+    given: "a SlackService configured to send using a mocked HTTP client"
+    def actualUrl = new BlockingVariable<String>()
+    def actualPayload = new BlockingVariable<String>()
+
+    // intercepting the HTTP call
+    mockHttpClient.execute(*_) >> { Request request ->
+      actualUrl.set(request.url)
+      actualPayload.set(getString(request.body))
+      mockResponse()
+    }
+
+    def slackService = slackConfig.slackService(useIncomingHook, endpoint, mockHttpClient, LogLevel.FULL)
+
+    when: "sending a notification"
+    slackService.sendMessage(token, new SlackMessage("Title", "the text"), "#testing", true)
+    def responseJson = new JsonSlurper().parseText(actualPayload.get())
+
+    then: "the HTTP URL and payload intercepted are the ones expected"
+    actualUrl.get() == expectedUrl
+    responseJson.attachments[0]["title"] == "Title"
+    responseJson.attachments[0]["text"] == "the text"
+    responseJson.attachments[0]["footer"] == "Spinnaker"
+    responseJson.channel == "#testing"
+
+    where:
+    token            | expectedUrl
+    "NEW/TYPE/TOKEN" | "https://hooks.slack.com/services/NEW/TYPE/TOKEN"
+
+    useIncomingHook = true
+    endpoint = newFixedEndpoint(SlackConfig.SLACK_INCOMING_WEBHOOK)
+  }
+
+  static Response mockResponse() {
+    new Response("url", 200, "nothing", emptyList(), new TypedByteArray("application/json", "response".bytes))
+  }
+
+  static String getString(TypedOutput typedOutput) {
+    OutputStream os = new ByteArrayOutputStream()
+    typedOutput.writeTo(os)
+    new String(os.toByteArray(),"UTF-8")
+  }
+}

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackServiceSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackServiceSpec.groovy
@@ -2,6 +2,9 @@ package com.netflix.spinnaker.echo.slack
 
 import com.netflix.spinnaker.echo.config.SlackConfig
 import groovy.json.JsonSlurper
+import org.apache.http.HttpEntity
+import org.apache.http.NameValuePair
+import org.apache.http.client.utils.URLEncodedUtils
 import retrofit.client.Client
 import retrofit.client.Request
 import retrofit.client.Response
@@ -11,46 +14,98 @@ import spock.lang.Specification
 import spock.lang.Subject
 import spock.util.concurrent.BlockingVariable
 
+import java.nio.charset.Charset
+
 import static java.util.Collections.emptyList
 import static retrofit.Endpoints.newFixedEndpoint
 import static retrofit.RestAdapter.LogLevel
 
 class SlackServiceSpec extends Specification {
-  @Subject mockHttpClient = Mock(Client)
   @Subject slackConfig = new SlackConfig()
+  @Subject mockHttpClient
+  @Subject BlockingVariable<String> actualUrl
+  @Subject BlockingVariable<String> actualPayload
 
-  def 'test sending Slack notification using incoming web hook'() {
+  def setup() {
+    actualUrl = new BlockingVariable<String>()
+    actualPayload = new BlockingVariable<String>()
 
-    given: "a SlackService configured to send using a mocked HTTP client"
-    def actualUrl = new BlockingVariable<String>()
-    def actualPayload = new BlockingVariable<String>()
-
+    mockHttpClient = Mock(Client)
     // intercepting the HTTP call
     mockHttpClient.execute(*_) >> { Request request ->
       actualUrl.set(request.url)
       actualPayload.set(getString(request.body))
       mockResponse()
     }
+  }
+
+  def 'test sending Slack notification using incoming web hook'() {
+
+    given: "a SlackService configured to send using a mocked HTTP client and useIncomingHook=true"
+    def useIncomingHook = true
+    def endpoint = newFixedEndpoint(SlackConfig.SLACK_INCOMING_WEBHOOK)
 
     def slackService = slackConfig.slackService(useIncomingHook, endpoint, mockHttpClient, LogLevel.FULL)
 
     when: "sending a notification"
-    slackService.sendMessage(token, new SlackMessage("Title", "the text"), "#testing", true)
+    slackService.sendMessage(token, new SlackAttachment("Title", "the text"), "#testing", true)
     def responseJson = new JsonSlurper().parseText(actualPayload.get())
 
     then: "the HTTP URL and payload intercepted are the ones expected"
     actualUrl.get() == expectedUrl
     responseJson.attachments[0]["title"] == "Title"
     responseJson.attachments[0]["text"] == "the text"
+    responseJson.attachments[0]["fallback"] == "the text"
     responseJson.attachments[0]["footer"] == "Spinnaker"
+    responseJson.attachments[0]["mrkdwn_in"] == ["text"]
     responseJson.channel == "#testing"
 
     where:
     token            | expectedUrl
     "NEW/TYPE/TOKEN" | "https://hooks.slack.com/services/NEW/TYPE/TOKEN"
+  }
 
-    useIncomingHook = true
-    endpoint = newFixedEndpoint(SlackConfig.SLACK_INCOMING_WEBHOOK)
+
+  def 'test sending Slack notification using chat.postMessage API'() {
+
+    given: "a SlackService configured to send using a mocked HTTP client and useIncomingHook=false"
+    def useIncomingHook = false
+    def endpoint = newFixedEndpoint(SlackConfig.SLACK_CHAT_API)
+
+    def slackService = slackConfig.slackService(useIncomingHook, endpoint, mockHttpClient, LogLevel.FULL)
+
+    when: "sending a notification"
+    slackService.sendMessage(token, new SlackAttachment("Title", "the text"), "#testing", true)
+
+    // Parse URL Encoded Form
+    def params = URLEncodedUtils.parse(actualPayload.get(), Charset.forName("UTF-8"))
+    def attachmentsField = getField(params, "attachments")
+    def attachmentsJson = parseJson(attachmentsField.value)
+
+    def channelField = getField(params, "channel")
+    def asUserField = getField(params, "as_user")
+
+    then: "the HTTP URL and payload intercepted are the ones expected"
+    actualUrl.get() == expectedUrl
+    attachmentsJson[0]["title"] == "Title"
+    attachmentsJson[0]["text"] == "the text"
+    attachmentsJson[0]["fallback"] == "the text"
+    attachmentsJson[0]["footer"] == "Spinnaker"
+    attachmentsJson[0]["mrkdwn_in"] == ["text"]
+    channelField.value == "#testing"
+    asUserField.value == "true"
+
+    where:
+    token           | expectedUrl
+    "oldStyleToken" | "https://slack.com/api/chat.postMessage?token=oldStyleToken"
+  }
+
+  def static getField(Collection<NameValuePair> params, String fieldName) {
+    params.find({ it -> it.name == fieldName })
+  }
+
+  def static parseJson(String value) {
+    new JsonSlurper().parseText(value)
   }
 
   static Response mockResponse() {
@@ -60,6 +115,6 @@ class SlackServiceSpec extends Specification {
   static String getString(TypedOutput typedOutput) {
     OutputStream os = new ByteArrayOutputStream()
     typedOutput.writeTo(os)
-    new String(os.toByteArray(),"UTF-8")
+    new String(os.toByteArray(), "UTF-8")
   }
 }


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/2103

This PR adds support for tokens generated for Slack Incoming web hooks [1], which follow this format: `T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX` and target a different Slack API.

This is backward compatible - still works with tokens that rely on chat.postMessage API [2]. 

The implementation is inspired from ansible's slack implementation [3].

Feedback is welcomed. We're using this internally in our environment with success.

![ss](https://user-images.githubusercontent.com/952836/33286845-51fb0360-d3bf-11e7-8faa-faff26d564aa.jpg)



<img width="642" alt="screenshot 2017-11-25 21 07 07" src="https://user-images.githubusercontent.com/952836/33233799-a1668fc4-d224-11e7-807f-d2832dabd6f9.png">

<img width="534" alt="screenshot 2017-11-25 20 49 25" src="https://user-images.githubusercontent.com/952836/33233719-14cd9e78-d223-11e7-88aa-cdc0fe6a548b.png">


[1] https://api.slack.com/incoming-webhooks
[2] https://api.slack.com/methods/chat.postMessage
[3] https://github.com/ansible/ansible-modules-extras/blob/devel/notification/slack.py#L236