### PR TITLE
feat(core): Front50 graphql client

### DIFF
--- a/echo-core/src/main/groovy/com/netflix/spinnaker/echo/services/Front50Service.java
+++ b/echo-core/src/main/groovy/com/netflix/spinnaker/echo/services/Front50Service.java
@@ -1,11 +1,10 @@
 package com.netflix.spinnaker.echo.services;
 
-import java.util.List;
 import com.netflix.spinnaker.echo.model.Pipeline;
-import retrofit.http.GET;
-import retrofit.http.Headers;
-import retrofit.http.Path;
+import retrofit.http.*;
 import rx.Observable;
+
+import java.util.List;
 
 public interface Front50Service {
   @GET("/pipelines?restricted=false")
@@ -15,4 +14,8 @@ public interface Front50Service {
   @GET("/pipelines/{application}?refresh=false")
   @Headers("Accept: application/json")
   Observable<List<Pipeline>> getPipelines(@Path("application") String application);
+
+  @POST("/graphql")
+  @Headers("Accept: application/json")
+  GraphQLQueryResponse query(@Body GraphQLQuery body);
 }

--- a/echo-core/src/main/groovy/com/netflix/spinnaker/echo/services/GraphQLQuery.java
+++ b/echo-core/src/main/groovy/com/netflix/spinnaker/echo/services/GraphQLQuery.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.echo.services;
+
+import javax.annotation.Nullable;
+
+import static java.lang.String.format;
+
+public class GraphQLQuery {
+
+  /**
+   * Oh yeah. This is the realness. Will need to write a query builder.
+   */
+  public static GraphQLQuery pipelines(@Nullable String havingTriggerType) {
+    if (havingTriggerType != null) {
+      havingTriggerType = format("(havingTriggerType: \"%s\")", havingTriggerType);
+    } else {
+      havingTriggerType = "";
+    }
+
+    return new GraphQLQuery(format("query {\n" +
+      "  pipelines%s {\n" +
+      "    id\n" +
+      "    name\n" +
+      "    application\n" +
+      "    triggers {\n" +
+      "      ... on CronTrigger {\n" +
+      "        id\n" +
+      "        enabled\n" +
+      "        cronExpression\n" +
+      "      }\n" +
+      "    }\n" +
+      "  }\n" +
+      "}\n", havingTriggerType));
+  }
+
+  public String query;
+
+  GraphQLQuery(String query) {
+    this.query = query;
+  }
+}

--- a/echo-core/src/main/groovy/com/netflix/spinnaker/echo/services/GraphQLQueryResponse.java
+++ b/echo-core/src/main/groovy/com/netflix/spinnaker/echo/services/GraphQLQueryResponse.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.echo.services;
+
+import java.util.List;
+import java.util.Map;
+
+public class GraphQLQueryResponse {
+
+  Map<String, Object> data;
+  List<Error> errors;
+
+  public Map<String, Object> getData() {
+    return data;
+  }
+
+  public List<Error> getErrors() {
+    return errors;
+  }
+
+  public static class Error {
+    String message;
+    List<Object> path;
+    List<Object> locations;
+    String errorType;
+    Object extensions;
+
+    public String getMessage() {
+      return message;
+    }
+
+    public List<Object> getPath() {
+      return path;
+    }
+
+    public List<Object> getLocations() {
+      return locations;
+    }
+
+    public String getErrorType() {
+      return errorType;
+    }
+
+    public Object getExtensions() {
+      return extensions;
+    }
+  }
+}

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
@@ -16,21 +16,10 @@
 
 package com.netflix.spinnaker.echo.pipelinetriggers;
 
-import static java.time.Instant.now;
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.model.Pipeline;
 import com.netflix.spinnaker.echo.model.Trigger;
 import com.netflix.spinnaker.echo.services.Front50Service;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +29,16 @@ import rx.Scheduler;
 import rx.Subscription;
 import rx.subjects.ReplaySubject;
 import rx.subjects.SerializedSubject;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.time.Instant.now;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Component
 @Slf4j


### PR DESCRIPTION
An experimental front50/graphql integration. The schema
exposed by front50 only really supports pipelines with
cron triggers. Similarly, we haven't implemented a query
builder or anything of that sort on the Echo side.

Should we see positive results from this integration,
a more focused effort will be put in to offer a more
fully featured integration.

Usage:

```java
GraphQLQueryResponse resp = front50.query(GraphQLQuery.pipelines("cron"));
```