### PR TITLE
fix(artifacts/github): Correctly pull github artifact out of echo event

### DIFF
--- a/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/GitEvent.groovy
+++ b/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/GitEvent.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.model.trigger
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import groovy.transform.Canonical
 
 @Canonical
@@ -34,6 +35,7 @@ class GitEvent extends TriggerEvent {
     String slug
     String hash
     String branch
+    List<Artifact> artifacts;
   }
 
   @JsonIgnore

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/GitEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/GitEventMonitor.java
@@ -102,9 +102,9 @@ public class GitEventMonitor extends TriggerMonitor {
     String project = gitEvent.getContent().getRepoProject();
     String slug = gitEvent.getContent().getSlug();
     String branch = gitEvent.getContent().getBranch();
-    List<Artifact> artifacts = gitEvent.getPayload() != null ?
-        (List<Artifact>) gitEvent.getPayload().getOrDefault("artifacts", new ArrayList<>()) :
-        new ArrayList<>();
+    List<Artifact> artifacts = gitEvent.getContent() != null && gitEvent.getContent().getArtifacts() != null ?
+      gitEvent.getContent().getArtifacts() : new ArrayList<>();
+
     return trigger -> trigger.getType().equals(GIT_TRIGGER_TYPE)
         && trigger.getSource().equalsIgnoreCase(source)
         && trigger.getProject().equalsIgnoreCase(project)


### PR DESCRIPTION
@lwander -

The logic that decides to trigger a pipeline with artifacts was looking for the artifacts in `event.payload.artifacts`. But according to this line:

https://github.com/spinnaker/echo/blob/master/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy#L107

it should be looking in `event.contents.artifacts`.