### PR TITLE
fix(artifacts): Fix NPE when no artifact is found in pubsub message. …

### DIFF
--- a/echo-core/src/main/groovy/com/netflix/spinnaker/echo/artifacts/MessageArtifactTranslator.java
+++ b/echo-core/src/main/groovy/com/netflix/spinnaker/echo/artifacts/MessageArtifactTranslator.java
@@ -103,6 +103,6 @@ public class MessageArtifactTranslator {
       // there is no template and no artifacts are expected
       log.warn("Unable to parse artifact from {}", hydratedTemplate);
     }
-    return null;
+    return Collections.EMPTY_LIST;
   }
 }


### PR DESCRIPTION
…Specifically the NPE is from [this line](https://github.com/ttomsu/echo/blob/ad32e054fd0a547e0b40f09c10dc1f4a66f94bbc/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubSubscriber.java#L207), and this change just ensures the  variable is not null.
