### PR TITLE
fix(echo/log): Append to log instead of overwrite

### DIFF
--- a/echo-web/etc/init/echo.conf
+++ b/echo-web/etc/init/echo.conf
@@ -9,4 +9,4 @@ expect fork
 
 stop on stopping spinnaker
 
-exec /opt/echo/bin/echo 2>&1 > /var/log/spinnaker/echo/echo.log &
+exec /opt/echo/bin/echo 2>&1 >> /var/log/spinnaker/echo/echo.log &


### PR DESCRIPTION
Changing to appending to the log file so logs will correctly rotate.  This prevents large amounts of null data at the start of a rotated log file.