### PR TITLE
Adding ability for custom webhook triggers to pass parameters.

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -65,6 +65,7 @@ public class Trigger {
   String project;
   String slug;
   String hash;
+  Map parameters;
   String account;
   String repository;
   String tag;
@@ -127,11 +128,12 @@ public class Trigger {
         .build();
   }
 
-  public Trigger atConstraints(final Map constraints) {
+  public Trigger atConstraints(final Map parameters, final Map constraints) {
     return this.toBuilder()
         .buildNumber(null)
         .hash(null)
         .digest(null)
+        .parameters(parameters)
         .constraints(constraints)
         .subscriptionName(null)
         .pubsubSystem(null)

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
@@ -33,6 +33,7 @@ import rx.Observable;
 import rx.functions.Action1;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -81,7 +82,9 @@ public class WebhookEventMonitor extends TriggerMonitor {
 
   @Override
   protected Function<Trigger, Pipeline> buildTrigger(Pipeline pipeline, TriggerEvent event) {
-    return trigger -> pipeline.withTrigger(trigger.atConstraints(event.getPayload()));
+    Map payload = event.getPayload();
+    Map parameters = payload.containsKey("parameters") ? (Map) payload.remove("parameters") : new HashMap();
+    return trigger -> pipeline.withTrigger(trigger.atConstraints(parameters, payload));
   }
 
   @Override


### PR DESCRIPTION
We wanted to add the ability for echo webhook triggers to pass on parameters if they are in the webhook payload. We are currently using this endpoint to prevent customization of automagically generated pipelines by using this trigger and tying a service account through RunAsuser that only the thing that can automagically generate pipelines has access to, we do this so that custom pipelines can be created but without impacting generated ones.

It is a bit of a mess but we couldn't really think of a reason why we shouldn't try and contribute this back up as it may be useful for other webhooks potentially.