### PR TITLE
fix(pubsub): echo starts up when pubsub not enabled

### DIFF
--- a/echo-pubsub-core/src/test/groovy/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandlerSpec.groovy
+++ b/echo-pubsub-core/src/test/groovy/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandlerSpec.groovy
@@ -42,7 +42,7 @@ class PubsubMessageHandlerSpec extends Specification {
   RedisClientDelegate redisClientDelegate
 
   @Shared
-  RedisClientSelector redisClientSelector
+  Optional<RedisClientSelector> redisClientSelector
 
   MessageDigest messageDigest = MessageDigest.getInstance("SHA-256")
 
@@ -58,7 +58,7 @@ class PubsubMessageHandlerSpec extends Specification {
   def setupSpec() {
     embeddedRedis = EmbeddedRedis.embed()
     redisClientDelegate = new JedisClientDelegate("primaryDefault", embeddedRedis.getPool())
-    redisClientSelector = new RedisClientSelector([redisClientDelegate])
+    redisClientSelector = Optional.of(new RedisClientSelector([redisClientDelegate]))
   }
 
   def cleanup() {


### PR DESCRIPTION
Make `redisClientSelector` optional so that if pubsub is not enabled echo actually starts up. 
Throw exception when redis is not enabled but pubsub is.