### PR TITLE
fix(pubsub): changing amazon subscription name

### DIFF
--- a/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/amazon/SQSSubscriber.java
+++ b/echo-pubsub/src/main/java/com/netflix/spinnaker/echo/pubsub/amazon/SQSSubscriber.java
@@ -111,7 +111,7 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
 
   @Override
   public String getName() {
-    return getWorkerName();
+    return subscriptionName();
   }
 
   @Override


### PR DESCRIPTION
This generates the name in the UI, and should return the user-given name instead of the queue worker name.