### PR TITLE
fix(artifacts): Artifacts with usePrior flag do not need to match a trigger

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
@@ -43,7 +43,13 @@ public class ArtifactMatcher {
     List<ExpectedArtifact> expectedArtifacts = pipelineExpectedArtifacts == null ? new ArrayList<>() : pipelineExpectedArtifacts
         .stream()
         .filter(e -> expectedArtifactIds.contains(e.getId()))
+        .filter(e -> !e.isUsePriorArtifact())
         .collect(Collectors.toList());
+
+    if ( expectedArtifacts == null || expectedArtifacts.isEmpty()) {
+      log.info("All expected artifacts are marked as UsePrior hence no need for matching.");
+      return true;
+    }
 
     if (messageArtifacts.size() > expectedArtifactIds.size()) {
       log.warn("Parsed message artifacts (size {}) greater than expected artifacts (size {}), continuing trigger anyway", messageArtifacts.size(), expectedArtifactIds.size());

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
@@ -39,17 +39,20 @@ public class ArtifactMatcher {
       return true;
     }
 
-    List<ExpectedArtifact> pipelineExpectedArtifacts = pipeline.getExpectedArtifacts();
-    List<ExpectedArtifact> expectedArtifacts = pipelineExpectedArtifacts == null ? new ArrayList<>() : pipelineExpectedArtifacts
+    List<ExpectedArtifact> pipelineExpectedArtifacts = pipeline.getExpectedArtifacts()
         .stream()
-        .filter(e -> expectedArtifactIds.contains(e.getId()))
         .filter(e -> !e.isUsePriorArtifact())
         .collect(Collectors.toList());
 
-    if ( expectedArtifacts == null || expectedArtifacts.isEmpty()) {
-      log.info("All expected artifacts are marked as UsePrior hence no need for matching.");
+    if ( pipelineExpectedArtifacts == null || pipelineExpectedArtifacts.isEmpty()) {
+      log.info("All pipeline expected artifacts are marked as UsePrior hence no need for matching.");
       return true;
     }
+
+    List<ExpectedArtifact> expectedArtifacts = pipelineExpectedArtifacts == null ? new ArrayList<>() : pipelineExpectedArtifacts
+        .stream()
+        .filter(e -> expectedArtifactIds.contains(e.getId()))
+        .collect(Collectors.toList());
 
     if (messageArtifacts.size() > expectedArtifactIds.size()) {
       log.warn("Parsed message artifacts (size {}) greater than expected artifacts (size {}), continuing trigger anyway", messageArtifacts.size(), expectedArtifactIds.size());


### PR DESCRIPTION
When echo receives a trigger and is matching the trigger event to the pipeline triggers, there might happen that a pipeline has 2 triggers and some expected artifacts - some expected artifacts can be flagged as "If not present, use from prior execution".
When that's the case, those artifacts do not need to be matched for the pipeline to be triggered.

Example:
Pipeline FooBar expects 3 Artifacts
- Artifact A (flagged as "If not present, use from prior execution")
- Artifact B (flagged as "If not present, use from prior execution")
- Artifact C (flagged as "If not present, use from prior execution")

The pipeline has 2 triggers:
- Trigger 1 - Provides artifacts A, B and C
- Trigger 2 - Do not provides artifacts

Currently, when a "Trigger 2" event is received it is does not start the pipeline because it doesn't match the expected artifacts - it should and just get the artifacts from a previous execution. This PR fixes that.