### PR TITLE
feat(pubsub): add sqs msgattr parsing, optional id in msgattrs

### DIFF
--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubProperties.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubProperties.java
@@ -52,9 +52,14 @@ public class AmazonPubsubProperties {
 
     private MessageFormat messageFormat;
 
+    private boolean idInMessageAttributes;
+
     int visibilityTimeout = 30;
     int sqsMessageRetentionPeriodSeconds = 120;
     int waitTimeSeconds = 5;
+
+    // 1 hour default
+    private Long dedupeRetentionMillis = 3600000L;
 
     public AmazonPubsubSubscription() {
     }
@@ -64,12 +69,23 @@ public class AmazonPubsubProperties {
       String topicARN,
       String queueARN,
       String templatePath,
-      MessageFormat messageFormat) {
+      MessageFormat messageFormat,
+      boolean idInMessageAttributes,
+      Long dedupeRetentionMillis
+    ) {
       this.name = name;
       this.topicARN = topicARN;
       this.queueARN = queueARN;
       this.templatePath = templatePath;
       this.messageFormat = messageFormat;
+      this.idInMessageAttributes = idInMessageAttributes;
+      if (dedupeRetentionMillis != null && dedupeRetentionMillis >= 0) {
+        this.dedupeRetentionMillis = dedupeRetentionMillis;
+      } else {
+        if (dedupeRetentionMillis != null) {
+          log.warn("Ignoring dedupeRetentionMillis invalid value of " + dedupeRetentionMillis);
+        }
+      }
     }
 
     private MessageFormat determineMessageFormat(){

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/MessageAttributeWrapper.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/MessageAttributeWrapper.java
@@ -1,0 +1,22 @@
+package com.netflix.spinnaker.echo.pubsub.aws;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class MessageAttributeWrapper {
+
+  @JsonProperty("Type")
+  private String attributeType;
+
+  @JsonProperty("Value")
+  private String attributeValue;
+
+  public MessageAttributeWrapper() {
+  }
+
+  public MessageAttributeWrapper(String attributeType, String attributeValue) {
+    this.attributeType = attributeType;
+    this.attributeValue= attributeValue;
+  }
+}

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/NotificationMessageWrapper.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/NotificationMessageWrapper.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
+import java.util.Map;
+
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class NotificationMessageWrapper {
@@ -38,14 +40,18 @@ public class NotificationMessageWrapper {
   @JsonProperty("Message")
   private String message;
 
+  @JsonProperty("MessageAttributes")
+  private Map<String, MessageAttributeWrapper> messageAttributes;
+
   public NotificationMessageWrapper() {
   }
 
-  public NotificationMessageWrapper(String type, String messageId, String topicArn, String subject, String message) {
+  public NotificationMessageWrapper(String type, String messageId, String topicArn, String subject, String message, Map messageAttributes) {
     this.type = type;
     this.messageId = messageId;
     this.topicArn = topicArn;
     this.subject = subject;
     this.message = message;
+    this.messageAttributes = messageAttributes;
   }
 }

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
@@ -168,13 +168,13 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
   private void handleMessage(Message message) {
     try {
       String messageId = message.getMessageId();
-      String messagePayload = unmarshallMessageBody(message.getBody());
+      String messagePayload = unmarshalMessageBody(message.getBody());
 
       Map<String, String> stringifiedMessageAttributes = message.getMessageAttributes().entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, e -> String.valueOf(e.getValue())));
 
       //SNS message attributes are stored within the SQS message body. Add them to other attributes..
-      Map<String, MessageAttributeWrapper> messageAttributes = unmarshallMessageAttributes(message.getBody());
+      Map<String, MessageAttributeWrapper> messageAttributes = unmarshalMessageAttributes(message.getBody());
       stringifiedMessageAttributes.putAll(messageAttributes.entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getAttributeValue())));
 
@@ -220,7 +220,7 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
     return artifacts;
   }
 
-  private String unmarshallMessageBody(String messageBody) {
+  private String unmarshalMessageBody(String messageBody) {
     String messagePayload = messageBody;
     try {
       NotificationMessageWrapper wrapper = objectMapper.readValue(messagePayload, NotificationMessageWrapper.class);
@@ -231,7 +231,7 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
       // Try to unwrap a notification message; if that doesn't work,
       // we're dealing with a message we can't parse. The template or
       // the pipeline potentially knows how to deal with it.
-      log.error("Unable unmarshall NotificationMessageWrapper. Unknown message type. (body: {})", messageBody, e);
+      log.error("Unable unmarshal NotificationMessageWrapper. Unknown message type. (body: {})", messageBody, e);
     }
     return messagePayload;
   }
@@ -240,7 +240,7 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
    * If there is an error parsing message attributes because the message is not a notification message,
    * an empty map will be returned.
    */
-  private Map<String, MessageAttributeWrapper> unmarshallMessageAttributes(String messageBody) {
+  private Map<String, MessageAttributeWrapper> unmarshalMessageAttributes(String messageBody) {
     try {
       NotificationMessageWrapper wrapper = objectMapper.readValue(messageBody, NotificationMessageWrapper.class);
       if (wrapper != null && wrapper.getMessageAttributes() != null) {

--- a/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
+++ b/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
@@ -55,7 +55,7 @@ class AmazonSQSSubscriberSpec extends Specification {
     new DefaultJinjavaFactory()
   )
 
-  def 'should unmarshall an sns notification message'() {
+  def 'should unmarshal an sns notification message'() {
     given:
     String payload = '''
       {\"Records\":[
@@ -82,7 +82,7 @@ class AmazonSQSSubscriberSpec extends Specification {
     String snsMesssage = objectMapper.writeValueAsString(notificationMessage)
 
     when:
-    String result = subject.unmarshallMessageBody(snsMesssage)
+    String result = subject.unmarshalMessageBody(snsMesssage)
 
     then:
     0 * subject.log.error()

--- a/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
+++ b/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
@@ -21,7 +21,6 @@ import com.amazonaws.services.sqs.AmazonSQS
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.echo.artifacts.DefaultJinjavaFactory
-import com.netflix.spinnaker.echo.artifacts.JinjavaFactory
 import com.netflix.spinnaker.echo.config.AmazonPubsubProperties
 import com.netflix.spinnaker.echo.pubsub.PubsubMessageHandler
 import com.netflix.spinnaker.kork.aws.ARN
@@ -39,7 +38,7 @@ class AmazonSQSSubscriberSpec extends Specification {
   ARN queueARN = new ARN("arn:aws:sqs:us-west-2:100:queueName")
   ARN topicARN = new ARN("arn:aws:sns:us-west-2:100:topicName")
   AmazonPubsubProperties.AmazonPubsubSubscription subscription =
-    new AmazonPubsubProperties.AmazonPubsubSubscription('aws_events', topicARN.arn, queueARN.arn, "", null)
+    new AmazonPubsubProperties.AmazonPubsubSubscription('aws_events', topicARN.arn, queueARN.arn, "", null, false, 3600L)
 
   @Shared
   def objectMapper = new ObjectMapper()
@@ -77,7 +76,8 @@ class AmazonSQSSubscriberSpec extends Specification {
       "4444-ffff",
       "arn:aws:sns:us-west-2:100:topicName",
       "Amazon S3 Notification",
-      payload
+      payload,
+      [:]
     )
     String snsMesssage = objectMapper.writeValueAsString(notificationMessage)
 


### PR DESCRIPTION
When you set message attributes on an SNS message, and then an SQS queue pulls that message, the message attributes aren't translated to the SQS message attributes field. Instead, they're in a `MessageAttributes` map on the message body. 

Adding the ability to parse sns message attributes and add them to the list of message attributes.

In order to dedupe client messages as well as sqs messages, I'm allowing you to provide an id to dedupe with. This will be present in a message attribute field with key `id`, like below:
```
pubsub:
  amazon:
    enabled: true
    subscriptions:
    - name: echo_events
      topicARN: arn:aws:sns....
      queueARN: arn:aws:sqs....
      templatePath: /sqs.jinja
      idInMessageAttributes: true #this is the new, optional field
```
This will still work with at least once delivery because any message delivered more than once will have the same content.