### PR TITLE
fix(metrics): replace Spring Boot metrics with Spectator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,12 @@ buildscript {
 allprojects {
     apply plugin: "spinnaker.project"
     apply plugin: "groovy"
+    apply plugin: 'java'
     apply plugin: 'jacoco'
     group = "com.netflix.spinnaker.echo"
 
     ext {
-        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.156.0'
+        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.156.1'
     }
 
     def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]
@@ -78,7 +79,7 @@ allprojects {
 
 subprojects {
     jacoco {
-        toolVersion = '0.7.0.201403182114'
+        toolVersion = '0.8.1'
     }
 
     dependencies {

--- a/echo-pipelinetriggers/echo-pipelinetriggers.gradle
+++ b/echo-pipelinetriggers/echo-pipelinetriggers.gradle
@@ -29,6 +29,7 @@ dependencies {
   compile spinnaker.dependency("eurekaClient")
   compile spinnaker.dependency("kork")
   compile spinnaker.dependency("korkSecurity")
+  compile spinnaker.dependency("spectatorApi")
 
   compile group: 'org.codehaus.groovy', name: 'groovy', version: "2.4.5"
   compile group: 'commons-codec', name: 'commons-codec', version: '1.10'

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheSpec.groovy
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.echo.pipelinetriggers
 
 import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.echo.model.Pipeline
@@ -36,12 +37,7 @@ import static rx.Observable.just
 class PipelineCacheSpec extends Specification implements RetrofitStubs {
   def scheduler = Schedulers.test()
   def front50 = Mock(Front50Service)
-  def registry = Stub(Registry) {
-    createId(*_) >> Stub(Id)
-    counter(*_) >> Stub(Counter)
-    gauge(*_) >> Integer.valueOf(1)
-  }
-
+  def registry = new DefaultRegistry()
 
   @Shared
   def interval = 30

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/BuildEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/BuildEventMonitorSpec.groovy
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.echo.pipelinetriggers.monitor
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.echo.model.Event
@@ -13,17 +14,16 @@ import rx.functions.Action1
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
+
+import javax.validation.groups.Default
+
 import static com.netflix.spinnaker.echo.model.trigger.BuildEvent.Result.*
 
 class BuildEventMonitorSpec extends Specification implements RetrofitStubs {
   def objectMapper = new ObjectMapper()
   def pipelineCache = Mock(PipelineCache)
   def subscriber = Mock(Action1)
-  def registry = Stub(Registry) {
-    createId(*_) >> Stub(Id)
-    counter(*_) >> Stub(Counter)
-    gauge(*_) >> Integer.valueOf(1)
-  }
+  def registry = new DefaultRegistry()
 
   @Subject
   def monitor = new BuildEventMonitor(pipelineCache, subscriber, registry)

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/DockerEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/DockerEventMonitorSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.pipelinetriggers.monitor
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.echo.model.Event
@@ -35,11 +36,7 @@ class DockerEventMonitorSpec extends Specification implements RetrofitStubs {
   def objectMapper = new ObjectMapper()
   def pipelineCache = Mock(PipelineCache)
   def subscriber = Mock(Action1)
-  def registry = Stub(Registry) {
-    createId(*_) >> Stub(Id)
-    counter(*_) >> Stub(Counter)
-    gauge(*_) >> Integer.valueOf(1)
-  }
+  def registry = new DefaultRegistry()
 
   @Subject
   def monitor = new DockerEventMonitor(pipelineCache, subscriber, registry)

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/GitEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/GitEventMonitorSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.pipelinetriggers.monitor
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.echo.model.Event
@@ -34,11 +35,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
   def objectMapper = new ObjectMapper()
   def pipelineCache = Mock(PipelineCache)
   def subscriber = Mock(Action1)
-  def registry = Stub(Registry) {
-    createId(*_) >> Stub(Id)
-    counter(*_) >> Stub(Counter)
-    gauge(*_) >> Integer.valueOf(1)
-  }
+  def registry = new DefaultRegistry()
 
   @Subject
   def monitor = new GitEventMonitor(pipelineCache, subscriber, registry)

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/PubsubEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/PubsubEventMonitorSpec.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.pipelinetriggers.monitor
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.echo.model.Event
@@ -40,11 +41,8 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
   def objectMapper = new ObjectMapper()
   def pipelineCache = Mock(PipelineCache)
   def subscriber = Mock(Action1)
-  def registry = Stub(Registry) {
-    createId(*_) >> Stub(Id)
-    counter(*_) >> Stub(Counter)
-    gauge(*_) >> Integer.valueOf(1)
-  }
+  def registry = new DefaultRegistry()
+
   @Shared
   def goodArtifacts = [new Artifact(name: 'myArtifact', type: 'artifactType')]
   @Shared

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitorSpec.groovy
@@ -16,6 +16,7 @@ package com.netflix.spinnaker.echo.pipelinetriggers.monitor
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Counter
+import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.echo.model.Event
@@ -35,11 +36,7 @@ class WebhookEventMonitorSpec extends Specification implements RetrofitStubs {
   def objectMapper = new ObjectMapper()
   def pipelineCache = Mock(PipelineCache)
   def subscriber = Mock(Action1)
-  def registry = Stub(Registry) {
-    createId(*_) >> Stub(Id)
-    counter(*_) >> Stub(Counter)
-    gauge(*_) >> Integer.valueOf(1)
-  }
+  def registry = new DefaultRegistry()
 
   @Shared
   def goodExpectedArtifacts = [

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiatorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiatorSpec.groovy
@@ -1,43 +1,33 @@
 package com.netflix.spinnaker.echo.pipelinetriggers.orca
 
-
+import com.netflix.spectator.api.DefaultRegistry
 import spock.lang.Specification
 import spock.lang.Subject
 import com.netflix.spinnaker.echo.model.Pipeline
-import org.springframework.boot.actuate.metrics.CounterService
+import spock.lang.Unroll
+
 import static rx.Observable.empty
 
 class PipelineInitiatorSpec extends Specification {
 
-  def counter = Stub(CounterService)
+  def registry = new DefaultRegistry()
   def orca = Mock(OrcaService)
 
-  def "calls Orca if enabled"() {
+  @Unroll
+  def "calls orca #orcaCalls times when enabled=#enabled flag"() {
     given:
-    @Subject pipelineInitiator = new PipelineInitiator(counter, orca, true, false, 5, 5000)
+    @Subject pipelineInitiator = new PipelineInitiator(registry, orca, enabled, false, 5, 5000)
+    def pipeline = Pipeline.builder().application("application").name("name").id("id").build()
 
     when:
     pipelineInitiator.call(pipeline)
 
     then:
-    1 * orca.trigger(pipeline) >> empty()
+    orcaCalls * orca.trigger(pipeline) >> empty()
 
     where:
-    pipeline = Pipeline.builder().application("application").name("name").id("id").build()
+    enabled || orcaCalls
+    true    || 1
+    false   || 0
   }
-
-  def "does not call Orca if disabled"() {
-    given:
-    @Subject pipelineInitiator = new PipelineInitiator(counter, orca, false, false, 5, 5000)
-
-    when:
-    pipelineInitiator.call(pipeline)
-
-    then:
-    0 * _
-
-    where:
-    pipeline = Pipeline.builder().application("application").name("name").id("id").build()
-  }
-
 }

--- a/echo-pubsub-aws/echo-pubsub-aws.gradle
+++ b/echo-pubsub-aws/echo-pubsub-aws.gradle
@@ -20,4 +20,5 @@ dependencies {
   compile spinnaker.dependency("cglib")
   compile spinnaker.dependency("aws")
   compile spinnaker.dependency("korkAws")
+  compile spinnaker.dependency("spectatorApi")
 }

--- a/echo-scheduler/echo-scheduler.gradle
+++ b/echo-scheduler/echo-scheduler.gradle
@@ -23,6 +23,7 @@ dependencies {
   compile spinnaker.dependency('groovy')
   compile spinnaker.dependency('slf4jApi')
   compile spinnaker.dependency('eurekaClient')
+  compile spinnaker.dependency('spectatorApi')
 
   testRuntime spinnaker.dependency('slf4jSimple')
   compile spinnaker.dependency('scheduledActionsCore')

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/PipelineConfigsPollingAgent.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/PipelineConfigsPollingAgent.groovy
@@ -18,16 +18,17 @@ package com.netflix.spinnaker.echo.scheduler.actions.pipeline.impl
 
 import com.netflix.scheduledactions.ActionInstance
 import com.netflix.scheduledactions.ActionsOperator
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.echo.model.Pipeline
 import com.netflix.spinnaker.echo.model.Trigger
 import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.actuate.metrics.CounterService
-import org.springframework.boot.actuate.metrics.GaugeService
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.stereotype.Component
+
+import java.util.concurrent.TimeUnit
 
 import static net.logstash.logback.argument.StructuredArguments.*
 
@@ -41,23 +42,20 @@ import static net.logstash.logback.argument.StructuredArguments.*
 class PipelineConfigsPollingAgent extends AbstractPollingAgent {
   public static final String TRIGGER_TYPE = "cron";
 
-  private final CounterService counterService
-  private final GaugeService gaugeService
+  private final Registry registry
   private final PipelineCache pipelineCache
   private final long intervalMs
   private final ActionsOperator actionsOperator
   private final String timeZoneId
 
   @Autowired
-  PipelineConfigsPollingAgent(CounterService counterService,
-                              GaugeService gaugeService,
+  PipelineConfigsPollingAgent(Registry registry,
                               PipelineCache pipelineCache,
                               ActionsOperator actionsOperator,
                               @Value('${scheduler.pipelineConfigsPoller.pollingIntervalMs:30000}') long intervalMs,
                               @Value('${scheduler.cron.timezone:America/Los_Angeles}') String timeZoneId) {
     super()
-    this.counterService = counterService
-    this.gaugeService = gaugeService
+    this.registry = registry
     this.pipelineCache = pipelineCache
     this.actionsOperator = actionsOperator
     this.intervalMs = intervalMs
@@ -95,13 +93,15 @@ class PipelineConfigsPollingAgent extends AbstractPollingAgent {
         updateChangedTriggers(pipelines, actionInstances)
         registerNewTriggers(pipelines, actionInstances)
       } catch (Exception e) {
-        counterService.increment("actionsOperator.list.errors")
+        registry.counter("actionsOperator.list.errors").increment()
         throw new Exception("Exception occurred while fetching all registered action instances", e)
       }
     } catch (Exception e) {
       log.error("Exception occurred in the execute() method of PipelineConfigsPollingAgent", e)
     } finally {
-      gaugeService.submit("pipelineConfigsPollingAgent.executionTimeMillis", (double) System.currentTimeMillis() - start)
+      long elapsedMillis = System.currentTimeMillis() - start
+      log.info("Done polling for pipeline configs in ${elapsedMillis/1000}s")
+      registry.timer("pipelineConfigsPollingAgent.executionTimeMillis").record(elapsedMillis, TimeUnit.MILLISECONDS)
     }
   }
 
@@ -118,8 +118,8 @@ class PipelineConfigsPollingAgent extends AbstractPollingAgent {
        * ActionInstance have the same 'id'
        */
       if (actionInstances) {
-        log.info("Found '${actionInstances?.size()}' existing scheduled action(s)...")
-        log.info("Iterating through each scheduled action and checking if the corresponding trigger has been changed...")
+        log.info("Found '${actionInstances?.size()}' existing scheduled action(s). " +
+          "Iterating through each scheduled action and checking if the corresponding trigger has been changed...")
       }
 
       actionInstances.each { actionInstance ->
@@ -164,7 +164,7 @@ class PipelineConfigsPollingAgent extends AbstractPollingAgent {
             log.info("Removed scheduled action '${actionInstance.id}' as the corresponding trigger has been removed")
           }
         } catch (Exception e) {
-          counterService.increment("updateTriggers.errors")
+          registry.counter("updateTriggers.errors", "exception", e.getClass().getName()).increment()
           log.error("Exception occurred while updating ${trigger}", e)
         }
       }
@@ -206,10 +206,9 @@ class PipelineConfigsPollingAgent extends AbstractPollingAgent {
             ActionInstance actionInstance = PipelineTriggerConverter.toScheduledAction(pipeline, trigger, timeZoneId)
             actionsOperator.registerActionInstance(actionInstance)
             log.info('Registered scheduled trigger {} {} {}', kv('id', actionInstance.id), kv('trigger', trigger), kv('pipeline', pipeline))
-            counterService.increment("newTriggers.count")
-
+            registry.counter("newTriggers.count").increment()
           } catch (Exception e) {
-            counterService.increment("newTriggers.errors")
+            registry.counter("newTriggers.errors", "exception", e.getClass().getName()).increment()
             log.error("Exception occurred while creating new ${trigger}", e)
           }
         }

--- a/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/MissedPipelineTriggerCompensationJobSpec.groovy
+++ b/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/MissedPipelineTriggerCompensationJobSpec.groovy
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.echo.scheduler.actions.pipeline
 
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.echo.model.Pipeline
 import com.netflix.spinnaker.echo.model.Trigger
 import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache
@@ -23,8 +25,6 @@ import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService
 import com.netflix.spinnaker.echo.pipelinetriggers.orca.PipelineInitiator
 import com.netflix.spinnaker.echo.scheduler.actions.pipeline.impl.MissedPipelineTriggerCompensationJob
 import org.quartz.CronExpression
-import org.springframework.boot.actuate.metrics.CounterService
-import org.springframework.boot.actuate.metrics.GaugeService
 import rx.schedulers.Schedulers
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -39,7 +39,7 @@ class MissedPipelineTriggerCompensationJobSpec extends Specification {
   def pipelineCache = Mock(PipelineCache)
   def orcaService = Mock(OrcaService)
   def pipelineInitiator = Mock(PipelineInitiator)
-  def counterService = Stub(CounterService)
+  Registry registry = new DefaultRegistry()
 
   def 'should trigger pipelines for all missed executions'() {
     given:
@@ -66,7 +66,7 @@ class MissedPipelineTriggerCompensationJobSpec extends Specification {
       now: getDateOffset(50)
     )
     def compensationJob = new MissedPipelineTriggerCompensationJob(scheduler, pipelineCache, orcaService,
-      pipelineInitiator, counterService, 30000, 'America/Los_Angeles', true, 900000, 20, dateContext)
+      pipelineInitiator, registry, 30000, 'America/Los_Angeles', true, 900000, 20, dateContext)
 
     when:
     compensationJob.triggerMissedExecutions(pipelines)
@@ -104,7 +104,7 @@ class MissedPipelineTriggerCompensationJobSpec extends Specification {
       now: getDateOffset(0)
     )
     def compensationJob = new MissedPipelineTriggerCompensationJob(scheduler, pipelineCache, orcaService,
-      pipelineInitiator, counterService, 30000, 'America/Los_Angeles', true, 900000, 20, dateContext)
+      pipelineInitiator, registry, 30000, 'America/Los_Angeles', true, 900000, 20, dateContext)
 
     when:
     compensationJob.triggerMissedExecutions(pipelines)
@@ -153,8 +153,12 @@ class MissedPipelineTriggerCompensationJobSpec extends Specification {
     def windowFloor = getDateOffset(windowFloorMinutes)
     def now = getDateOffset(nowMinutes)
 
+    def dateContext = Mock(MissedPipelineTriggerCompensationJob.DateContext)
+    def compensationJob = new MissedPipelineTriggerCompensationJob(scheduler, pipelineCache, orcaService,
+      pipelineInitiator, registry, 30000, 'America/Los_Angeles', true, 900000, 20, dateContext)
+
     when:
-    def result = MissedPipelineTriggerCompensationJob.missedExecution(expr, lastExecution, windowFloor, now)
+    def result = compensationJob.missedExecution(expr, lastExecution, windowFloor, now)
 
     then:
     result == missedExecution
@@ -201,8 +205,12 @@ class MissedPipelineTriggerCompensationJobSpec extends Specification {
     def now = new Date(lastExecutionTs + TimeUnit.HOURS.toMillis(24) + TimeUnit.MINUTES.toMillis(5)) // day 2 at 10:05:02
     def windowFloor = new Date(now.getTime() - TimeUnit.MINUTES.toMillis(30))   // now - 30m
 
+    def dateContext = Mock(MissedPipelineTriggerCompensationJob.DateContext)
+    def compensationJob = new MissedPipelineTriggerCompensationJob(scheduler, pipelineCache, orcaService,
+      pipelineInitiator, registry, 30000, 'America/Los_Angeles', true, 900000, 20, dateContext)
+
     when:
-    def missedExecution = MissedPipelineTriggerCompensationJob.missedExecution(expr, lastExecution, windowFloor, now)
+    def missedExecution = compensationJob.missedExecution(expr, lastExecution, windowFloor, now)
 
     then:
     missedExecution == true

--- a/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineConfigsPollingAgentSpec.groovy
+++ b/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineConfigsPollingAgentSpec.groovy
@@ -18,21 +18,21 @@ package com.netflix.spinnaker.echo.scheduler.actions.pipeline
 import com.netflix.scheduledactions.ActionInstance
 import com.netflix.scheduledactions.ActionsOperator
 import com.netflix.scheduledactions.triggers.CronTrigger
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.echo.model.Pipeline
 import com.netflix.spinnaker.echo.model.Trigger
 import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache
 import com.netflix.spinnaker.echo.scheduler.actions.pipeline.impl.PipelineConfigsPollingAgent
-import org.springframework.boot.actuate.metrics.CounterService
-import org.springframework.boot.actuate.metrics.GaugeService
 import spock.lang.Specification
 import spock.lang.Subject
+
 class PipelineConfigsPollingAgentSpec extends Specification {
 
-    def counterService = Stub(CounterService)
-    def gaugeService = Stub(GaugeService)
+    Registry registry = new DefaultRegistry()
     def actionsOperator = Mock(ActionsOperator)
     def pipelineCache = Mock(PipelineCache)
-    @Subject pollingAgent = new PipelineConfigsPollingAgent(counterService, gaugeService, pipelineCache, actionsOperator, 1000000, 'America/Los_Angeles')
+    @Subject pollingAgent = new PipelineConfigsPollingAgent(registry, pipelineCache, actionsOperator, 1000000, 'America/Los_Angeles')
 
     void 'when a new pipeline trigger is added, a scheduled action instance is registered with an id same as the trigger id'() {
         given:

--- a/echo-web/echo-web.gradle
+++ b/echo-web/echo-web.gradle
@@ -42,6 +42,7 @@ dependencies {
     compile spinnaker.dependency('bootActuator')
     compile spinnaker.dependency('bootWeb')
     compile spinnaker.dependency('jacksonDatabind')
+    compile spinnaker.dependency('spectatorApi')
     testCompile spinnaker.dependency('spockSpring')
     testCompile spinnaker.dependency('springTest')
 }


### PR DESCRIPTION
Also:
* pick up new spinnaker-dependencies for spectator 0.68.0 update
* update jacoco, which otherwise conflicts with spectator
* add explicit dependency on spectatorApi when we use it
* add exception tag on error metrics
* don't use a mock Registry when unnecessary
* make triggers.cronMisfires a timer (so that we can estimate trigger lag)
* adjust some log levels and messages
* add a pipelineConfigsPollingAgent.executionTimeMillis timer
