### PR TITLE
fix(docker): fixed command to add spinnaker user

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -6,7 +6,7 @@ COPY ./echo-web/build/install/echo /opt/echo
 
 RUN apk --no-cache add --update bash
 
-RUN useradd -m spinnaker -U
+RUN adduser -D -S spinnaker
 
 USER spinnaker
 


### PR DESCRIPTION
`useradd` was causing build errors:

```
...
Step 5/7 : RUN useradd -m spinnaker -U
 ---> Running in 7fabf6d609a4
/bin/sh: useradd: not found
```

so I fixed it match the other services.
ex:
igor: https://github.com/spinnaker/igor/blob/master/Dockerfile.slim#L9
clouddriver: https://github.com/spinnaker/igor/blob/master/Dockerfile.slim#L9
orca: https://github.com/spinnaker/orca/blob/master/Dockerfile.slim#L9