### PR TITLE
feat(pubsub): allow custom jinjava

### DIFF
--- a/echo-core/src/main/groovy/com/netflix/spinnaker/echo/artifacts/DefaultJinjavaFactory.java
+++ b/echo-core/src/main/groovy/com/netflix/spinnaker/echo/artifacts/DefaultJinjavaFactory.java
@@ -1,0 +1,16 @@
+package com.netflix.spinnaker.echo.artifacts;
+
+import com.hubspot.jinjava.Jinjava;
+
+/**
+ * Creates a regular jinjava.
+ * You can overwrite this to create a custom jinjava with
+ *  things like custom filters and tags.
+ */
+public class DefaultJinjavaFactory implements JinjavaFactory {
+
+  @Override
+  public Jinjava create() {
+    return new Jinjava();
+  }
+}

--- a/echo-core/src/main/groovy/com/netflix/spinnaker/echo/artifacts/JinjavaFactory.java
+++ b/echo-core/src/main/groovy/com/netflix/spinnaker/echo/artifacts/JinjavaFactory.java
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.echo.artifacts;
+
+import com.hubspot.jinjava.Jinjava;
+
+public interface JinjavaFactory {
+
+  Jinjava create();
+}

--- a/echo-core/src/main/groovy/com/netflix/spinnaker/echo/config/EchoCoreConfig.groovy
+++ b/echo-core/src/main/groovy/com/netflix/spinnaker/echo/config/EchoCoreConfig.groovy
@@ -16,11 +16,14 @@
 
 package com.netflix.spinnaker.echo.config
 
+import com.netflix.spinnaker.echo.artifacts.DefaultJinjavaFactory
+import com.netflix.spinnaker.echo.artifacts.JinjavaFactory
 import com.netflix.spinnaker.echo.discovery.DiscoveryPollingConfiguration
 import com.netflix.spinnaker.echo.events.EchoEventListener
 import com.netflix.spinnaker.echo.events.EventPropagator
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
@@ -46,5 +49,11 @@ class EchoCoreConfig {
             instance.addListener(it)
         }
         instance
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    JinjavaFactory jinjavaFactory() {
+      return new DefaultJinjavaFactory()
     }
 }

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
@@ -24,6 +24,7 @@ import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.echo.artifacts.JinjavaFactory;
 import com.netflix.spinnaker.echo.artifacts.MessageArtifactTranslator;
 import com.netflix.spinnaker.echo.config.AmazonPubsubProperties;
 import com.netflix.spinnaker.echo.model.pubsub.MessageDescription;
@@ -81,7 +82,8 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
                        AmazonSNS amazonSNS,
                        AmazonSQS amazonSQS,
                        Supplier<Boolean> isEnabled,
-                       Registry registry) {
+                       Registry registry,
+                       JinjavaFactory jinjavaFactory) {
     this.objectMapper = objectMapper;
     this.subscription = subscription;
     this.pubsubMessageHandler = pubsubMessageHandler;
@@ -90,7 +92,7 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
     this.isEnabled = isEnabled;
     this.registry = registry;
 
-    this.messageArtifactTranslator = new MessageArtifactTranslator(subscription.readTemplatePath());
+    this.messageArtifactTranslator = new MessageArtifactTranslator(subscription.readTemplatePath(), jinjavaFactory);
     this.queueARN = new ARN(subscription.getQueueARN());
     this.topicARN = new ARN(subscription.getTopicARN());
   }

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriberProvider.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriberProvider.java
@@ -22,6 +22,7 @@ import com.amazonaws.services.sns.AmazonSNSClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.echo.artifacts.JinjavaFactory;
 import com.netflix.spinnaker.echo.config.AmazonPubsubProperties;
 import com.netflix.spinnaker.echo.discovery.DiscoveryActivated;
 import com.netflix.spinnaker.echo.pubsub.PubsubMessageHandler;
@@ -55,6 +56,7 @@ public class SQSSubscriberProvider implements DiscoveryActivated {
   private final PubsubSubscribers pubsubSubscribers;
   private final PubsubMessageHandler pubsubMessageHandler;
   private final Registry registry;
+  private final JinjavaFactory jinjavaFactory;
 
   @Autowired
   SQSSubscriberProvider(ObjectMapper objectMapper,
@@ -62,13 +64,15 @@ public class SQSSubscriberProvider implements DiscoveryActivated {
                         AmazonPubsubProperties properties,
                         PubsubSubscribers pubsubSubscribers,
                         PubsubMessageHandler pubsubMessageHandler,
-                        Registry registry) {
+                        Registry registry,
+                        JinjavaFactory jinjavaFactory) {
     this.objectMapper = objectMapper;
     this.awsCredentialsProvider = awsCredentialsProvider;
     this.properties = properties;
     this.pubsubSubscribers = pubsubSubscribers;
     this.pubsubMessageHandler = pubsubMessageHandler;
     this.registry = registry;
+    this.jinjavaFactory = jinjavaFactory;
   }
 
   @PostConstruct
@@ -108,7 +112,8 @@ public class SQSSubscriberProvider implements DiscoveryActivated {
           .withRegion(queueArn.getRegion())
           .build(),
         () -> enabled.get(),
-        registry
+        registry,
+        jinjavaFactory
       );
 
       try {

--- a/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
+++ b/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
@@ -20,6 +20,8 @@ import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sqs.AmazonSQS
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.echo.artifacts.DefaultJinjavaFactory
+import com.netflix.spinnaker.echo.artifacts.JinjavaFactory
 import com.netflix.spinnaker.echo.config.AmazonPubsubProperties
 import com.netflix.spinnaker.echo.pubsub.PubsubMessageHandler
 import com.netflix.spinnaker.kork.aws.ARN
@@ -50,7 +52,9 @@ class AmazonSQSSubscriberSpec extends Specification {
     amazonSNS,
     amazonSQS,
     {true},
-    registry)
+    registry,
+    new DefaultJinjavaFactory()
+  )
 
   def 'should unmarshall an sns notification message'() {
     given:


### PR DESCRIPTION
Doing this so that you can add custom jinja filters and tags in and load them. No change in functionality from a google or pubsub perspective, I'm just building off of it for a custom trigger.