### PR TITLE
fix(build): Fix spring warnings about validated classes

### DIFF
--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/config/GooglePubsubProperties.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/config/GooglePubsubProperties.java
@@ -29,9 +29,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import org.springframework.validation.annotation.Validated;
 
 @Data
 @ConfigurationProperties(prefix = "pubsub.google")
+@Validated
 public class GooglePubsubProperties {
 
   @Valid

--- a/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/config/RestProperties.groovy
+++ b/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/config/RestProperties.groovy
@@ -20,6 +20,7 @@ import groovy.transform.CompileStatic
 import org.hibernate.validator.constraints.NotEmpty
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Configuration
+import org.springframework.validation.annotation.Validated
 
 import javax.validation.Valid
 
@@ -29,6 +30,7 @@ import javax.validation.Valid
 @Configuration
 @CompileStatic
 @ConfigurationProperties(prefix = 'rest')
+@Validated
 class RestProperties {
   @Valid
   List<RestEndpointConfiguration> endpoints


### PR DESCRIPTION
As of Spring Boot 1.5, `@ConfigurationProperties` classes that use constraint annotations should also be annotated with `@Validated`; this is currently throwing warnings but may actually break in the future.