### PR TITLE
chore(pubsub): switch to seconds and setex redis command

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/pubsub/MessageDescription.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/pubsub/MessageDescription.java
@@ -47,9 +47,9 @@ public class MessageDescription {
 
   private PubsubSystem pubsubSystem;
 
-  private Long ackDeadlineMillis;
+  private Integer ackDeadlineSeconds;
 
-  private Long retentionDeadlineMillis;
+  private Integer retentionDeadlineSeconds;
 
   /**
    * List of artifacts parsed from the pub/sub message.

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/PubsubEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/PubsubEventMonitorSpec.groovy
@@ -190,7 +190,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
 
     def description = MessageDescription.builder()
       .pubsubSystem(PubsubSystem.GOOGLE)
-      .ackDeadlineMillis(10000)
+      .ackDeadlineSeconds(1)
       .subscriptionName("projects/project/subscriptions/subscription")
       .messagePayload(JsonOutput.toJson([key: 'value']))
       .build()
@@ -226,7 +226,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
 
     def description = MessageDescription.builder()
       .pubsubSystem(PubsubSystem.GOOGLE)
-      .ackDeadlineMillis(10000)
+      .ackDeadlineSeconds(1)
       .subscriptionName("projects/project/subscriptions/subscription")
       .messagePayload(JsonOutput.toJson([key: 'value']))
       .messageAttributes([key: 'value'])

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubProperties.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubProperties.java
@@ -65,7 +65,7 @@ public class AmazonPubsubProperties {
     int waitTimeSeconds = 5;
 
     // 1 hour default
-    private Long dedupeRetentionMillis = 3600000L;
+    private Integer dedupeRetentionSeconds = 3600;
 
     public AmazonPubsubSubscription() {
     }
@@ -77,7 +77,7 @@ public class AmazonPubsubProperties {
       String templatePath,
       MessageFormat messageFormat,
       String alternateIdInMessageAttributes,
-      Long dedupeRetentionMillis
+      Integer dedupeRetentionSeconds
     ) {
       this.name = name;
       this.topicARN = topicARN;
@@ -85,11 +85,11 @@ public class AmazonPubsubProperties {
       this.templatePath = templatePath;
       this.messageFormat = messageFormat;
       this.alternateIdInMessageAttributes = alternateIdInMessageAttributes;
-      if (dedupeRetentionMillis != null && dedupeRetentionMillis >= 0) {
-        this.dedupeRetentionMillis = dedupeRetentionMillis;
+      if (dedupeRetentionSeconds != null && dedupeRetentionSeconds >= 0) {
+        this.dedupeRetentionSeconds = dedupeRetentionSeconds;
       } else {
-        if (dedupeRetentionMillis != null) {
-          log.warn("Ignoring dedupeRetentionMillis invalid value of " + dedupeRetentionMillis);
+        if (dedupeRetentionSeconds != null) {
+          log.warn("Ignoring dedupeRetentionSeconds invalid value of " + dedupeRetentionSeconds);
         }
       }
     }

--- a/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
+++ b/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
@@ -38,7 +38,7 @@ class AmazonSQSSubscriberSpec extends Specification {
   ARN queueARN = new ARN("arn:aws:sqs:us-west-2:100:queueName")
   ARN topicARN = new ARN("arn:aws:sns:us-west-2:100:topicName")
   AmazonPubsubProperties.AmazonPubsubSubscription subscription =
-    new AmazonPubsubProperties.AmazonPubsubSubscription('aws_events', topicARN.arn, queueARN.arn, "", null, null, 3600L)
+    new AmazonPubsubProperties.AmazonPubsubSubscription('aws_events', topicARN.arn, queueARN.arn, "", null, null, 3600)
 
   @Shared
   def objectMapper = new ObjectMapper()

--- a/echo-pubsub-core/src/test/groovy/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandlerSpec.groovy
+++ b/echo-pubsub-core/src/test/groovy/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandlerSpec.groovy
@@ -71,7 +71,7 @@ class PubsubMessageHandlerSpec extends Specification {
     given:
     String key = 'key'
     String id = 'id'
-    Long ackDeadline = 1000
+    Integer ackDeadline = 1
 
     when:
     def resp = pubsubMessageHandler.acquireMessageLock(key, id, ackDeadline)
@@ -84,7 +84,7 @@ class PubsubMessageHandlerSpec extends Specification {
     given:
     String key = 'key'
     String id = 'id'
-    Long ackDeadline = 1000
+    Integer ackDeadline = 1
 
     when:
     pubsubMessageHandler.acquireMessageLock(key, id, ackDeadline)
@@ -98,11 +98,11 @@ class PubsubMessageHandlerSpec extends Specification {
     given:
     String key = 'key'
     String id = 'id'
-    Long ackDeadline = 10
+    Integer ackDeadline = 1
 
     when:
     pubsubMessageHandler.acquireMessageLock(key, id, ackDeadline)
-    sleep(15)
+    sleep(1005)
     def resp = pubsubMessageHandler.acquireMessageLock(key, id, ackDeadline)
 
     then:
@@ -113,8 +113,8 @@ class PubsubMessageHandlerSpec extends Specification {
     given:
     String key = 'key'
     String id = 'id'
-    Long ackDeadline = 100
-    Long retentionDeadline = 1000
+    Integer ackDeadline = 1
+    Integer retentionDeadline = 5
 
     when:
     pubsubMessageHandler.setMessageHandled(key, id, retentionDeadline)
@@ -131,8 +131,8 @@ class PubsubMessageHandlerSpec extends Specification {
     .subscriptionName('subscriptionName')
     .messagePayload('THE TRUTH IS OUT THERE')
     .pubsubSystem(PubsubSystem.GOOGLE)
-    .ackDeadlineMillis(1000)
-    .retentionDeadlineMillis(10001)
+    .ackDeadlineSeconds(1)
+    .retentionDeadlineSeconds(2)
     .build()
 
     def acker = Mock(MessageAcknowledger)
@@ -154,8 +154,8 @@ class PubsubMessageHandlerSpec extends Specification {
         .subscriptionName('subscriptionName')
         .messagePayload('THE TRUTH IS OUT THERE')
         .pubsubSystem(PubsubSystem.GOOGLE)
-        .ackDeadlineMillis(1000)
-        .retentionDeadlineMillis(10001)
+        .ackDeadlineSeconds(1)
+        .retentionDeadlineSeconds(2)
         .build()
 
     def acker = Mock(MessageAcknowledger)

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubSubscriber.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubSubscriber.java
@@ -187,8 +187,8 @@ public class GooglePubsubSubscriber implements PubsubSubscriber {
         .messagePayload(messagePayload)
         .messageAttributes(messageAttributes)
         .pubsubSystem(pubsubSystem)
-        .ackDeadlineMillis(5 * TimeUnit.SECONDS.toMillis(ackDeadlineSeconds)) // Set a high upper bound on message processing time.
-        .retentionDeadlineMillis(TimeUnit.DAYS.toMillis(7)) // Expire key after max retention time, which is 7 days.
+        .ackDeadlineSeconds(5 * ackDeadlineSeconds) // Set a high upper bound on message processing time.
+        .retentionDeadlineSeconds(7 * 24 * 60 * 60) // Expire key after max retention time, which is 7 days.
         .build();
       GoogleMessageAcknowledger acknowledger = new GoogleMessageAcknowledger(consumer);
 

--- a/echo-test/src/main/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
+++ b/echo-test/src/main/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
@@ -99,7 +99,7 @@ trait RetrofitStubs {
 
     def description = MessageDescription.builder()
         .pubsubSystem(pubsubSystem)
-        .ackDeadlineMillis(10000)
+        .ackDeadlineSeconds(1)
         .subscriptionName(subscriptionName)
         .artifacts(artifacts)
         .build()


### PR DESCRIPTION
We use Dynomite internally, and the `psetex` command is not implemented. Switching to seconds here, and `setex` (which is supported for us). Sound ok?