### PR TITLE
fix(pubsub): Wait until pipelines are loaded to process pubsub messages

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
@@ -16,10 +16,21 @@
 
 package com.netflix.spinnaker.echo.pipelinetriggers;
 
+import static java.time.Instant.now;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.model.Pipeline;
 import com.netflix.spinnaker.echo.model.Trigger;
 import com.netflix.spinnaker.echo.services.Front50Service;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,18 +38,8 @@ import org.springframework.stereotype.Component;
 import rx.Observable;
 import rx.Scheduler;
 import rx.Subscription;
-
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-
-import static java.time.Instant.now;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import rx.subjects.ReplaySubject;
+import rx.subjects.SerializedSubject;
 
 @Component
 @Slf4j
@@ -51,6 +52,7 @@ public class PipelineCache implements MonitoredPoller {
   private transient Instant lastPollTimestamp;
   private transient Subscription subscription;
 
+  private transient SerializedSubject<List<Pipeline>, List<Pipeline>> pipelineSubject = ReplaySubject.<List<Pipeline>>createWithSize(1).toSerialized();
   private transient AtomicReference<List<Pipeline>> pipelines = new AtomicReference<>(Collections.emptyList());
 
   @Autowired
@@ -72,7 +74,8 @@ public class PipelineCache implements MonitoredPoller {
         .flatMap(tick -> front50.getPipelines())
         .doOnError(this::onFront50Error)
         .retry()
-        .subscribe(this::cachePipelines);
+        .doOnNext(this::cachePipelines)
+        .subscribe(pipelineSubject);
     }
   }
 
@@ -98,6 +101,26 @@ public class PipelineCache implements MonitoredPoller {
     return pollingIntervalSeconds;
   }
 
+  /**
+   * Returns an observable that emits the configured pipelines as of the most recent polling cycle.
+   * If no polling cycles have been completed, the observable will wait until the first cycle
+   * completes and then emit the pipelines from that polling cycle.
+   *
+   * @return An observable emitting the pipelines as of the most recent polling cycle
+   */
+  public Observable<List<Pipeline>> getPipelinesAsync() {
+    return pipelineSubject.take(1);
+  }
+
+  /**
+   * Returns the pipelines as of the most recent polling cycle.  If no polling cycles have been
+   * completed, returns an empty list.
+   *
+   * See {@link #getPipelinesAsync()} for an alternate way of getting pipelines that will wait at
+   * at least one polling cycle before returning a value.
+   *
+   * @return The pipelines as of the most recent polling cycle
+   */
   public List<Pipeline> getPipelines() {
     return pipelines.get();
   }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
@@ -74,6 +74,7 @@ public class PipelineCache implements MonitoredPoller {
         .flatMap(tick -> front50.getPipelines())
         .doOnError(this::onFront50Error)
         .retry()
+        .map(PipelineCache::decorateTriggers)
         .doOnNext(this::cachePipelines)
         .subscribe(pipelineSubject);
     }
@@ -127,7 +128,7 @@ public class PipelineCache implements MonitoredPoller {
 
   private void cachePipelines(final List<Pipeline> pipelines) {
     log.info("Refreshing pipelines");
-    this.pipelines.set(decorateTriggers(pipelines));
+    this.pipelines.set(pipelines);
   }
 
   private void onFront50Request(final long tick) {

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/PubsubEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/PubsubEventMonitorSpec.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.echo.test.RetrofitStubs
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact
 import groovy.json.JsonOutput
+import rx.Observable
 import rx.functions.Action1
 import spock.lang.Shared
 import spock.lang.Specification
@@ -82,7 +83,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
   def "triggers pipelines for successful builds for Google pubsub"() {
     given:
     def pipeline = createPipelineWith(goodExpectedArtifacts, trigger)
-    pipelineCache.getPipelines() >> [pipeline]
+    pipelineCache.getPipelinesAsync() >> Observable.just([pipeline])
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -104,7 +105,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
 
   def "attaches Google pubsub trigger to the pipeline"() {
     given:
-    pipelineCache.getPipelines() >> [pipeline]
+    pipelineCache.getPipelinesAsync() >> Observable.just([pipeline])
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -124,7 +125,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger #description pipelines for Google pubsub"() {
     given:
-    pipelineCache.getPipelines() >> [pipeline]
+    pipelineCache.getPipelinesAsync() >> Observable.just([pipeline])
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -145,7 +146,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger #description pipelines containing artifacts for Google pubsub"() {
     given:
-    pipelineCache.getPipelines() >> [pipeline]
+    pipelineCache.getPipelinesAsync() >> Observable.just([pipeline])
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -164,7 +165,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger a pipeline that has an enabled pubsub trigger with missing #field"() {
     given:
-    pipelineCache.getPipelines() >> [badPipeline, goodPipeline]
+    pipelineCache.getPipelinesAsync() >> Observable.just([badPipeline, goodPipeline])
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -195,7 +196,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
       .build()
 
     def pipeline = createPipelineWith(goodExpectedArtifacts, trigger)
-    pipelineCache.getPipelines() >> [pipeline]
+    pipelineCache.getPipelinesAsync() >> Observable.just([pipeline])
 
     when:
     def content = new PubsubEvent.Content()
@@ -232,7 +233,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
       .build()
 
     def pipeline = createPipelineWith(goodExpectedArtifacts, trigger)
-    pipelineCache.getPipelines() >> [pipeline]
+    pipelineCache.getPipelinesAsync() >> Observable.just([pipeline])
 
     when:
     def content = new PubsubEvent.Content()


### PR DESCRIPTION
This change causes the pubsub event processor to wait until pipelines have been polled at least once before processing pubsub messages.  This fixes a race condition whereby pubsub messages that were received immediately after startup were not triggering any pipelines.