### PR TITLE
feat(pubsub): allow alternate id in msg attrs and define key

### DIFF
--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubProperties.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubProperties.java
@@ -52,7 +52,13 @@ public class AmazonPubsubProperties {
 
     private MessageFormat messageFormat;
 
-    private boolean idInMessageAttributes;
+    /**
+     * Provide an id, present in the message attributes as a string,
+     * to use as a unique identifier for processing messages.
+     * Fall back to amazon sqs id if alternate Id is not present in
+     * the message attributes
+     */
+    private String alternateIdInMessageAttributes;
 
     int visibilityTimeout = 30;
     int sqsMessageRetentionPeriodSeconds = 120;
@@ -70,7 +76,7 @@ public class AmazonPubsubProperties {
       String queueARN,
       String templatePath,
       MessageFormat messageFormat,
-      boolean idInMessageAttributes,
+      String alternateIdInMessageAttributes,
       Long dedupeRetentionMillis
     ) {
       this.name = name;
@@ -78,7 +84,7 @@ public class AmazonPubsubProperties {
       this.queueARN = queueARN;
       this.templatePath = templatePath;
       this.messageFormat = messageFormat;
-      this.idInMessageAttributes = idInMessageAttributes;
+      this.alternateIdInMessageAttributes = alternateIdInMessageAttributes;
       if (dedupeRetentionMillis != null && dedupeRetentionMillis >= 0) {
         this.dedupeRetentionMillis = dedupeRetentionMillis;
       } else {

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
@@ -198,9 +198,11 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
         }
       }
 
-      if (subscription.isIdInMessageAttributes() && stringifiedMessageAttributes.containsKey("id")){
+      if (subscription.getAlternateIdInMessageAttributes() != null
+          && !subscription.getAlternateIdInMessageAttributes().isEmpty()
+          && stringifiedMessageAttributes.containsKey(subscription.getAlternateIdInMessageAttributes())){
         // Message attributes contain the unique id used for deduping
-        messageId = stringifiedMessageAttributes.get("id");
+        messageId = stringifiedMessageAttributes.get(subscription.getAlternateIdInMessageAttributes());
       }
 
       pubsubMessageHandler.handleMessage(description, acknowledger, identity.getIdentity(), messageId);

--- a/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
+++ b/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
@@ -38,7 +38,7 @@ class AmazonSQSSubscriberSpec extends Specification {
   ARN queueARN = new ARN("arn:aws:sqs:us-west-2:100:queueName")
   ARN topicARN = new ARN("arn:aws:sns:us-west-2:100:topicName")
   AmazonPubsubProperties.AmazonPubsubSubscription subscription =
-    new AmazonPubsubProperties.AmazonPubsubSubscription('aws_events', topicARN.arn, queueARN.arn, "", null, false, 3600L)
+    new AmazonPubsubProperties.AmazonPubsubSubscription('aws_events', topicARN.arn, queueARN.arn, "", null, null, 3600L)
 
   @Shared
   def objectMapper = new ObjectMapper()


### PR DESCRIPTION
Instead of assuming the field is `id`, allow specification of the field name. 