### PR TITLE
refactor(core): Clean up echo-pipelinetriggers dependencies

### DIFF
--- a/echo-notifications/echo-notifications.gradle
+++ b/echo-notifications/echo-notifications.gradle
@@ -21,6 +21,7 @@ dependencies {
     spinnaker.group("bootWeb")
     spinnaker.group("retrofitDefault")
     compile spinnaker.dependency("groovy")
+    compile spinnaker.dependency("logstashEncoder")
     compile spinnaker.dependency("kork")
     compile spinnaker.dependency('korkWeb')
     compile spinnaker.dependency("rxJava")

--- a/echo-pipelinetriggers/echo-pipelinetriggers.gradle
+++ b/echo-pipelinetriggers/echo-pipelinetriggers.gradle
@@ -15,25 +15,26 @@
  */
 
 dependencies {
-  spinnaker.group("test")
-  spinnaker.group("lombok")
-  spinnaker.group("retrofitDefault")
-  spinnaker.group("fiat")
+  spinnaker.group('fiat')
+  spinnaker.group('lombok')
+  spinnaker.group('retrofitDefault')
 
   compile project(':echo-core')
+  compile project(':echo-model')
+  compile spinnaker.dependency('kork')
+  compile spinnaker.dependency('korkArtifacts')
+  compile spinnaker.dependency('korkSecurity')
   compile spinnaker.dependency('korkWeb')
-  compile spinnaker.dependency("bootWeb")
-  compile spinnaker.dependency("bootActuator")
-  compile spinnaker.dependency("rxJava")
-  compile spinnaker.dependency("guava")
-  compile spinnaker.dependency("okHttp")
-  compile spinnaker.dependency("eurekaClient")
-  compile spinnaker.dependency("kork")
-  compile spinnaker.dependency("korkSecurity")
-  compile spinnaker.dependency("spectatorApi")
 
-  compile group: 'org.codehaus.groovy', name: 'groovy', version: "2.4.5"
+  compile spinnaker.dependency('bootWeb')
+  compile spinnaker.dependency('bootActuator')
+  compile spinnaker.dependency('jacksonDatabind')
+  compile spinnaker.dependency('rxJava')
+  compile spinnaker.dependency('springContext')
+  compile spinnaker.dependency('spectatorApi')
   compile group: 'commons-codec', name: 'commons-codec', version: '1.10'
-  testCompile "org.spockframework:spock-core:1.0-groovy-2.4"
+  compile group: 'org.apache.commons', name:'commons-lang3', version: '3.4'
+
+  spinnaker.group('test')
   testCompile project(':echo-test')
 }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/DockerEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/DockerEventHandler.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.PatternSyntaxException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandler.java
@@ -32,7 +32,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.HmacUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandler.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/health/MonitoredPollerHealth.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/health/MonitoredPollerHealth.java
@@ -31,7 +31,7 @@ import java.time.ZoneId;
 import static java.time.Instant.now;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.apache.commons.lang.time.DurationFormatUtils.formatDurationWords;
+import static org.apache.commons.lang3.time.DurationFormatUtils.formatDurationWords;
 
 /**
  * A {@link HealthIndicator} implementation that monitors an instance of {@link MonitoredPoller}.

--- a/echo-scheduler/echo-scheduler.gradle
+++ b/echo-scheduler/echo-scheduler.gradle
@@ -22,6 +22,7 @@ dependencies {
   compile spinnaker.dependency('groovy')
   compile spinnaker.dependency('slf4jApi')
   compile spinnaker.dependency('eurekaClient')
+  compile spinnaker.dependency('logstashEncoder')
   compile spinnaker.dependency('spectatorApi')
 
   testRuntime spinnaker.dependency('slf4jSimple')


### PR DESCRIPTION
Reduce transitive dependencies in echo-pipelinetriggers by explicitly specifying dependencies, and remove any unused dependencies.

Explicitly include the following, which were transitively included before:
* echo-model
* korkArtifacts
* jacksonDatabind
* springContext
* commons-lang (pull in lang3, and update calls from lang)

Remove the following, which are not needed:
* guava (unused)
* okHttp (part of retrofitDefault group)
* eurekaClient (unused)
* groovy (only in test module now and included in test group)
* spock (included in test group)

Update two other modules to explicitly pull in logstashEncoder as they were transitively depending on it being in echo-pipelinetriggers