### PR TITLE
fix(webhooks) Webhook trigger events should be treated as immutable.

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -29,7 +29,7 @@ import lombok.experimental.Wither;
 @JsonDeserialize(builder = Trigger.TriggerBuilder.class)
 @Builder(toBuilder = true)
 @Wither
-@ToString(of = {"type", "master", "job", "cronExpression", "source", "project", "slug", "account", "repository", "tag", "constraints", "branch", "runAsUser", "subscriptionName", "pubsubSystem", "expectedArtifactIds"}, includeFieldNames = false)
+@ToString(of = {"type", "master", "job", "cronExpression", "source", "project", "slug", "account", "repository", "tag", "parameters", "constraints", "branch", "runAsUser", "subscriptionName", "pubsubSystem", "expectedArtifactIds"}, includeFieldNames = false)
 @Value
 public class Trigger {
   public enum Type {

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
@@ -83,7 +83,7 @@ public class WebhookEventMonitor extends TriggerMonitor {
   @Override
   protected Function<Trigger, Pipeline> buildTrigger(Pipeline pipeline, TriggerEvent event) {
     Map payload = event.getPayload();
-    Map parameters = payload.containsKey("parameters") ? (Map) payload.remove("parameters") : new HashMap();
+    Map parameters = payload.containsKey("parameters") ? (Map) payload.get("parameters") : new HashMap();
     return trigger -> pipeline.withTrigger(trigger.atConstraints(parameters, payload));
   }
 


### PR DESCRIPTION
This should fix an issue we ran into with our prior contribution: https://github.com/spinnaker/echo/pull/207

Since events aren't filtered for each pipeline by the point the trigger is built for a pipeline, only the first pipeline processed would have the parameters while the rest would never have them (because we were using remove and not just get).