### PR TITLE
feat(slack): allow more compact slack notifications

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/CompactSlackMessage.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/CompactSlackMessage.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.echo.slack
+
+import groovy.json.JsonBuilder
+import groovy.transform.Canonical
+
+@Canonical
+class CompactSlackMessage {
+
+  String body
+  String color = '#cccccc'
+
+  /**
+   * To display a message with a colored vertical bar on the left, Slack expects the message to be in an "attachments"
+   * field as a JSON string of an array of objects, e.g.
+   *   [{"fallback":"plain-text summary", "text":"the message to send", "color":"#hexcolor"}]
+   * @return a stringified version of the JSON array containing the attachment
+   */
+  String buildMessage() {
+    new JsonBuilder([
+      [
+        fallback: body,
+        text: body,
+        color: color,
+        mrkdwn_in: ["text"]
+      ]
+    ]).toString()
+  }
+}

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
@@ -35,6 +35,9 @@ class SlackNotificationService implements NotificationService {
   @Value('${slack.token}')
   String token
 
+  @Value('${slack.sendCompactMessages:false}')
+  Boolean sendCompactMessages
+
   @Autowired
   NotificationTemplateEngine notificationTemplateEngine
 
@@ -48,7 +51,11 @@ class SlackNotificationService implements NotificationService {
     def text = notificationTemplateEngine.build(notification, NotificationTemplateEngine.Type.BODY)
     notification.to.each {
       String address = it.startsWith('#') ? it : "#${it}"
-      slack.sendMessage(token, new SlackAttachment("Spinnaker Notification", text), address, true)
+      if (sendCompactMessages) {
+        slack.sendCompactMessage(token, new CompactSlackMessage(text), address, true)
+      } else {
+        slack.sendMessage(token, new SlackAttachment("Spinnaker Notification", text), address, true)
+      }
     }
   }
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackService.groovy
@@ -27,6 +27,10 @@ class SlackService {
   SlackClient slackClient
   boolean useIncomingWebHook
 
+  Response sendCompactMessage(String token, CompactSlackMessage message, String channel, boolean asUser) {
+    slackClient.sendMessage(token, message.buildMessage(), channel, asUser)
+  }
+
   Response sendMessage(String token, SlackAttachment message, String channel, boolean asUser) {
     useIncomingWebHook ?
       slackClient.sendUsingIncomingWebHook(token, new SlackRequest([message], channel)) :


### PR DESCRIPTION
We're hearing from users internally that the new Slack message format is unnecessarily verbose, so we are restoring the smaller version of messages as an opt-in feature.

_Without `sendCompactMessages` enabled_

<img width="428" alt="screen shot 2017-12-06 at 2 28 42 pm" src="https://user-images.githubusercontent.com/73450/33688877-0291915c-da92-11e7-9ed8-681fb731dc33.png">

<img width="436" alt="screen shot 2017-12-06 at 2 25 13 pm" src="https://user-images.githubusercontent.com/73450/33688742-59426c48-da91-11e7-8e73-fa4400f5ccc5.png">


_With `sendCompactMessages` enabled_

<img width="416" alt="screen shot 2017-12-06 at 2 30 12 pm" src="https://user-images.githubusercontent.com/73450/33688883-08f4d590-da92-11e7-9bcf-0a566be4f00b.png">

<img width="446" alt="screen shot 2017-12-06 at 2 26 13 pm" src="https://user-images.githubusercontent.com/73450/33688765-735df066-da91-11e7-8d1f-04c2ed330d99.png">
