### PR TITLE
chore(build): Add debug flag to echo build

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ It does so via two modules:
 ## Running Echo
 This can be done locally via `./gradlew bootRun`, which will start with an embedded cassandra instance. Or by following the instructions using the [Spinnaker installation scripts](http://www.github.com/spinnaker/spinnaker).
  
+### Debugging
+
+To start the JVM in debug mode, set the Java system property `DEBUG=true`:
+```
+./gradlew -DDEBUG=true
+```
+
+The JVM will then listen for a debugger to be attached on port 8189.  The JVM will _not_ wait for
+the debugger to be attached before starting Echo; the relevant JVM arguments can be seen and
+modified as needed in `build.gradle`.

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,12 @@ allprojects {
             force 'com.google.guava:guava:20.0'
         }
     }
+
+    tasks.withType(JavaExec) {
+      if (System.getProperty('DEBUG', 'false') == 'true') {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8189'
+      }
+    }
 }
 
 subprojects {


### PR DESCRIPTION
Starting echo with ./gradlew -DDEBUG=true now causes the JVM to
listen on port 8189 for a remote debugger.