### PR TITLE
feat(email/slack): allow custom messages per notification

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgent.groovy
@@ -75,7 +75,7 @@ class EmailNotificationAgent extends AbstractEventNotificationAgent {
       status == 'complete' ? 'completed successfully' : status
     }"""
 
-    subject = context.customSubject ?: subject
+    subject = preference.customSubject ?: context.customSubject ?: subject
 
     log.info('Sending email {} for {} {} {} {}', kv('address', preference.address), kv('application', application), kv('type', config.type), kv('status', status), kv('executionId', event.content?.execution?.id))
 
@@ -88,7 +88,7 @@ class EmailNotificationAgent extends AbstractEventNotificationAgent {
       status,
       config.link,
       preference.message?."$config.type.$status"?.text,
-      context.customBody
+      preference.customBody ?: context.customBody
     )
   }
 

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
@@ -93,7 +93,7 @@ class SlackNotificationAgent extends AbstractEventNotificationAgent {
         body += "\n\n" + preference.message."$config.type.$status".text
       }
 
-      String customMessage = event.content?.context?.customMessage
+      String customMessage = preference.customMessage ?: event.content?.context?.customMessage
       if (customMessage) {
         body = customMessage
           .replace("{{executionId}}", (String) event.content.execution?.id ?: "")


### PR DESCRIPTION
Enhancement to an undocumented feature: allow custom messages (slack, email subject/body) per notification, not just at the entire stage level. This allows more fine-grained custom notifications for stage failures vs. completions.

(We will document this feature once we're happy with it)