### PR TITLE
fix(pubsub): Restart Google Pubsub subscriber on failures

### DIFF
--- a/echo-pubsub-google/echo-pubsub-google.gradle
+++ b/echo-pubsub-google/echo-pubsub-google.gradle
@@ -16,5 +16,5 @@
 
 dependencies {
   compile project(':echo-pubsub-core')
-  compile 'com.google.cloud:google-cloud-pubsub:0.33.0-beta'
+  compile 'com.google.cloud:google-cloud-pubsub:0.48.0-beta'
 }

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubMonitor.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubMonitor.java
@@ -71,13 +71,13 @@ public class GooglePubsubMonitor implements PollingMonitor {
     lastPoll = System.currentTimeMillis();
 
     GooglePubsubSubscriber googleSubscriber = (GooglePubsubSubscriber) subscriber;
-    googleSubscriber.getSubscriber().startAsync();
+    googleSubscriber.start();
   }
 
   private void closeConnection(PubsubSubscriber subscriber) {
     log.info("Closing async connection to {}", subscriber.subscriptionName());
     GooglePubsubSubscriber googleSubscriber = (GooglePubsubSubscriber) subscriber;
-    googleSubscriber.getSubscriber().stopAsync();
+    googleSubscriber.stop();
   }
 
   @Override


### PR DESCRIPTION
Creates a new `Subscriber` on failures, as according to https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1579#issuecomment-282603572 we can `"restart" the Subscriber by creating a new Subscriber object`.

I've also removed `.setMaxAckExtensionPeriod(Duration.ofSeconds(0))` as https://github.com/GoogleCloudPlatform/google-cloud-java/issues/2465#issuecomment-351941181 recommends against it.

Potentially solves https://github.com/spinnaker/spinnaker/issues/2762 but needs more testing. I've verified that echo resumes consuming pubsub messages after I removed its `Pub/Sub Subscriber` permission (took a little while before it noticed) and then added it back again.