### PR TITLE
fix(artifacts/github): Github artifacts should be type file

### DIFF
--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/artifacts/GitHubArtifactExtractor.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/artifacts/GitHubArtifactExtractor.java
@@ -65,7 +65,7 @@ public class GitHubArtifactExtractor implements WebhookArtifactExtractor {
 
   @Override
   public boolean handles(String type, String source) {
-    return type.equals("git") && source.equals("github");
+    return type.equals("file") && source.equals("github");
   }
 
   @Data


### PR DESCRIPTION
@lwander - Right now when GitHub webhooks to Echo, the artifacts aren't extracted. I think that artifact type should be `file`. However, I'm not exactly sure under what circumstances type `git` would be used, so could be wrong.