### PR TITLE
refactor(pubsub): adding redisClientDelegate

### DIFF
--- a/echo-pubsub/echo-pubsub.gradle
+++ b/echo-pubsub/echo-pubsub.gradle
@@ -25,6 +25,8 @@ dependencies {
   compile spinnaker.dependency("groovy")
   compile spinnaker.dependency("guava")
   compile spinnaker.dependency("jedis")
+  compile spinnaker.dependency('kork')
+  compile spinnaker.dependency("korkJedis")
   compile spinnaker.dependency("korkJedisTest")
 
   compile 'com.google.cloud:google-cloud-pubsub:0.33.0-beta'

--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/JedisConfig.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/config/JedisConfig.java
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.echo.config;
 
+import com.netflix.spinnaker.kork.jedis.JedisClientDelegate;
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import redis.clients.jedis.JedisPool;
@@ -23,11 +26,17 @@ import redis.clients.jedis.JedisPool;
 import java.net.URI;
 
 @Configuration
+@ConditionalOnExpression("${redis.enabled:true}")
 public class JedisConfig {
 
   @Bean
   JedisPool jedisPool(EchoPubsubConfigurationProperties echoPubsubConfigurationProperties) {
     EchoPubsubConfigurationProperties.RedisProperties redis = echoPubsubConfigurationProperties.getRedis();
     return new JedisPool(URI.create(redis.getConnection()), redis.getTimeout());
+  }
+
+  @Bean
+  RedisClientDelegate redisClientDelegate(JedisPool jedisPool) {
+    return new JedisClientDelegate(jedisPool);
   }
 }

--- a/echo-pubsub/src/test/groovy/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandlerSpec.groovy
+++ b/echo-pubsub/src/test/groovy/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandlerSpec.groovy
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.echo.model.pubsub.PubsubSystem
 import com.netflix.spinnaker.echo.pipelinetriggers.monitor.PubsubEventMonitor
 import com.netflix.spinnaker.echo.pubsub.google.GoogleMessageAcknowledger
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -35,22 +37,21 @@ class PubsubMessageHandlerSpec extends Specification {
   @AutoCleanup("destroy")
   EmbeddedRedis embeddedRedis
 
+  RedisClientDelegate redisClientDelegate = new JedisClientDelegate(embeddedRedis.getPool())
+
   MessageDigest messageDigest = MessageDigest.getInstance("SHA-256")
 
   PubsubEventMonitor pubsubEventMonitor = Mock(PubsubEventMonitor)
 
   @Subject
-  PubsubMessageHandler pubsubMessageHandler
+  PubsubMessageHandler pubsubMessageHandler = new PubsubMessageHandler(
+    pubsubEventMonitor,
+    new ObjectMapper(),
+    redisClientDelegate,
+  )
 
   def setupSpec() {
     embeddedRedis = EmbeddedRedis.embed()
-  }
-
-  def setup() {
-    pubsubMessageHandler = new PubsubMessageHandler()
-    pubsubMessageHandler.setJedisPool(embeddedRedis.getPool())
-    pubsubMessageHandler.setPubsubEventMonitor(pubsubEventMonitor)
-    pubsubMessageHandler.setObjectMapper(new ObjectMapper())
   }
 
   def cleanup() {


### PR DESCRIPTION
Using the redis client delegate to talk to redis so that we can add in dynomite support (coming in a later PR). 

Creating autowired constructor instead of properties.