### PR TITLE
fix(pipeline-triggers): Remove high cardinality tags on echo metrics

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/BuildEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/BuildEventMonitor.java
@@ -112,11 +112,8 @@ public class BuildEventMonitor extends TriggerMonitor {
   @Override
   protected void emitMetricsOnMatchingPipeline(Pipeline pipeline) {
     val id = registry.createId("pipelines.triggered")
-      .withTag("application", pipeline.getApplication())
-      .withTag("name", pipeline.getName());
-    if (isBuildTrigger(pipeline.getTrigger())) {
-      id.withTag("job", pipeline.getTrigger().getJob());
-    }
+      .withTag("monitor", getClass().getSimpleName())
+      .withTag("application", pipeline.getApplication());
     registry.counter(id).increment();
   }
 

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/DockerEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/DockerEventMonitor.java
@@ -143,11 +143,8 @@ public class DockerEventMonitor extends TriggerMonitor {
   @Override
   protected void emitMetricsOnMatchingPipeline(Pipeline pipeline) {
     val id = registry.createId("pipelines.triggered")
-      .withTag("application", pipeline.getApplication())
-      .withTag("name", pipeline.getName());
-    id.withTag("imageId", pipeline.getTrigger().getAccount() + "/" +
-      pipeline.getTrigger().getRepository() + ":" +
-      pipeline.getTrigger().getTag());
+      .withTag("monitor", getClass().getSimpleName())
+      .withTag("application", pipeline.getApplication());
     registry.counter(id).increment();
   }
 }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/GitEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/GitEventMonitor.java
@@ -125,10 +125,7 @@ public class GitEventMonitor extends TriggerMonitor {
   protected void emitMetricsOnMatchingPipeline(Pipeline pipeline) {
     val id = registry.createId("pipelines.triggered")
       .withTag("application", pipeline.getApplication())
-      .withTag("name", pipeline.getName());
-
-    id.withTag("repository", pipeline.getTrigger().getProject() + ' ' + pipeline.getTrigger().getSlug());
-
+      .withTag("monitor", getClass().getSimpleName());
     registry.counter(id).increment();
   }
 

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/PubsubEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/PubsubEventMonitor.java
@@ -116,7 +116,7 @@ public class PubsubEventMonitor extends TriggerMonitor {
   protected void emitMetricsOnMatchingPipeline(Pipeline pipeline) {
     val id = registry.createId("pipelines.triggered")
       .withTag("application", pipeline.getApplication())
-      .withTag("name", pipeline.getName());
+      .withTag("monitor", getClass().getSimpleName());
 
     if (isPubsubTrigger(pipeline.getTrigger())) {
       id.withTag("pubsubSystem", pipeline.getTrigger().getPubsubSystem());

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitor.java
@@ -129,7 +129,7 @@ public class WebhookEventMonitor extends TriggerMonitor {
   protected void emitMetricsOnMatchingPipeline(Pipeline pipeline) {
     val id = registry.createId("pipelines.triggered")
       .withTag("application", pipeline.getApplication())
-      .withTag("name", pipeline.getName());
+      .withTag("monitor", getClass().getSimpleName());
     id.withTag("type", pipeline.getTrigger().getType());
     registry.counter(id).increment();
   }


### PR DESCRIPTION
While auditing our echo metrics, I noticed a _huge_ amount of metrics coming in from echo that have very little use. Furthermore, the `name` tag is reserved in Atlas, so the `pipeline.triggered` metric sort of got clobbered.

I removed a couple of the tags, but added `monitor` to track which monitor is actually triggering pipelines. 