### PR TITLE
chore(pubsub): add a global enable flag for pubsub

### DIFF
--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubConfig.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubConfig.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.echo.config;
 
 import com.netflix.spinnaker.kork.aws.bastion.BastionConfig;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Import;
 import javax.validation.Valid;
 
 @Configuration
-@ConditionalOnProperty("pubsub.amazon.enabled")
+@ConditionalOnExpression("${pubsub.enabled:false} && ${pubsub.amazon.enabled:false}")
 @Import(BastionConfig.class)
 @EnableConfigurationProperties(AmazonPubsubProperties.class)
 public class AmazonPubsubConfig {

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/config/GooglePubsubConfig.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/config/GooglePubsubConfig.java
@@ -32,13 +32,13 @@ import javax.annotation.PostConstruct;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @Slf4j
-@ConditionalOnProperty("pubsub.google.enabled")
+@ConditionalOnExpression("${pubsub.enabled:false} && ${pubsub.google.enabled:false}")
 @EnableConfigurationProperties(GooglePubsubProperties.class)
 public class GooglePubsubConfig {
 


### PR DESCRIPTION
If a particular echo profile wants to disable all pubsub, it currently
needs to do it for each pubsub provider. This is brittle, as new pubsub
providers may be added later.

It can now be disabled globally with

  pubsub:
    enabled: false
