### PR TITLE
chore(logs+tests): removing excessive logging, adding tests

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
@@ -22,9 +22,7 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -59,18 +57,17 @@ public class ArtifactMatcher {
    * Check that there is a key in the payload for each constraint declared in a Trigger.
    * Also check that if there is a value for a given key, that the value matches the value in the payload.
    * @param constraints A map of constraints configured in the Trigger (eg, created in Deck).
+   *                    A constraint is a [key, java regex value] pair.
    * @param payload A map of the payload contents POST'd in the triggering event.
    * @return Whether every key (and value if applicable) in the constraints map is represented in the payload.
    */
   public static boolean isConstraintInPayload(final Map constraints, final Map payload) {
     for (Object key : constraints.keySet()) {
       if (!payload.containsKey(key) || payload.get(key) == null) {
-        log.info("Trigger ignored. Constrained key entry " + key.toString() + " was not found in payload");
         return false;
       }
 
       if (constraints.get(key) != null && !matches(constraints.get(key).toString(), payload.get(key).toString()) ) {
-        log.info("Trigger ignored. Value of item " + key.toString() + " (" + payload.get(key) + ") in payload does not match constraint " + constraints.get(key));
         return false;
       }
     }

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcherSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcherSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pipelinetriggers.artifacts
+
+import spock.lang.Specification
+
+class ArtifactMatcherSpec extends Specification {
+
+  def matchPayload = [
+    "one": "one",
+    "two": "two",
+    "three": "three"
+  ]
+
+  def noMatchPayload = [
+      "four": "four",
+      "five": "five"
+  ]
+
+  def contstraints = [
+    "one": "one"
+  ]
+
+  def shortConstraint = [
+    "one": "o"
+  ]
+
+  def constraintsOR = [
+      "one": ["uno", "one"]
+  ]
+
+  def payloadWithList = [
+      "one": ["one"]
+  ]
+
+  def stringifiedListConstraints = [
+    "one": "['uno', 'one']"
+  ]
+
+  def "matches when constraint is partial word"() {
+    when:
+    boolean result = ArtifactMatcher.isConstraintInPayload(shortConstraint, matchPayload)
+
+    then:
+    result
+  }
+
+  def "matches exact string"() {
+    when:
+    boolean result = ArtifactMatcher.isConstraintInPayload(contstraints, matchPayload)
+
+    then:
+    result
+  }
+
+  def "no match when constraint word not present"() {
+    when:
+    boolean result = ArtifactMatcher.isConstraintInPayload(contstraints, noMatchPayload)
+
+    then:
+    !result
+  }
+
+  def "matches when payload value is in a list of constraint strings"() {
+    when:
+    boolean result = ArtifactMatcher.isConstraintInPayload(constraintsOR, matchPayload)
+
+    then:
+    result
+  }
+
+  def "no match when val not present in list of constraint strings"() {
+    when:
+    boolean result = ArtifactMatcher.isConstraintInPayload(constraintsOR, noMatchPayload)
+
+    then:
+    !result
+  }
+
+  def "matches when val is in stringified list of constraints"() {
+    when:
+    boolean result = ArtifactMatcher.isConstraintInPayload(stringifiedListConstraints, matchPayload)
+
+    then:
+    result
+  }
+
+  def "matches when payload contains list and constraint is a stringified list"() {
+    when:
+    boolean result = ArtifactMatcher.isConstraintInPayload(stringifiedListConstraints, payloadWithList)
+
+    then:
+    result
+  }
+
+  def "matches when payload is a list list and constraints are a list"() {
+    when:
+    boolean result = ArtifactMatcher.isConstraintInPayload(constraintsOR, payloadWithList)
+
+    then:
+    result
+  }
+}

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/AmazonMessageAcknowledger.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/AmazonMessageAcknowledger.java
@@ -52,7 +52,6 @@ public class AmazonMessageAcknowledger implements MessageAcknowledger {
     // Delete from queue
     try {
       amazonSQS.deleteMessage(queueUrl, message.getReceiptHandle());
-      log.debug("Deleted message: {} from queue {}", message.getMessageId(), queueUrl);
       registry.counter(getProcessedMetricId(subscriptionName)).increment();
     } catch (ReceiptHandleIsInvalidException e) {
       log.warn(

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
@@ -169,8 +169,6 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
       Map<String, String> stringifiedMessageAttributes = message.getMessageAttributes().entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, e -> String.valueOf(e.getValue())));
 
-      log.debug("Received Amazon sqs message: {} with payload: {} and attributes: {}", messageId, messagePayload, stringifiedMessageAttributes);
-
       MessageDescription description = MessageDescription.builder()
         .subscriptionName(subscriptionName())
         .messagePayload(messagePayload)
@@ -194,14 +192,10 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
 
   private List<Artifact> parseArtifacts(String messagePayload, String messageId){
     List<Artifact> artifacts = messageArtifactTranslator.parseArtifacts(messagePayload);
-    if (artifacts == null || artifacts.size() == 0) {
-      log.debug("No artifacts were found for subscription: {} and messageId: {}", subscription.getName(), messageId);
-    } else {
-      log.debug(
-        "Artifacts found for subscription: {}: {}",
-        subscription.getName(),
-        String.join(", ", artifacts.stream().map(Artifact::toString).collect(Collectors.toList()))
-      );
+    // Artifact must have at least a reference defined.
+    if (artifacts == null || artifacts.size() == 0
+        || artifacts.get(0).getReference() == null || artifacts.get(0).getReference().equals("")) {
+      return Collections.emptyList();
     }
     return artifacts;
   }

--- a/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandler.java
+++ b/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandler.java
@@ -113,8 +113,7 @@ public class PubsubMessageHandler {
 
 
   private void processEvent(MessageDescription description) {
-    log.info("Processed Pubsub event with payload {}", description.getMessagePayload());
-
+    log.debug("Processing pubsub event with payload {}", description.getMessagePayload());
     Event event = new Event();
     Map<String, Object> content = new HashMap<>();
     Metadata details = new Metadata();


### PR DESCRIPTION
The logging around pubsub is a little excessive. I'd like to trim down the log messages produced and rely on emitting metrics for number of messages processed etc.

Also adding tests for ArtifactMatcher and adding clarifying text around usage of `isConstraintInPayload`