### PR TITLE
feat(aws pubsub): adding filterPolicy to sns topics

### DIFF
--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubProperties.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubProperties.java
@@ -24,10 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import javax.validation.Valid;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.util.List;
 
 @Data
@@ -48,12 +45,20 @@ public class AmazonPubsubProperties {
     @NotEmpty
     private String topicARN;
 
+    // TODO emburns: make optional and generate a good name if not given
     @NotEmpty
     private  String queueARN;
 
     private String templatePath;
 
     private MessageFormat messageFormat;
+
+    // TODO emburns: add option to give file path to policy file
+    /**
+     * Filter policy in a string as define in aws docs
+     * https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html
+     */
+    private String filterPolicy;
 
     int visibilityTimeout = 30;
     int sqsMessageRetentionPeriodSeconds = 120;
@@ -67,15 +72,18 @@ public class AmazonPubsubProperties {
       String topicARN,
       String queueARN,
       String templatePath,
-      MessageFormat messageFormat) {
+      MessageFormat messageFormat,
+      String filterPolicy
+    ) {
       this.name = name;
       this.topicARN = topicARN;
       this.queueARN = queueARN;
       this.templatePath = templatePath;
       this.messageFormat = messageFormat;
+      this.filterPolicy = filterPolicy;
     }
 
-    private MessageFormat determineMessageFormat(){
+    private MessageFormat determineMessageFormat() {
       // Supplying a custom template overrides a MessageFormat choice
       if (!StringUtils.isEmpty(templatePath)) {
         return MessageFormat.CUSTOM;

--- a/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
+++ b/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
@@ -37,7 +37,7 @@ class AmazonSQSSubscriberSpec extends Specification {
   ARN queueARN = new ARN("arn:aws:sqs:us-west-2:100:queueName")
   ARN topicARN = new ARN("arn:aws:sns:us-west-2:100:topicName")
   AmazonPubsubProperties.AmazonPubsubSubscription subscription =
-    new AmazonPubsubProperties.AmazonPubsubSubscription('aws_events', topicARN.arn, queueARN.arn, "", null)
+    new AmazonPubsubProperties.AmazonPubsubSubscription('aws_events', topicARN.arn, queueARN.arn, "", null, null)
 
   @Shared
   def objectMapper = new ObjectMapper()
@@ -93,7 +93,7 @@ class AmazonSQSSubscriberSpec extends Specification {
     String snsMesssage = objectMapper.writeValueAsString(notificationMessage)
 
     when:
-    String result = subject.unmarshallMessageBody(snsMesssage)
+    String result = subject.unmarshalMessageBody(snsMesssage)
 
     then:
     0 * subject.log.error()


### PR DESCRIPTION
- Adding filter policies to sns subscriptions as described https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html so that we have more control over sns subscriptions.
- Adding some try/catch to properly show and recover from amazon exceptions (usually as a result of incorrect permissions) which were impossible to detect without logging the exception. Not all errors are fatal, but it might be better to throw new a new RuntimeException instead of just logging?
- Fixing the spelling of marshal and other typos.