### PR TITLE
fix(notifications): Support email notifications with ' ' in them

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/email/EmailNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/email/EmailNotificationService.groovy
@@ -55,8 +55,8 @@ class EmailNotificationService implements NotificationService {
 
   @Override
   EchoResponse.Void handle(Notification notification) {
-    def to = notification.to as String[]
-    def cc = notification.cc as String[]
+    def to = notification.to?.collect { it.split(" ") }?.flatten() as String[]
+    def cc = notification.cc?.collect { it.split(" ") }?.flatten() as String[]
     def subject = notificationTemplateEngine.build(notification, NotificationTemplateEngine.Type.SUBJECT)
     def body = notificationTemplateEngine.build(notification, NotificationTemplateEngine.Type.BODY)
 


### PR DESCRIPTION
Handle the situation where someone has configured a notification with
' '-separated email addresses (vs. presumably comma separation).
