### PR TITLE
fix(artifacts): Git artifacts should be added to the pipeline.

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/GitEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/GitEventMonitor.java
@@ -117,7 +117,9 @@ public class GitEventMonitor extends TriggerMonitor {
   @Override
   protected Function<Trigger, Pipeline> buildTrigger(Pipeline pipeline, TriggerEvent event) {
     GitEvent gitEvent = (GitEvent) event;
-    return trigger -> pipeline.withTrigger(trigger.atHash(gitEvent.getHash()).atBranch(gitEvent.getBranch()));
+    return trigger -> pipeline
+      .withReceivedArtifacts(gitEvent.getContent().getArtifacts())
+      .withTrigger(trigger.atHash(gitEvent.getHash()).atBranch(gitEvent.getBranch()));
   }
 
   @Override


### PR DESCRIPTION
Without the artifact being attached to the pipeline, it can not be fetched when the pipeline runs.