### PR TITLE
feat(fiat): Delegate whether fiat is enabled to `FiatStatus`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
     ext {
-        springBootVersion = "1.5.4.RELEASE"
+        springBootVersion = "1.5.10.RELEASE"
     }
     repositories {
         jcenter()
@@ -36,7 +36,7 @@ allprojects {
     group = "com.netflix.spinnaker.echo"
 
     ext {
-        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.159.2'
+        spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.161.0'
     }
 
     def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/echo-pipelinetriggers/echo-pipelinetriggers.gradle
+++ b/echo-pipelinetriggers/echo-pipelinetriggers.gradle
@@ -18,6 +18,7 @@ dependencies {
   spinnaker.group("test")
   spinnaker.group("lombok")
   spinnaker.group("retrofitDefault")
+  spinnaker.group("fiat")
 
   compile project(':echo-core')
   compile spinnaker.dependency('korkWeb')

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/PipelineTriggerConfiguration.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/PipelineTriggerConfiguration.java
@@ -6,12 +6,16 @@ import com.netflix.spinnaker.echo.model.Pipeline;
 import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache;
 import com.netflix.spinnaker.echo.pipelinetriggers.monitor.PubsubEventMonitor;
 import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService;
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties;
+import com.netflix.spinnaker.fiat.shared.FiatStatus;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import com.squareup.okhttp.OkHttpClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -24,9 +28,10 @@ import rx.Scheduler;
 import rx.functions.Action1;
 import rx.schedulers.Schedulers;
 
+@Slf4j
 @Configuration
 @ComponentScan("com.netflix.spinnaker.echo.pipelinetriggers")
-@Slf4j
+@EnableConfigurationProperties(FiatClientConfigurationProperties.class)
 public class PipelineTriggerConfiguration {
   private Client retrofitClient;
 
@@ -53,6 +58,13 @@ public class PipelineTriggerConfiguration {
   @Bean
   public Client retrofitClient() {
     return new OkClient();
+  }
+
+  @Bean
+  public FiatStatus fiatStatus(Registry registry,
+                               DynamicConfigService dynamicConfigService,
+                               FiatClientConfigurationProperties fiatClientConfigurationProperties) {
+    return new FiatStatus(registry, dynamicConfigService, fiatClientConfigurationProperties);
   }
 
   @Bean

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiatorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiatorSpec.groovy
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.echo.pipelinetriggers.orca
 
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.echo.model.Pipeline
+import com.netflix.spinnaker.fiat.shared.FiatStatus
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -9,20 +10,22 @@ import spock.lang.Unroll
 import static rx.Observable.empty
 
 class PipelineInitiatorSpec extends Specification {
-
   def registry = new NoopRegistry()
   def orca = Mock(OrcaService)
+  def fiatStatus = Mock(FiatStatus)
+
 
   @Unroll
   def "calls orca #orcaCalls times when enabled=#enabled flag"() {
     given:
-    @Subject pipelineInitiator = new PipelineInitiator(registry, orca, enabled, false, 5, 5000)
+    def pipelineInitiator = new PipelineInitiator(registry, orca, fiatStatus, enabled, 5, 5000)
     def pipeline = Pipeline.builder().application("application").name("name").id("id").build()
 
     when:
     pipelineInitiator.call(pipeline)
 
     then:
+    _ * fiatStatus.isEnabled() >> { return enabled }
     orcaCalls * orca.trigger(pipeline) >> empty()
 
     where:

--- a/echo-web/src/main/groovy/com/netflix/spinnaker/echo/filters/EchoCorsFilter.groovy
+++ b/echo-web/src/main/groovy/com/netflix/spinnaker/echo/filters/EchoCorsFilter.groovy
@@ -30,7 +30,7 @@ import javax.servlet.http.HttpServletResponse
  * A filter to enable CORS access
  */
 @Component
-class CorsFilter implements Filter {
+class EchoCorsFilter implements Filter {
 
     void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
         HttpServletResponse response = (HttpServletResponse) res


### PR DESCRIPTION
This allows for fiat to be selectively enabled at runtime via the
DynamicConfigService (environment-specific).

`s/CorsFilter/EchoCorsFilter` to get around an equivalently named bean
in spring boot.

