### PR TITLE
fix(cron): fallback for cron triggers with null id

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
@@ -21,10 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.ToString;
-import lombok.Value;
+import lombok.*;
 import lombok.experimental.Wither;
 
 import java.util.List;
@@ -34,7 +31,8 @@ import java.util.Map;
 @Builder
 @Wither
 @ToString(of = {"application", "name", "id"}, includeFieldNames = false)
-@Value public class Pipeline {
+@Value
+public class Pipeline {
   @JsonProperty
   @NonNull String application;
 

--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -30,10 +30,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * the values we include in toString are meaningful, they are hashed and become part of generateFallbackId()
+ */
 @JsonDeserialize(builder = Trigger.TriggerBuilder.class)
 @Builder(toBuilder = true)
 @Wither
-@ToString(of = {"id", "type", "master", "job", "cronExpression", "source", "project", "slug", "account", "repository", "tag", "parameters", "payloadConstraints", "attributeConstraints", "branch", "runAsUser", "subscriptionName", "pubsubSystem", "expectedArtifactIds", "payload"}, includeFieldNames = false)
+@ToString(of = {"id", "parent", "type", "master", "job", "cronExpression", "source", "project", "slug", "account", "repository", "tag", "parameters", "payloadConstraints", "attributeConstraints", "branch", "runAsUser", "subscriptionName", "pubsubSystem", "expectedArtifactIds", "payload"}, includeFieldNames = false)
 @Value
 public class Trigger {
   public enum Type {
@@ -93,20 +96,10 @@ public class Trigger {
   Map<String, ?> lastSuccessfulExecution;
 
   // this is set after deserialization, not in the json representation
-  @NonFinal
   Pipeline parent;
 
-  public String getIdWithFallback() {
-    if (id != null) {
-      return id;
-    }
-
-    if (parent == null) {
-      log.warn("Trigger with unknown parent: {}", this);
-      return UUID.nameUUIDFromBytes(this.toString().getBytes()).toString();
-    }
-
-    return UUID.nameUUIDFromBytes((parent.getId() + "/" + this.toString()).getBytes()).toString();
+  public String generateFallbackId() {
+    return UUID.nameUUIDFromBytes(this.toString().getBytes()).toString();
   }
 
   public Trigger atBuildNumber(final int buildNumber) {

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
@@ -73,7 +73,7 @@ public class PipelineInitiator implements Action1<Pipeline> {
     }
 
     return (fiatEnabled && runAsUser != null && !runAsUser.isEmpty()) ?
-      orca.trigger(pipeline, pipeline.getTrigger().getRunAsUser()) :
+      orca.trigger(pipeline, runAsUser) :
       orca.trigger(pipeline);
   }
 

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/MissedPipelineTriggerCompensationJob.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/MissedPipelineTriggerCompensationJob.groovy
@@ -59,7 +59,7 @@ import static net.logstash.logback.argument.StructuredArguments.kv
 @Slf4j
 class MissedPipelineTriggerCompensationJob implements ApplicationListener<ContextRefreshedEvent> {
 
-  final static Duration STARTUP_POLL_INTERVAL = Duration.ofSeconds(5000000)
+  final static Duration STARTUP_POLL_INTERVAL = Duration.ofSeconds(60)
 
   final Scheduler scheduler
   final PipelineCache pipelineCache

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/MissedPipelineTriggerCompensationJob.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/MissedPipelineTriggerCompensationJob.groovy
@@ -59,7 +59,7 @@ import static net.logstash.logback.argument.StructuredArguments.kv
 @Slf4j
 class MissedPipelineTriggerCompensationJob implements ApplicationListener<ContextRefreshedEvent> {
 
-  final static Duration STARTUP_POLL_INTERVAL = Duration.ofSeconds(5)
+  final static Duration STARTUP_POLL_INTERVAL = Duration.ofSeconds(5000000)
 
   final Scheduler scheduler
   final PipelineCache pipelineCache

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/PipelineConfigsPollingAgent.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/PipelineConfigsPollingAgent.groovy
@@ -78,20 +78,20 @@ class PipelineConfigsPollingAgent extends AbstractPollingAgent {
     try {
       log.info("Running the pipeline configs polling agent...")
 
-      /**
-       * Only interested in pipelines that have triggers and that too scheduled triggers
-       */
+      // Only interested in pipelines that have triggers and that too scheduled triggers
       def pipelines = pipelineCache.getPipelines().findAll {
         it.triggers && it.triggers.any { TRIGGER_TYPE.equalsIgnoreCase(it.type) }
       }
+
+      def triggerRepo = new TriggerRepository(pipelines)
 
       try {
         /**
          * Getting all the registered scheduled actions
          */
         List<ActionInstance> actionInstances = actionsOperator.getActionInstances()
-        updateChangedTriggers(pipelines, actionInstances)
-        registerNewTriggers(pipelines, actionInstances)
+        updateChangedTriggers(triggerRepo, actionInstances)
+        registerNewTriggers(triggerRepo, actionInstances)
       } catch (Exception e) {
         registry.counter("actionsOperator.list.errors").increment()
         throw new Exception("Exception occurred while fetching all registered action instances", e)
@@ -105,29 +105,25 @@ class PipelineConfigsPollingAgent extends AbstractPollingAgent {
     }
   }
 
-  void updateChangedTriggers(List<Pipeline> pipelines, List<ActionInstance> actionInstances) {
+  void updateChangedTriggers(TriggerRepository triggerRepo, List<ActionInstance> actionInstances) {
     try {
-      /**
-       * Extract ALL the triggers
-       */
-      List<Trigger> triggers = pipelines.collect { it.triggers }.flatten()
-
       /**
        * Iterate through all the registered ActionInstances and for each, check if the corresponding
        * trigger has been updated or not. If it is, then update the ActionInstance as well. Trigger and
        * ActionInstance have the same 'id'
        */
       if (actionInstances) {
-        log.info("Found '${actionInstances?.size()}' existing scheduled action(s). " +
+        log.info("Found ${actionInstances?.size()} existing scheduled action(s). " +
           "Iterating through each scheduled action and checking if the corresponding trigger has been changed...")
       }
 
       actionInstances.each { actionInstance ->
-        // InMemoryActionInstanceDao builds composite action instance ids that end with the trigger id.
-        Trigger trigger = triggers.find { it.id == actionInstance.id || actionInstance.id.endsWith(":$it.id") }
+        // InMemoryActionInstanceDao builds composite action instance ids that end with the trigger id
+        // e.g. 2d05822d-0275-454b-9616-361bf3b557ca:com.netflix.scheduledactions.ActionInstance:74f13df7-e642-4f8b-a5f2-0d5319aa0bd1
+        Trigger trigger = triggerRepo.getTrigger(actionInstance.id)
         try {
           if (trigger) {
-            Pipeline pipeline = pipelines.find { it.triggers.contains(trigger) }
+            Pipeline pipeline = trigger.parent
             if (trigger.enabled && !pipeline.disabled) {
               if (!PipelineTriggerConverter.isInSync(actionInstance, trigger, timeZoneId)) {
                 /**
@@ -155,7 +151,7 @@ class PipelineConfigsPollingAgent extends AbstractPollingAgent {
             } else {
               if (!actionInstance.disabled) {
                 actionsOperator.disableActionInstance(actionInstance)
-                log.info("Disabled scheduled action '${actionInstance.id}' as the corresponding trigger has been " +
+                log.info("Disabled scheduled action '${actionInstance.id}' as the corresponding trigger ${trigger} has been " +
                   "disabled")
               }
             }
@@ -165,6 +161,7 @@ class PipelineConfigsPollingAgent extends AbstractPollingAgent {
           }
         } catch (Exception e) {
           registry.counter("updateTriggers.errors", "exception", e.getClass().getName()).increment()
+
           log.error("Exception occurred while updating ${trigger}", e)
         }
       }
@@ -173,48 +170,46 @@ class PipelineConfigsPollingAgent extends AbstractPollingAgent {
     }
   }
 
-  void registerNewTriggers(List<Pipeline> pipelines, List<ActionInstance> actionInstances) {
+  void registerNewTriggers(TriggerRepository triggerRepo, List<ActionInstance> actionInstances) {
     try {
-      List<String> actionIds = actionInstances.collect { it.id }
-
-      /**
-       * Find all pipelines that don't have a trigger that is not associated (by id) with any actionInstance in the
-       * list of actionInstances. This indicates that these are new triggers
-       */
-      List<Pipeline> pipelinesWithNewTriggers = pipelines.findAll {
-        def cronTriggers = it.triggers.findAll { it.type == Trigger.Type.CRON.toString() }
-        cronTriggers.any { !actionIds.contains(it.id) && !actionIds.find { actionId -> actionId.endsWith(":$it.id") } }
+      // find all the triggers that don't have a corresponding action instance (by id)
+      // this indicates that these are new triggers
+      actionInstances.each { actionInstance ->
+        triggerRepo.remove(actionInstance.id)
       }
-      pipelinesWithNewTriggers.each { pipeline ->
-        /**
-         * Extract all the triggers of type 'cron' from a pipeline. Ideally, there would be just one,
-         * but pipelines 'could' have multiple cron triggers
-         */
-        List<Trigger> triggers = pipeline.triggers.findAll {
-          it.type == Trigger.Type.CRON.toString() && it.enabled
+
+      Collection<Trigger> newTriggers = triggerRepo.triggers()
+      newTriggers.each { trigger ->
+        if (!Trigger.Type.CRON.toString().equalsIgnoreCase(trigger.type) || !trigger.enabled) {
+//          log.debug("Skipping disabled or non-cron trigger ${trigger}")
+          return
         }
-        if (triggers) {
-          log.info("Found '${triggers.size()}' new cron trigger(s) for ${pipeline}...")
+
+        Pipeline pipeline = trigger.parent
+        if (pipeline.disabled) {
+          log.debug("Skipping disabled pipeline ${pipeline}")
+          return
         }
-        triggers.each { trigger ->
-          try {
-            /**
-             * Create an ActionInstance for each trigger and assign the same id as the trigger id
-             * ActionInstances are grouped by pipeline id. Pass in enough parameters to the ActionInstance for it
-             * to construct the Pipeline instance back
-             */
-            ActionInstance actionInstance = PipelineTriggerConverter.toScheduledAction(pipeline, trigger, timeZoneId)
-            actionsOperator.registerActionInstance(actionInstance)
-            log.info('Registered scheduled trigger {} {} {}', kv('id', actionInstance.id), kv('trigger', trigger), kv('pipeline', pipeline))
-            registry.counter("newTriggers.count").increment()
-          } catch (Exception e) {
-            registry.counter("newTriggers.errors", "exception", e.getClass().getName()).increment()
-            log.error("Exception occurred while creating new ${trigger}", e)
-          }
+
+        try {
+          // Create an ActionInstance for each trigger and assign the same id as the trigger id
+          // ActionInstances are grouped by pipeline id. Pass in enough parameters to the ActionInstance for it
+          // to construct the Pipeline instance back
+          ActionInstance actionInstance = PipelineTriggerConverter.toScheduledAction(pipeline, trigger, timeZoneId)
+          actionsOperator.registerActionInstance(actionInstance)
+          log.info('Registered scheduled trigger {} {} {}', kv('id', actionInstance.id), kv('trigger', trigger), kv('pipeline', pipeline))
+          registry.counter("newTriggers.count").increment()
+        } catch (Exception e) {
+          log.error("Exception occurred while creating new trigger ${trigger} for pipeline ${pipeline}", e)
+          registry.counter("newTriggers.errors", "exception", e.getClass().getName()).increment()
         }
       }
     } catch (Exception e) {
       log.error("Exception occurred while creating new triggers", e)
     }
+  }
+
+  private void extractTriggerId(ActionInstance actionInstance) {
+    actionInstance.id.split(':')
   }
 }

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/PipelineConfigsPollingAgent.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/PipelineConfigsPollingAgent.groovy
@@ -181,7 +181,7 @@ class PipelineConfigsPollingAgent extends AbstractPollingAgent {
       Collection<Trigger> newTriggers = triggerRepo.triggers()
       newTriggers.each { trigger ->
         if (!Trigger.Type.CRON.toString().equalsIgnoreCase(trigger.type) || !trigger.enabled) {
-//          log.debug("Skipping disabled or non-cron trigger ${trigger}")
+          log.debug("Skipping disabled or non-cron trigger ${trigger}")
           return
         }
 
@@ -207,9 +207,5 @@ class PipelineConfigsPollingAgent extends AbstractPollingAgent {
     } catch (Exception e) {
       log.error("Exception occurred while creating new triggers", e)
     }
-  }
-
-  private void extractTriggerId(ActionInstance actionInstance) {
-    actionInstance.id.split(':')
   }
 }

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/PipelineConfigsPollingAgent.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/PipelineConfigsPollingAgent.groovy
@@ -161,7 +161,6 @@ class PipelineConfigsPollingAgent extends AbstractPollingAgent {
           }
         } catch (Exception e) {
           registry.counter("updateTriggers.errors", "exception", e.getClass().getName()).increment()
-
           log.error("Exception occurred while updating ${trigger}", e)
         }
       }

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/PipelineTriggerConverter.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/PipelineTriggerConverter.groovy
@@ -30,7 +30,7 @@ class PipelineTriggerConverter {
   static Map<String, String> toParameters(Pipeline pipeline, Trigger trigger, String timeZoneId) {
     def params = [
       id                   : pipeline.id,
-      triggerId            : trigger.getIdWithFallback(),
+      triggerId            : trigger.id,
       triggerType          : trigger.type,
       triggerCronExpression: trigger.cronExpression,
       triggerTimeZoneId    : timeZoneId,
@@ -63,7 +63,7 @@ class PipelineTriggerConverter {
 
   static ActionInstance toScheduledAction(Pipeline pipeline, Trigger trigger, String timeZoneId) {
     ActionInstance.ActionInstanceBuilder actionInstanceBuilder = ActionInstance.newActionInstance()
-      .withId(trigger.getIdWithFallback())
+      .withId(trigger.id)
       .withName("Pipeline Trigger")
       .withGroup(pipeline.id)
       .withAction(PipelineTriggerAction)

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/PipelineTriggerConverter.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/PipelineTriggerConverter.groovy
@@ -30,7 +30,7 @@ class PipelineTriggerConverter {
   static Map<String, String> toParameters(Pipeline pipeline, Trigger trigger, String timeZoneId) {
     def params = [
       id                   : pipeline.id,
-      triggerId            : trigger.id,
+      triggerId            : trigger.getIdWithFallback(),
       triggerType          : trigger.type,
       triggerCronExpression: trigger.cronExpression,
       triggerTimeZoneId    : timeZoneId,
@@ -63,7 +63,7 @@ class PipelineTriggerConverter {
 
   static ActionInstance toScheduledAction(Pipeline pipeline, Trigger trigger, String timeZoneId) {
     ActionInstance.ActionInstanceBuilder actionInstanceBuilder = ActionInstance.newActionInstance()
-      .withId(trigger.id)
+      .withId(trigger.getIdWithFallback())
       .withName("Pipeline Trigger")
       .withGroup(pipeline.id)
       .withAction(PipelineTriggerAction)

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/TriggerRepository.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/TriggerRepository.groovy
@@ -1,0 +1,63 @@
+package com.netflix.spinnaker.echo.scheduler.actions.pipeline.impl
+
+import com.netflix.spinnaker.echo.model.Pipeline
+import com.netflix.spinnaker.echo.model.Trigger
+import groovy.util.logging.Slf4j
+
+import javax.annotation.Nullable
+
+@Slf4j
+class TriggerRepository {
+  private final Map<String, Trigger> triggersById;
+
+  TriggerRepository(List<Pipeline> pipelines) {
+    triggersById = new HashMap<>()
+    for (Pipeline pipeline : pipelines) {
+      for (Trigger trigger : pipeline.triggers) {
+        if (trigger.parent == null) {
+          trigger.parent = pipeline
+        } else if (trigger.parent != pipeline) {
+          log.warn("pipeline ${pipeline} has trigger ${trigger}, but the trigger has parent pipeline ${trigger.parent}")
+        }
+
+        Trigger previous = triggersById.put(trigger.getIdWithFallback(), trigger)
+        if (previous) {
+          log.warn("Duplicate trigger ids found: ${previous} with parent ${previous.parent} and ${trigger} with parent ${trigger.parent}")
+        }
+      }
+    }
+  }
+
+  // visible for testing
+  static String extractTriggerId(String id) {
+    int index = id.lastIndexOf(':')
+    return (index == -1) ? id : id.substring(index + 1)
+  }
+
+  /**
+   * @param id can be a straight-up trigger id or an ActionInstance composite id of the form:
+   *           composites are of the form <pipeId>:className:<triggerId>, so in this case we want to extract <triggerId>
+   *           for the lookup
+   * @return null if no trigger is mapped to id
+   */
+  @Nullable
+  public Trigger getTrigger(String id) {
+    if (id == null) {
+      return null
+    }
+
+    return triggersById.get(id) ?: triggersById.get(extractTriggerId(id))
+  }
+
+  public Trigger remove(String id) {
+    if (id == null) {
+      return null
+    }
+
+    return triggersById.remove(id) ?: triggersById.remove(extractTriggerId(id))
+  }
+
+  public Collection<Trigger> triggers() {
+    return triggersById.values()
+  }
+}

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/TriggerRepository.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/impl/TriggerRepository.groovy
@@ -8,19 +8,18 @@ import javax.annotation.Nullable
 
 @Slf4j
 class TriggerRepository {
-  private final Map<String, Trigger> triggersById;
+  private final Map<String, Trigger> triggersById
 
   TriggerRepository(List<Pipeline> pipelines) {
     triggersById = new HashMap<>()
     for (Pipeline pipeline : pipelines) {
       for (Trigger trigger : pipeline.triggers) {
-        if (trigger.parent == null) {
-          trigger.parent = pipeline
-        } else if (trigger.parent != pipeline) {
-          log.warn("pipeline ${pipeline} has trigger ${trigger}, but the trigger has parent pipeline ${trigger.parent}")
+        if (trigger.id == null) {
+          // see PipelineCache::decorateTriggers
+          throw new IllegalStateException("Trigger with null id ${trigger}")
         }
 
-        Trigger previous = triggersById.put(trigger.getIdWithFallback(), trigger)
+        Trigger previous = triggersById.put(trigger.id, trigger)
         if (previous) {
           log.warn("Duplicate trigger ids found: ${previous} with parent ${previous.parent} and ${trigger} with parent ${trigger.parent}")
         }

--- a/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineTriggerActionConverterSpec.groovy
+++ b/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineTriggerActionConverterSpec.groovy
@@ -40,11 +40,12 @@ class PipelineTriggerActionConverterSpec extends Specification {
       .parallel(true)
       .build()
 
-    void 'toParameters() should return an equivalent map of parameters'() {
+    @Unroll
+    void 'toParameters() should return an equivalent map of parameters with triggerId=#triggerId'() {
         setup:
         Trigger trigger = Trigger.builder()
             .enabled(true)
-            .id('123-456')
+            .id(triggerId)
             .type('cron')
             .cronExpression('* 0/30 * * * ? *')
             .build()
@@ -54,11 +55,14 @@ class PipelineTriggerActionConverterSpec extends Specification {
 
         then:
         parameters.id == pipeline.id
-        parameters.triggerId == trigger.id
+        parameters.triggerId == trigger.getIdWithFallback()
         parameters.triggerType == trigger.type
         parameters.triggerCronExpression == trigger.cronExpression
         parameters.triggerTimeZoneId == 'America/New_York'
         parameters.triggerEnabled == Boolean.toString(trigger.enabled)
+
+        where:
+        triggerId << ['123-456', null]
     }
 
     void 'fromParameters() should return an equivalent valid Pipeline instance'() {
@@ -88,11 +92,11 @@ class PipelineTriggerActionConverterSpec extends Specification {
         pipelineWithTrigger.trigger.enabled == Boolean.valueOf(parameters.triggerEnabled)
     }
 
-    void 'toScheduledAction() should return an equivalent valid ActionInstance'() {
+    void 'toScheduledAction() should return an equivalent valid ActionInstance with triggerId=#triggerId'() {
         setup:
         Trigger trigger = Trigger.builder()
             .enabled(true)
-            .id('123-456')
+            .id(triggerId)
             .type('cron')
             .cronExpression('* 0/30 * * * ? *')
             .build()
@@ -101,7 +105,7 @@ class PipelineTriggerActionConverterSpec extends Specification {
         ActionInstance actionInstance = PipelineTriggerConverter.toScheduledAction(pipeline, trigger, 'America/Los_Angeles')
 
         then:
-        actionInstance.id == trigger.id
+        actionInstance.id == trigger.getIdWithFallback()
         actionInstance.name == 'Pipeline Trigger'
         actionInstance.group == pipeline.id
         actionInstance.action == PipelineTriggerAction.class
@@ -110,11 +114,14 @@ class PipelineTriggerActionConverterSpec extends Specification {
         ((CronTrigger) actionInstance.trigger).cronExpression == trigger.cronExpression
         actionInstance.parameters != null
         actionInstance.parameters.id == pipeline.id
-        actionInstance.parameters.triggerId == trigger.id
+        actionInstance.parameters.triggerId == trigger.getIdWithFallback()
         actionInstance.parameters.triggerType == trigger.type
         actionInstance.parameters.triggerCronExpression == trigger.cronExpression
         actionInstance.parameters.triggerTimeZoneId == 'America/Los_Angeles'
         actionInstance.parameters.triggerEnabled == Boolean.toString(trigger.enabled)
+
+        where:
+        triggerId << ['123-456', null]
     }
 
     @Unroll

--- a/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineTriggerActionConverterSpec.groovy
+++ b/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineTriggerActionConverterSpec.groovy
@@ -55,7 +55,7 @@ class PipelineTriggerActionConverterSpec extends Specification {
 
         then:
         parameters.id == pipeline.id
-        parameters.triggerId == trigger.getIdWithFallback()
+        parameters.triggerId == trigger.id
         parameters.triggerType == trigger.type
         parameters.triggerCronExpression == trigger.cronExpression
         parameters.triggerTimeZoneId == 'America/New_York'
@@ -92,6 +92,7 @@ class PipelineTriggerActionConverterSpec extends Specification {
         pipelineWithTrigger.trigger.enabled == Boolean.valueOf(parameters.triggerEnabled)
     }
 
+    @Unroll
     void 'toScheduledAction() should return an equivalent valid ActionInstance with triggerId=#triggerId'() {
         setup:
         Trigger trigger = Trigger.builder()
@@ -105,7 +106,7 @@ class PipelineTriggerActionConverterSpec extends Specification {
         ActionInstance actionInstance = PipelineTriggerConverter.toScheduledAction(pipeline, trigger, 'America/Los_Angeles')
 
         then:
-        actionInstance.id == trigger.getIdWithFallback()
+        actionInstance.id == trigger.id
         actionInstance.name == 'Pipeline Trigger'
         actionInstance.group == pipeline.id
         actionInstance.action == PipelineTriggerAction.class
@@ -114,7 +115,7 @@ class PipelineTriggerActionConverterSpec extends Specification {
         ((CronTrigger) actionInstance.trigger).cronExpression == trigger.cronExpression
         actionInstance.parameters != null
         actionInstance.parameters.id == pipeline.id
-        actionInstance.parameters.triggerId == trigger.getIdWithFallback()
+        actionInstance.parameters.triggerId == trigger.id
         actionInstance.parameters.triggerType == trigger.type
         actionInstance.parameters.triggerCronExpression == trigger.cronExpression
         actionInstance.parameters.triggerTimeZoneId == 'America/Los_Angeles'
@@ -168,5 +169,4 @@ class PipelineTriggerActionConverterSpec extends Specification {
         expect:
         isInSync(actionInstance, trigger, null)
     }
-
 }

--- a/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/TriggerRepositorySpec.groovy
+++ b/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/TriggerRepositorySpec.groovy
@@ -1,0 +1,122 @@
+package com.netflix.spinnaker.echo.scheduler.actions.pipeline
+
+import com.netflix.spinnaker.echo.model.Pipeline
+import com.netflix.spinnaker.echo.model.Trigger
+import com.netflix.spinnaker.echo.scheduler.actions.pipeline.impl.TriggerRepository
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class TriggerRepositorySpec extends Specification {
+  private static final String TRIGGER_ID = '74f13df7-e642-4f8b-a5f2-0d5319aa0bd1'
+  private static final String ACTION_INSTANCE_ID = "2d05822d-0275-454b-9616-361bf3b557ca:com.netflix.scheduledactions.ActionInstance:${TRIGGER_ID}"
+
+  @Shared Trigger triggerA = Trigger.builder().id('123-456').build()
+  @Shared Trigger triggerB = Trigger.builder().id('456-789').build()
+  @Shared Trigger triggerC = Trigger.builder().id(null).build() // to test the fallback mechanism
+  @Shared Trigger triggerD = Trigger.builder().id('123-789').build() // not assigned to any pipeline
+
+  @Shared Pipeline pipelineA = Pipeline.builder().application('app').name('pipeA').id('idPipeA').triggers([triggerA]).build()
+  @Shared Pipeline pipelineB = Pipeline.builder().application('app').name('pipeB').id('idPipeB').triggers([triggerB, triggerC]).build()
+  @Shared Pipeline pipelineC = Pipeline.builder().application('app').name('pipeC').build()
+
+  @Shared TriggerRepository repo = new TriggerRepository([pipelineA, pipelineB, pipelineC])
+
+  @Unroll
+  def 'looking up id #id in repo should return trigger #trigger'() {
+    when:
+    Trigger result = repo.getTrigger(id)
+
+    then:
+    result == trigger
+    result?.parent == pipeline
+
+    where:
+    id                      || trigger  | pipeline
+    triggerA.idWithFallback || triggerA | pipelineA
+    triggerB.idWithFallback || triggerB | pipelineB
+    triggerC.idWithFallback || triggerC | pipelineB
+    triggerC.id             || null     | null      // this is why we have idWithFallback
+    triggerD.idWithFallback || null     | null      // not in our repo
+  }
+
+
+  @Unroll
+  def 'we can remove triggers by id'() {
+    given:
+    TriggerRepository repo = new TriggerRepository([pipelineA, pipelineB, pipelineC])
+
+    when: 'we remove using a trigger id directly'
+    Trigger removed = repo.remove(triggerA.idWithFallback)
+
+    then: 'it is effectively removed'
+    removed == triggerA
+    repo.triggers().size() == 2
+    !repo.triggers().contains(triggerA)
+
+    when: 'we remove using a compound id'
+    removed = repo.remove("${pipelineB.id}:com.netflix.scheduledactions.ActionInstance:${triggerB.idWithFallback}")
+
+    then: 'it is also effectively removed'
+    removed == triggerB
+    repo.triggers().size() == 1
+    repo.triggers().contains(triggerC)
+
+    when: 'we remove a thing that is not there'
+    removed = repo.remove(triggerA.idWithFallback)
+
+    then: 'everything is ok'
+    removed == null
+    repo.triggers().size() == 1
+  }
+
+
+  @Unroll
+  def 'we can extract a trigger id from an action instance id'() {
+    when:
+    String result = TriggerRepository.extractTriggerId(inputId)
+
+    then:
+    result == triggerId
+
+    where:
+    inputId             || triggerId
+    ACTION_INSTANCE_ID  || '74f13df7-e642-4f8b-a5f2-0d5319aa0bd1'
+    TRIGGER_ID          || TRIGGER_ID // no-op if we pass something else
+    ":${TRIGGER_ID}"    || TRIGGER_ID // fishing for off-by-one errors
+    "${TRIGGER_ID}:"    || '' // we should not freak out if we get something plain unexpected
+  }
+
+
+  def 'we generate fallback ids based on cron expressions and parent pipelines'() {
+    when: 'they have an explicit id'
+    Trigger every5minNoParent = Trigger.builder().id('idA').cronExpression('*/5 * * * *').parent(null).build()
+
+    then: 'the fallback id is the explicit id'
+    every5minNoParent.idWithFallback == every5minNoParent.id
+    every5minNoParent.idWithFallback == 'idA'
+
+
+    when: 'two triggers have no id, no parent and the same cron expression'
+    Trigger nullIdEvery5minNoParentA = Trigger.builder().id(null).cronExpression('*/5 * * * *').parent(null).build()
+    Trigger nullIdEvery5minNoParentB = Trigger.builder().id(null).cronExpression('*/5 * * * *').parent(null).build()
+
+    then: 'they get the same fallback id'
+    nullIdEvery5minNoParentA.idWithFallback == nullIdEvery5minNoParentB.idWithFallback
+
+
+    when: 'two triggers have different parents'
+    Trigger nullIdEvery5minParentA = Trigger.builder().id(null).cronExpression('*/5 * * * *').parent(pipelineA).build()
+    Trigger nullIdEvery5minParentB = Trigger.builder().id(null).cronExpression('*/5 * * * *').parent(pipelineB).build()
+
+    then: 'they get different fallback ids'
+    nullIdEvery5minParentA.idWithFallback != nullIdEvery5minParentB.idWithFallback
+
+
+    when: 'two triggers have a different cron expression'
+    Trigger nullIdEvery30minParentA = Trigger.builder().id(null).cronExpression('*/30 * * * *').parent(pipelineA).build()
+
+    then: 'they get different fallback ids'
+    nullIdEvery5minParentA.idWithFallback != nullIdEvery30minParentA.idWithFallback
+  }
+}


### PR DESCRIPTION
If pipeline configurations with null cron trigger ids somehow went past
front50, we would have "flagging" registrations: new triggers would be found,
then on the next pass of the PipelineConfigsPollingAgent we would find
scheduled actions with no corresponding triggers (since they don't have)
a matching id. We would then deregister then, only to register them again
right away, and so on.

With this change, we no longer need a persisted id for cron triggers in
the pipeline configurations (which is bound to be messed with, deleted,
copied, mangled...)
