### PR TITLE
fix(pubsub): Use message IDs instead of payload hash. (#201)

### DIFF
--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubSubscriber.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubSubscriber.java
@@ -143,6 +143,7 @@ public class GooglePubsubSubscriber implements PubsubSubscriber {
     @Override
     public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
       String messagePayload = message.getData().toStringUtf8();
+      String messageId = message.getMessageId();
       log.debug("Received message with payload: {}", messagePayload);
 
       MessageDescription description = MessageDescription.builder()
@@ -154,7 +155,7 @@ public class GooglePubsubSubscriber implements PubsubSubscriber {
           .artifacts(messageArtifactTranslator.parseArtifacts(messagePayload))
           .build();
       GoogleMessageAcknowledger acknowledger = new GoogleMessageAcknowledger(consumer);
-      pubsubMessageHandler.handleMessage(description, acknowledger, identity.getIdentity());
+      pubsubMessageHandler.handleMessage(description, acknowledger, identity.getIdentity(), messageId);
     }
   }
 

--- a/echo-pubsub/src/test/groovy/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandlerSpec.groovy
+++ b/echo-pubsub/src/test/groovy/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandlerSpec.groovy
@@ -47,7 +47,6 @@ class PubsubMessageHandlerSpec extends Specification {
 
   def setup() {
     pubsubMessageHandler = new PubsubMessageHandler()
-    pubsubMessageHandler.setDigest(messageDigest)
     pubsubMessageHandler.setJedisPool(embeddedRedis.getPool())
     pubsubMessageHandler.setPubsubEventMonitor(pubsubEventMonitor)
   }
@@ -115,6 +114,7 @@ class PubsubMessageHandlerSpec extends Specification {
 
   def "event processed on pubsub message if it hasn't been processed already"() {
     given:
+    String messageId = 'X'
     MessageDescription description = MessageDescription.builder()
     .subscriptionName('subscriptionName')
     .messagePayload('THE TRUTH IS OUT THERE')
@@ -127,7 +127,7 @@ class PubsubMessageHandlerSpec extends Specification {
     String id = 'id'
 
     when:
-    pubsubMessageHandler.handleMessage(description, acker, id)
+    pubsubMessageHandler.handleMessage(description, acker, id, messageId)
 
     then:
     1 * pubsubEventMonitor.processEvent(_)
@@ -137,6 +137,7 @@ class PubsubMessageHandlerSpec extends Specification {
 
   def "message gets handled only once while it's retained in the topic"() {
     given:
+    String messageId = 'X'
     MessageDescription description = MessageDescription.builder()
         .subscriptionName('subscriptionName')
         .messagePayload('THE TRUTH IS OUT THERE')
@@ -149,8 +150,8 @@ class PubsubMessageHandlerSpec extends Specification {
     String id = 'id'
 
     when:
-    pubsubMessageHandler.handleMessage(description, acker, id)
-    pubsubMessageHandler.handleMessage(description, acker, id)
+    pubsubMessageHandler.handleMessage(description, acker, id, messageId)
+    pubsubMessageHandler.handleMessage(description, acker, id, messageId)
 
     then:
     1 * pubsubEventMonitor.processEvent(_)


### PR DESCRIPTION
@spinnaker/google-reviewers FYI This is a _port_ of https://github.com/spinnaker/echo/pull/201 to 1.5.x. There was a small refactor underneath this fix, so it had to be applied slightly differently on both base branches `master` and `release-1.5.x`.