### PR TITLE
fix(webhooks): Correctly deserialize webhook artifacts

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
@@ -14,16 +14,25 @@
 
 package com.netflix.spinnaker.echo.pipelinetriggers.monitor;
 
+import static com.netflix.spinnaker.echo.pipelinetriggers.artifacts.ArtifactMatcher.isConstraintInPayload;
+import static java.util.Collections.emptyList;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.model.Event;
 import com.netflix.spinnaker.echo.model.Pipeline;
 import com.netflix.spinnaker.echo.model.Trigger;
-import com.netflix.spinnaker.echo.model.trigger.WebhookEvent;
 import com.netflix.spinnaker.echo.model.trigger.TriggerEvent;
+import com.netflix.spinnaker.echo.model.trigger.WebhookEvent;
 import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache;
 import com.netflix.spinnaker.echo.pipelinetriggers.artifacts.ArtifactMatcher;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -32,19 +41,13 @@ import org.springframework.stereotype.Component;
 import rx.Observable;
 import rx.functions.Action1;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.function.Predicate;
-
-import static com.netflix.spinnaker.echo.pipelinetriggers.artifacts.ArtifactMatcher.isConstraintInPayload;
-
 @Component @Slf4j
 public class WebhookEventMonitor extends TriggerMonitor {
 
   public static final String TRIGGER_TYPE = "webhook";
+
+  private static final TypeReference<List<Artifact>> ARTIFACT_LIST =
+      new TypeReference<List<Artifact>>() {};
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -95,12 +98,16 @@ public class WebhookEventMonitor extends TriggerMonitor {
     String type = event.getDetails().getType();
     String source = event.getDetails().getSource();
 
+    Map payload = event.getPayload();
+    List<Artifact> messageArtifacts =
+        objectMapper.convertValue(payload.getOrDefault("artifacts", emptyList()), ARTIFACT_LIST);
+
     return trigger ->
-      trigger.getType().equalsIgnoreCase(type) &&
-      trigger.getSource().equals(source) &&
+        trigger.getType().equalsIgnoreCase(type) &&
+        trigger.getSource().equals(source) &&
         (
-          // The Constraints in the Trigger could be null. That's OK.
-          trigger.getPayloadConstraints() == null ||
+            // The Constraints in the Trigger could be null. That's OK.
+            trigger.getPayloadConstraints() == null ||
 
             // If the Constraints are present, check that there are equivalents in the webhook payload.
             (  trigger.getPayloadConstraints() != null &&
@@ -108,14 +115,8 @@ public class WebhookEventMonitor extends TriggerMonitor {
             )
 
         ) &&
-          // note this returns true when no artifacts are expected
-          ArtifactMatcher.anyArtifactsMatchExpected(
-              (List<Artifact>) event
-                  .getPayload()
-                  .getOrDefault("artifacts", new ArrayList<Artifact>()),
-              trigger,
-              pipeline
-          );
+        // note this returns true when no artifacts are expected
+        ArtifactMatcher.anyArtifactsMatchExpected(messageArtifacts, trigger, pipeline);
   }
 
   protected void onMatchingPipeline(Pipeline pipeline) {

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
@@ -67,8 +67,6 @@ public class WebhookEventMonitor extends TriggerMonitor {
 
     /* Need to create WebhookEvent, since TriggerEvent is abstract */
     WebhookEvent webhookEvent = objectMapper.convertValue(event, WebhookEvent.class);
-    webhookEvent.setDetails(event.getDetails());
-    webhookEvent.setPayload(event.getContent());
 
     Observable.just(webhookEvent)
       .doOnNext(this::onEchoResponse)
@@ -89,12 +87,7 @@ public class WebhookEventMonitor extends TriggerMonitor {
 
   @Override
   protected boolean isValidTrigger(final Trigger trigger) {
-    boolean valid =  trigger.isEnabled() &&
-      (
-          TRIGGER_TYPE.equals(trigger.getType())
-      );
-
-    return valid;
+    return trigger.isEnabled() && TRIGGER_TYPE.equals(trigger.getType());
   }
 
   @Override
@@ -103,7 +96,7 @@ public class WebhookEventMonitor extends TriggerMonitor {
     String source = event.getDetails().getSource();
 
     return trigger ->
-      trigger.getType().equals(type) &&
+      trigger.getType().equalsIgnoreCase(type) &&
       trigger.getSource().equals(source) &&
         (
           // The Constraints in the Trigger could be null. That's OK.

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitorSpec.groovy
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pipelinetriggers.monitor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.echo.model.Event
+import com.netflix.spinnaker.echo.model.pubsub.PubsubSystem
+import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache
+import com.netflix.spinnaker.echo.test.RetrofitStubs
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact
+import rx.functions.Action1
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class WebhookEventMonitorSpec extends Specification implements RetrofitStubs {
+
+  def objectMapper = new ObjectMapper()
+  def pipelineCache = Mock(PipelineCache)
+  def subscriber = Mock(Action1)
+  def registry = Stub(Registry) {
+    createId(*_) >> Stub(Id)
+    counter(*_) >> Stub(Counter)
+    gauge(*_) >> Integer.valueOf(1)
+  }
+
+  @Shared
+  def goodExpectedArtifacts = [
+      new ExpectedArtifact(
+          matchArtifact: new Artifact(
+              name: 'myArtifact',
+              type: 'artifactType',
+          ),
+          id: 'goodId'
+      )
+  ]
+
+  @Subject
+  def monitor = new WebhookEventMonitor(pipelineCache, subscriber, registry)
+
+  def 'triggers pipelines for successful builds for webhook'() {
+    given:
+    def pipeline = createPipelineWith(goodExpectedArtifacts, trigger)
+    pipelineCache.getPipelines() >> [pipeline]
+
+    when:
+    monitor.processEvent(objectMapper.convertValue(event, Event))
+
+    then:
+    1 * subscriber.call({
+      it.application == pipeline.application && it.name == pipeline.name
+    })
+
+    where:
+    event = createWebhookEvent('myCIServer',
+        [foo: 'bar', artifacts: [[name: 'myArtifact', type: 'artifactType']]])
+    trigger = enabledWebhookTrigger
+        .withSource('myCIServer')
+        .withPayloadConstraints([foo: 'bar'])
+        .withExpectedArtifactIds(['goodId'])
+  }
+
+  def 'attaches webhook trigger to the pipeline'() {
+    given:
+    pipelineCache.getPipelines() >> [pipeline]
+
+    when:
+    monitor.processEvent(objectMapper.convertValue(event, Event))
+
+    then:
+    1 * subscriber.call({
+      it.trigger.type == enabledWebhookTrigger.type
+    })
+
+    where:
+    event = createWebhookEvent('myCIServer')
+    pipeline = createPipelineWith([],
+        enabledWebhookTrigger.withSource('myCIServer'),
+        disabledWebhookTrigger)
+  }
+
+  @Unroll
+  def "does not trigger #description pipelines for webhook"() {
+    given:
+    pipelineCache.getPipelines() >> [pipeline]
+
+    when:
+    monitor.processEvent(objectMapper.convertValue(event, Event))
+
+    then:
+    0 * subscriber._
+
+    where:
+    trigger                                              | description
+    disabledWebhookTrigger                               | 'disabled webhook trigger'
+    enabledWebhookTrigger.withSource('wrongName') | 'different source name'
+    enabledWebhookTrigger.withSource('myCIServer').withPayloadConstraints([foo: 'bar']) |
+        'unsatisfied payload constraints'
+    enabledWebhookTrigger.withSource('myCIServer') .withExpectedArtifactIds(['goodId']) |
+        'unmatched expected artifact'
+
+    pipeline = createPipelineWith(goodExpectedArtifacts, trigger)
+    event = createWebhookEvent('myCIServer')
+  }
+}

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
@@ -7,6 +7,7 @@ import com.netflix.spinnaker.echo.model.pubsub.MessageDescription
 import com.netflix.spinnaker.echo.model.pubsub.PubsubSystem
 import com.netflix.spinnaker.echo.model.trigger.*
 import com.netflix.spinnaker.echo.pipelinetriggers.monitor.PubsubEventMonitor
+import com.netflix.spinnaker.echo.pipelinetriggers.monitor.WebhookEventMonitor
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact
 import retrofit.RetrofitError
@@ -36,7 +37,7 @@ trait RetrofitStubs {
   final Trigger enabledDockerTrigger = Trigger.builder().enabled(true).type('docker').account('account').repository('repository').tag('tag').build()
   final Trigger disabledDockerTrigger = Trigger.builder().enabled(false).type('docker').account('account').repository('repository').tag('tag').build()
   final Trigger enabledWebhookTrigger = Trigger.builder().enabled(true).type('webhook').build()
-  final Trigger disabledWebhookTrigger = Trigger.builder().enabled(true).type('webhook').build()
+  final Trigger disabledWebhookTrigger = Trigger.builder().enabled(false).type('webhook').build()
   final Trigger nonWebhookTrigger = Trigger.builder().enabled(true).type('not webhook').build()
   final Trigger webhookTriggerWithConstraints = Trigger.builder().enabled(true).type('webhook').payloadConstraints([ "application": "myApplicationName", "pipeline": "myPipeLineName" ]).build()
   final Trigger webhookTriggerWithoutConstraints = Trigger.builder().enabled(true).type('webhook').payloadConstraints().build()

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
@@ -80,10 +80,14 @@ trait RetrofitStubs {
     return res
   }
 
-  WebhookEvent createWebhookEvent(String type) {
+  WebhookEvent createWebhookEvent(final String source) {
+    return createWebhookEvent(source, [:])
+  }
+
+  WebhookEvent createWebhookEvent(final String source, final Map payload) {
     def res = new WebhookEvent()
-    res.details = new Metadata([type: type, source: "myCIServer"])
-    res.payload = [ application : "myApplicationName" ]
+    res.details = new Metadata([type: WebhookEvent.TYPE, source: source])
+    res.payload = payload
     return res
   }
 


### PR DESCRIPTION
Before this change a webhook payload of

```json
{
  "projectId": "warpspeed-playground",
  "imageName": "dxia-spinnaker-test",
  "imageTag": "0.0.1-SNAPSHOT-20180123T195009-6b82c8e",
  "artifacts": [
    {
      "type": "docker/image",
      "name": "gcr.io/image",
      "reference": "gcr.io/image"
    }
  ]
}
```

would cause the following error.

```
java.lang.ClassCastException: java.util.LinkedHashMap cannot be cast to com.netflix.spinnaker.kork.artifacts.model.Artifact
    at java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90) ~[na:1.8.0_141]
    at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1351) ~[na:1.8.0_141]
    at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126) ~[na:1.8.0_141]
    at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:498) ~[na:1.8.0_141]
    at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:485) ~[na:1.8.0_141]
    at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[na:1.8.0_141]
    at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230) ~[na:1.8.0_141]
    at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196) ~[na:1.8.0_141]
    at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:1.8.0_141]
    at java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:449) ~[na:1.8.0_141]
    at com.netflix.spinnaker.echo.pipelinetriggers.artifacts.ArtifactMatcher.anyArtifactsMatchExpected(ArtifactMatcher.java:55) ~[echo-pipelinetriggers-1.544.0-SNAPSHOT.jar:1.544.0-SNAPSHOT]
    at com.netflix.spinnaker.echo.pipelinetriggers.monitor.WebhookEventMonitor.lambda$matchTriggerFor$1(WebhookEventMonitor.java:119) ~[echo-pipelinetriggers-1.544.0-SNAPSHOT.jar:1.544.0-SNAPSHOT]
```

This change correctly deserializes the JSON payload into
`List<Artifact>`.