### PR TITLE
feat(trigger): provide link to triggering event and link text

### DIFF
--- a/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/BuildEvent.groovy
+++ b/echo-model/src/main/groovy/com/netflix/spinnaker/echo/model/trigger/BuildEvent.groovy
@@ -49,6 +49,7 @@ class BuildEvent extends TriggerEvent {
     boolean building
     int number
     Result result
+    String url
     List<Artifact> artifacts
   }
 

--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 @JsonDeserialize(builder = Trigger.TriggerBuilder.class)
 @Builder(toBuilder = true)
 @Wither
-@ToString(of = {"id", "parent", "type", "master", "job", "cronExpression", "source", "project", "slug", "account", "repository", "tag", "parameters", "payloadConstraints", "attributeConstraints", "branch", "runAsUser", "subscriptionName", "pubsubSystem", "expectedArtifactIds", "payload", "status", "artifactName"}, includeFieldNames = false)
+@ToString(of = {"id", "parent", "type", "master", "job", "cronExpression", "source", "project", "slug", "account", "repository", "tag", "parameters", "payloadConstraints", "attributeConstraints", "branch", "runAsUser", "subscriptionName", "pubsubSystem", "expectedArtifactIds", "payload", "status", "artifactName", "link", "linkText"}, includeFieldNames = false)
 @Value
 public class Trigger {
   public enum Type {
@@ -108,6 +108,12 @@ public class Trigger {
    * Field to use for custom triggers involving artifacts
    */
   String artifactName;
+
+  // url to triggering event
+  String link;
+
+  // text to display when linking to triggering event
+  String linkText;
 
   // this is set after deserialization, not in the json representation
   @JsonIgnore

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/BuildEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/BuildEventMonitor.java
@@ -85,8 +85,10 @@ public class BuildEventMonitor extends TriggerMonitor {
   @Override
   protected Function<Trigger, Pipeline> buildTrigger(Pipeline pipeline, TriggerEvent event) {
     BuildEvent buildEvent = (BuildEvent) event;
-    return trigger -> pipeline.withTrigger(trigger.atBuildNumber(buildEvent.getBuildNumber()).withEventId(event.getEventId()))
-      .withReceivedArtifacts(getArtifacts(buildEvent));
+    return trigger -> pipeline.withTrigger(trigger.atBuildNumber(buildEvent.getBuildNumber())
+                                                  .withEventId(event.getEventId())
+                                                  .withLink(buildEvent.getContent().getProject().getLastBuild().getUrl()))
+                              .withReceivedArtifacts(getArtifacts(buildEvent));
   }
 
   @Override


### PR DESCRIPTION
In the Pipeline UI, we have great support for linking back to a build job. This support is not great when the event is not a build, because we hardcode "Build #X" in the UI, and scrape the url from `trigger.buildInfo.url`.

<img width="311" alt="screen shot 2018-08-13 at 11 50 22 am" src="https://user-images.githubusercontent.com/8454927/44051694-66c62940-9eef-11e8-9f8f-2e8215424f3b.png">

This PR provides two fields in the trigger:
- trigger.link = the link to the event that caused this trigger
- trigger.linkText = the text to display for a trigger. There is a UI refactor coming (@erikmunson ) that will allow triggers to provided their own logic, and this field will be removed, but for now you can build the correct text and provide it when you build the trigger, and the UI will soon display that.

This PR pulls the build URL for jenkins triggers as a first step.

@tomaslin can you think of any problems with adding a field to the `BuildEvent` object? This field is already present in the jenkins payload we have, just surfacing it in Echo.