### PR TITLE
feat(artifacts): Docker registry event artifact parser

### DIFF
--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/artifacts/DockerRegistryArtifactExtractor.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/artifacts/DockerRegistryArtifactExtractor.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.artifacts;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class DockerRegistryArtifactExtractor implements WebhookArtifactExtractor {
+  final private ObjectMapper objectMapper;
+  final private String MEDIA_TYPE_V1_MANIFEST = "application/vnd.docker.distribution.manifest.v1+json";
+  final private String MEDIA_TYPE_V2_MANIFEST = "application/vnd.docker.distribution.manifest.v2+json";
+
+  @Autowired
+  public DockerRegistryArtifactExtractor(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public List<Artifact> getArtifacts(String source, Map payload) {
+    Notification notification = objectMapper.convertValue(payload, Notification.class);
+    List<Event> pushEvents = notification.getEvents().stream()
+      .filter(e -> e.action.equals("push")
+        && e.getTarget() != null
+        && (e.getTarget().getMediaType().equals(MEDIA_TYPE_V1_MANIFEST) || e.getTarget().getMediaType().equals(MEDIA_TYPE_V2_MANIFEST))
+        && e.getTarget().getRepository() != null
+        && (e.getTarget().getTag() != null || e.getTarget().getDigest() != null))
+      .collect(Collectors.toList());
+
+    if (pushEvents.isEmpty()) {
+      return Collections.EMPTY_LIST;
+    }
+
+    return pushEvents.stream()
+      .map(e -> {
+        String tag;
+        String tagSeparator = ":";
+        if (e.getTarget().getTag() != null) {
+          tag = e.getTarget().getTag();
+        } else if (e.getTarget().getDigest() != null) {
+          tag = e.getTarget().getDigest();
+          tagSeparator = "@";
+        } else {
+          return null;
+        }
+        String host = (e.getRequest() != null && e.getRequest().getHost() != null) ? (e.getRequest().getHost() + "/") : "";
+        return Artifact.builder()
+          .name(host + e.getTarget().getRepository())
+          .version(tag)
+          .reference(host + e.getTarget().getRepository() + tagSeparator + tag)
+          .type("docker/image")
+          .build();
+      })
+      .filter(Objects::nonNull)
+      .collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean handles(String type, String source) {
+    return (source != null && source.equals("dockerregistry"));
+  }
+
+  @Data
+  private static class Notification {
+    private List<Event> events;
+  }
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class Event {
+    private String action;
+    private Target target;
+    private Source request;
+  }
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class Target {
+    private String mediaType;
+    private String digest;
+    private String repository;
+    private String url;
+    private String tag;
+  }
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class Source {
+    private String addr;
+    private String host;
+  }
+}

--- a/echo-webhooks/src/test/groovy/com/netflix/spinnaker/echo/artifacts/DockerRegistryArtifactExtractorSpec.groovy
+++ b/echo-webhooks/src/test/groovy/com/netflix/spinnaker/echo/artifacts/DockerRegistryArtifactExtractorSpec.groovy
@@ -1,0 +1,208 @@
+package com.netflix.spinnaker.echo.artifacts
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import spock.lang.Specification
+
+
+class DockerRegistryArtifactExtractorSpec extends Specification {
+
+  ObjectMapper mapper = new ObjectMapper()
+  DockerRegistryArtifactExtractor dockerRegistryArtifactExtractor = new DockerRegistryArtifactExtractor(mapper)
+
+  void 'extracts artifact from Docker registry event in official documentation'() {
+    given:
+    String rawPayload = '''
+{
+   "events": [
+      {
+         "id": "asdf-asdf-asdf-asdf-0",
+         "timestamp": "2006-01-02T15:04:05Z",
+         "action": "push",
+         "target": {
+            "mediaType": "application/vnd.docker.distribution.manifest.v1+json",
+            "length": 1,
+            "digest": "sha256:fea8895f450959fa676bcc1df0611ea93823a735a01205fd8622846041d0c7cf",
+            "repository": "library/test",
+            "url": "http://example.com/v2/library/test/manifests/sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5",
+            "tag": "latest"
+         },
+         "request": {
+            "id": "asdfasdf",
+            "addr": "client.local",
+            "host": "registrycluster.local",
+            "method": "PUT",
+            "useragent": "test/0.1"
+         },
+         "actor": {
+            "name": "test-actor"
+         },
+         "source": {
+            "addr": "hostname.local:port"
+         }
+      },
+      {
+         "id": "asdf-asdf-asdf-asdf-1",
+         "timestamp": "2006-01-02T15:04:05Z",
+         "action": "push",
+         "target": {
+            "mediaType": "application/vnd.docker.container.image.rootfs.diff+x-gtar",
+            "length": 2,
+            "digest": "sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5",
+            "repository": "library/test",
+            "url": "http://example.com/v2/library/test/blobs/sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5"
+         },
+         "request": {
+            "id": "asdfasdf",
+            "addr": "client.local",
+            "host": "registrycluster.local",
+            "method": "PUT",
+            "useragent": "test/0.1"
+         },
+         "actor": {
+            "name": "test-actor"
+         },
+         "source": {
+            "addr": "hostname.local:port"
+         }
+      },
+      {
+         "id": "asdf-asdf-asdf-asdf-2",
+         "timestamp": "2006-01-02T15:04:05Z",
+         "action": "push",
+         "target": {
+            "mediaType": "application/vnd.docker.container.image.rootfs.diff+x-gtar",
+            "length": 3,
+            "digest": "sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5",
+            "repository": "library/test",
+            "url": "http://example.com/v2/library/test/blobs/sha256:c3b3692957d439ac1928219a83fac91e7bf96c153725526874673ae1f2023f8d5"
+         },
+         "request": {
+            "id": "asdfasdf",
+            "addr": "client.local",
+            "host": "registrycluster.local",
+            "method": "PUT",
+            "useragent": "test/0.1"
+         },
+         "actor": {
+            "name": "test-actor"
+         },
+         "source": {
+            "addr": "hostname.local:port"
+         }
+      }
+   ]
+}
+'''
+    Map postedEvent = mapper.readValue(rawPayload, Map)
+
+    when:
+    List<Artifact> artifacts = dockerRegistryArtifactExtractor.getArtifacts(
+      'dockerregistry',
+      postedEvent
+    )
+
+    then:
+    artifacts.size() == 1
+    artifacts.get(0).getVersion() == 'latest'
+    artifacts.get(0).getName() == 'registrycluster.local/library/test'
+    artifacts.get(0).getReference() == 'registrycluster.local/library/test:latest'
+  }
+
+  void 'extracts artifact from Docker registry event with tag'() {
+    given:
+    String rawPayload = '''
+{
+  "events": [
+    {
+      "id": "6fb5fd5c-a2f7-4d96-bd77-6de873a21e5f",
+      "timestamp": "2018-03-25T23:25:46.7738079Z",
+      "action": "push",
+      "target": {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "size": 1576,
+        "digest": "sha256:2c39235310cfed3fc661bf899a4b79894327220d4947edbf952af8941614feea",
+        "length": 1576,
+        "repository": "wjoel/gitweb",
+        "url": "http://registry.default.svc/v2/wjoel/gitweb/manifests/sha256:2c39235310cfed3fc661bf899a4b79894327220d4947edbf952af8941614feea",
+        "tag": "2018-03-26-b1"
+      },
+      "request": {
+        "id": "f0be0c76-bd2c-4422-87f6-1d20b70cf318",
+        "addr": "192.168.1.193:59692",
+        "host": "registry.default.svc",
+        "method": "PUT",
+        "useragent": "docker/17.12.1-ce go/go1.9.4 git-commit/7390fc6 kernel/4.14.0-3-amd64 os/linux arch/amd64 UpstreamClient(Docker-Client/17.12.1-ce (linux))"
+      },
+      "actor": {"":""},
+      "source": {
+        "addr": "registry-5b74898d77-xm6k6:80",
+        "instanceID": "738f8347-a04f-4577-9674-d3a8cdcc18e1"
+      }
+    }
+  ]
+}
+'''
+    Map postedEvent = mapper.readValue(rawPayload, Map)
+
+    when:
+    List<Artifact> artifacts = dockerRegistryArtifactExtractor.getArtifacts(
+      'dockerregistry',
+      postedEvent
+    )
+
+    then:
+    artifacts.size() == 1
+    artifacts.get(0).getVersion() == '2018-03-26-b1'
+    artifacts.get(0).getName() == 'registry.default.svc/wjoel/gitweb'
+    artifacts.get(0).getReference() == 'registry.default.svc/wjoel/gitweb:2018-03-26-b1'
+  }
+
+  void 'extracts artifact from Docker registry event without tag'() {
+    given:
+    String rawPayload = '''
+{
+  "events": [
+    {
+      "id": "6fb5fd5c-a2f7-4d96-bd77-6de873a21e5f",
+      "timestamp": "2018-03-25T23:25:46.7738079Z",
+      "action": "push",
+      "target": {
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "size": 1576,
+        "digest": "sha256:2c39235310cfed3fc661bf899a4b79894327220d4947edbf952af8941614feea",
+        "length": 1576,
+        "repository": "wjoel/gitweb",
+        "url": "http://registry.default.svc/v2/wjoel/gitweb/manifests/sha256:2c39235310cfed3fc661bf899a4b79894327220d4947edbf952af8941614feea"
+      },
+      "request": {
+        "id": "f0be0c76-bd2c-4422-87f6-1d20b70cf318",
+        "addr": "192.168.1.193:59692",
+        "host": "registry.default.svc",
+        "method": "PUT",
+        "useragent": "docker/17.12.1-ce go/go1.9.4 git-commit/7390fc6 kernel/4.14.0-3-amd64 os/linux arch/amd64 UpstreamClient(Docker-Client/17.12.1-ce (linux))"
+      },
+      "actor": {"":""},
+      "source": {
+        "addr": "registry-5b74898d77-xm6k6:80",
+        "instanceID": "738f8347-a04f-4577-9674-d3a8cdcc18e1"
+      }
+    }
+  ]
+}
+'''
+    Map postedEvent = mapper.readValue(rawPayload, Map)
+
+    when:
+    List<Artifact> artifacts = dockerRegistryArtifactExtractor.getArtifacts(
+      'dockerregistry',
+      postedEvent
+    )
+
+    then:
+    artifacts.size() == 1
+    artifacts.get(0).getVersion() == 'sha256:2c39235310cfed3fc661bf899a4b79894327220d4947edbf952af8941614feea'
+    artifacts.get(0).getName() == 'registry.default.svc/wjoel/gitweb'
+    artifacts.get(0).getReference() == 'registry.default.svc/wjoel/gitweb@sha256:2c39235310cfed3fc661bf899a4b79894327220d4947edbf952af8941614feea'
+  }
+}


### PR DESCRIPTION
Extracts Docker images from push events sent by the Docker registry.

Example config for a Docker registry Kubernetes manifest:
```
        - name: REGISTRY_NOTIFICATIONS_ENDPOINTS
          value: |
            - name: spinnaker
              url: http://spin-gate.spinnaker.svc:8084/webhooks/webhook/dockerregistry
              timeout: 500ms
              threshold: 5
              backoff: 1s
```