### PR TITLE
 fix(core): Ensure event processing occurs in the same thread

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
@@ -111,6 +111,10 @@ public class PipelineCache implements MonitoredPoller {
     return pipelineSubject.take(1);
   }
 
+  public List<Pipeline> getPipelinesSync() {
+    return getPipelines().toBlocking().first();
+  }
+
   private void logRefresh(final List<Pipeline> pipelines) {
     log.info("Refreshing pipelines");
   }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/ManualEventMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/ManualEventMonitor.java
@@ -34,7 +34,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import rx.functions.Action1;
-import rx.functions.Func1;
 
 /**
  * Triggers pipelines in _Orca_ when a user manually starts a pipeline.
@@ -61,19 +60,18 @@ public class ManualEventMonitor extends TriggerMonitor {
     super(pipelineCache, subscriber, registry);
   }
 
-  protected Func1<Pipeline, Optional<Pipeline>> withMatchingTrigger(final TriggerEvent event) {
-    return pipeline -> {
-      if (pipeline.isDisabled()) {
-        return Optional.empty();
-      } else {
-        ManualEvent manualEvent = (ManualEvent) event;
-        Trigger trigger = manualEvent.getContent().getTrigger();
-        return Stream.of(trigger)
-          .filter(matchTriggerFor(event, pipeline))
-          .findFirst()
-          .map(buildTrigger(pipeline, event));
-      }
-    };
+  @Override
+  protected Optional<Pipeline> withMatchingTrigger(final TriggerEvent event, Pipeline pipeline) {
+    if (pipeline.isDisabled()) {
+      return Optional.empty();
+    } else {
+      ManualEvent manualEvent = (ManualEvent) event;
+      Trigger trigger = manualEvent.getContent().getTrigger();
+      return Stream.of(trigger)
+        .filter(matchTriggerFor(event, pipeline))
+        .findFirst()
+        .map(buildTrigger(pipeline, event));
+    }
   }
 
   @Override

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/BuildEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/BuildEventMonitorSpec.groovy
@@ -27,7 +27,7 @@ class BuildEventMonitorSpec extends Specification implements RetrofitStubs {
   def "triggers pipelines for successful builds for #triggerType"() {
     given:
     def pipeline = createPipelineWith(trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -47,7 +47,7 @@ class BuildEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "attaches #triggerType trigger to the pipeline"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -69,7 +69,7 @@ class BuildEventMonitorSpec extends Specification implements RetrofitStubs {
 
   def "an event can trigger multiple pipelines"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just(pipelines)
+    pipelineCache.getPipelinesSync() >> pipelines
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -92,7 +92,7 @@ class BuildEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger pipelines for #description builds"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -115,7 +115,7 @@ class BuildEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger #description pipelines"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -141,7 +141,7 @@ class BuildEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger a pipeline that has an enabled #triggerType trigger with missing #field"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([badPipeline, goodPipeline])
+    pipelineCache.getPipelinesSync() >> [badPipeline, goodPipeline]
     println objectMapper.writeValueAsString(createBuildEventWith(SUCCESS))
 
     when:

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/DockerEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/DockerEventMonitorSpec.groovy
@@ -42,7 +42,7 @@ class DockerEventMonitorSpec extends Specification implements RetrofitStubs {
   def "triggers pipelines for successful builds for #triggerType"() {
     given:
     def pipeline = createPipelineWith(trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -59,7 +59,7 @@ class DockerEventMonitorSpec extends Specification implements RetrofitStubs {
 
   def "attaches docker trigger to the pipeline"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -87,7 +87,7 @@ class DockerEventMonitorSpec extends Specification implements RetrofitStubs {
 
   def "an event can trigger multiple pipelines"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just(pipelines)
+    pipelineCache.getPipelinesSync() >> pipelines
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -110,7 +110,7 @@ class DockerEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger #description pipelines"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -130,7 +130,7 @@ class DockerEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger #description pipelines for docker"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -152,7 +152,7 @@ class DockerEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger a pipeline that has an enabled docker trigger with missing #field"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([badPipeline, goodPipeline])
+    pipelineCache.getPipelinesSync() >> [badPipeline, goodPipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -175,7 +175,7 @@ class DockerEventMonitorSpec extends Specification implements RetrofitStubs {
   def "triggers a pipeline that has an enabled docker trigger with regex"() {
     given:
     def pipeline = createPipelineWith(trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -194,7 +194,7 @@ class DockerEventMonitorSpec extends Specification implements RetrofitStubs {
   def "triggers a pipeline that has an enabled docker trigger with empty string for regex"() {
     given:
     def pipeline = createPipelineWith(trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -213,7 +213,7 @@ class DockerEventMonitorSpec extends Specification implements RetrofitStubs {
   def "triggers a pipeline that has an enabled docker trigger with only whitespace for regex"() {
     given:
     def pipeline = createPipelineWith(trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -232,7 +232,7 @@ class DockerEventMonitorSpec extends Specification implements RetrofitStubs {
   def "does not trigger a pipeline that has an enabled docker trigger with regex"() {
     given:
     def pipeline = createPipelineWith(trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/GitEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/GitEventMonitorSpec.groovy
@@ -41,7 +41,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
   def "triggers pipelines for successful builds for #triggerType"() {
     given:
     def pipeline = createPipelineWith(trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -59,7 +59,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
 
   def "attaches stash trigger to the pipeline"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -79,7 +79,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
 
   def "attaches bitbucket trigger to the pipeline"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -99,7 +99,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
 
   def "an event can trigger multiple pipelines"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just(pipelines)
+    pipelineCache.getPipelinesSync() >> pipelines
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -122,7 +122,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger #description pipelines"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -142,7 +142,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger #description pipelines for stash"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -165,7 +165,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger #description pipelines for bitbucket"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -188,7 +188,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger a pipeline that has an enabled stash trigger with missing #field"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([badPipeline, goodPipeline])
+    pipelineCache.getPipelinesSync() >> [badPipeline, goodPipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -210,7 +210,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger a pipeline that has an enabled bitbucket trigger with missing #field"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([badPipeline, goodPipeline])
+    pipelineCache.getPipelinesSync() >> [badPipeline, goodPipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -236,7 +236,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
     gitEvent.content.branch = eventBranch
     def trigger = enabledStashTrigger.atBranch(triggerBranch)
     def pipeline = createPipelineWith(trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(gitEvent, Event))
@@ -262,7 +262,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
     gitEvent.content.branch = eventBranch
     def trigger = enabledStashTrigger.atBranch(triggerBranch)
     def pipeline = createPipelineWith(trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(gitEvent, Event))
@@ -288,7 +288,7 @@ class GitEventMonitorSpec extends Specification implements RetrofitStubs {
     def trigger = enabledGithubTrigger.atSecret(secret).atBranch("master")
 
     def pipeline = createPipelineWith(trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(gitEvent, Event))

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/PubsubEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/PubsubEventMonitorSpec.groovy
@@ -83,7 +83,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
   def "triggers pipelines for successful builds for Google pubsub"() {
     given:
     def pipeline = createPipelineWith(goodExpectedArtifacts, trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -105,7 +105,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
 
   def "attaches Google pubsub trigger to the pipeline"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -125,7 +125,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger #description pipelines for Google pubsub"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -146,7 +146,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger #description pipelines containing artifacts for Google pubsub"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -165,7 +165,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger a pipeline that has an enabled pubsub trigger with missing #field"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([badPipeline, goodPipeline])
+    pipelineCache.getPipelinesSync() >> [badPipeline, goodPipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -196,7 +196,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
       .build()
 
     def pipeline = createPipelineWith(goodExpectedArtifacts, trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     def content = new PubsubEvent.Content()
@@ -233,7 +233,7 @@ class PubsubEventMonitorSpec extends Specification implements RetrofitStubs {
       .build()
 
     def pipeline = createPipelineWith(goodExpectedArtifacts, trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     def content = new PubsubEvent.Content()

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/monitor/WebhookEventMonitorSpec.groovy
@@ -52,7 +52,7 @@ class WebhookEventMonitorSpec extends Specification implements RetrofitStubs {
   def 'triggers pipelines for successful builds for webhook'() {
     given:
     def pipeline = createPipelineWith(goodExpectedArtifacts, trigger)
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -73,7 +73,7 @@ class WebhookEventMonitorSpec extends Specification implements RetrofitStubs {
 
   def 'attaches webhook trigger to the pipeline'() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))
@@ -93,7 +93,7 @@ class WebhookEventMonitorSpec extends Specification implements RetrofitStubs {
   @Unroll
   def "does not trigger #description pipelines for webhook"() {
     given:
-    pipelineCache.getPipelines() >> Observable.just([pipeline])
+    pipelineCache.getPipelinesSync() >> [pipeline]
 
     when:
     monitor.processEvent(objectMapper.convertValue(event, Event))


### PR DESCRIPTION
Two changes:
* Change the fix I made in https://github.com/spinnaker/echo/pull/274 so that we block waiting for the initialization of the pipeline cache instead of having RxJava defer the operation and perform it on the pipeline cache thread.  This is necessary to properly pass authentication headers through Echo.
* Remove some RxJava from `TriggerMonitor.java`

Keeping these as separate commits as I may want to pull the fix into 1.10 so that my new manual trigger workflow works there without a race condition on startup.