### PR TITLE
feat(quiet-periods): optionally supress triggers during quiet periods

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
@@ -61,6 +61,9 @@ public class Pipeline {
   boolean plan;
 
   @JsonProperty
+  boolean respectQuietPeriod;
+
+  @JsonProperty
   List<Trigger> triggers;
 
   @JsonProperty

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/PipelineTriggerConfiguration.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/PipelineTriggerConfiguration.java
@@ -13,10 +13,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.*;
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
 import retrofit.RestAdapter.LogLevel;
@@ -28,7 +27,7 @@ import rx.schedulers.Schedulers;
 
 @Slf4j
 @Configuration
-@ComponentScan("com.netflix.spinnaker.echo.pipelinetriggers")
+@ComponentScan(value = "com.netflix.spinnaker.echo.pipelinetriggers")
 @EnableConfigurationProperties(FiatClientConfigurationProperties.class)
 public class PipelineTriggerConfiguration {
   private Client retrofitClient;
@@ -75,6 +74,12 @@ public class PipelineTriggerConfiguration {
   @ConditionalOnMissingBean(PubsubEventHandler.class)
   PubsubEventHandler pubsubEventHandler(Registry registry, ObjectMapper objectMapper) {
     return new PubsubEventHandler(registry, objectMapper);
+  }
+
+  @Bean
+  @ConfigurationProperties(prefix = "quietPeriod")
+  public QuietPeriodIndicatorConfigurationProperties quietPeriodIndicatorConfigurationProperties() {
+    return new QuietPeriodIndicatorConfigurationProperties();
   }
 
   private <T> T bindRetrofitService(final Class<T> type, final String endpoint) {

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/QuietPeriodIndicatorConfigurationProperties.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/QuietPeriodIndicatorConfigurationProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.config;
+
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuietPeriodIndicatorConfigurationProperties {
+
+  boolean enabled;
+
+  String startIso;
+
+  String endIso;
+
+  List<String> suppressedTriggerTypes = new ArrayList<>();
+}

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/QuietPeriodIndicator.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/QuietPeriodIndicator.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pipelinetriggers;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.patterns.PolledMeter;
+import com.netflix.spinnaker.echo.config.QuietPeriodIndicatorConfigurationProperties;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+
+@Slf4j
+@Component
+@ConditionalOnExpression("${quietPeriod.enabled:false}")
+@Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
+public class QuietPeriodIndicator {
+  private final Registry registry;
+
+  private final boolean enabled;
+  private final long startEpochMillis;
+  private final long endEpochMillis;
+  private final List<String> suppressedTriggerTypes;
+
+  private final Id quietPeriodTestId;
+
+  @Autowired
+  public QuietPeriodIndicator(@NonNull Registry registry,
+                              @NonNull QuietPeriodIndicatorConfigurationProperties config) {
+    this.registry = registry;
+
+    long startEpochMillis = parseIso(config.getStartIso());
+    long endEpochMillis = parseIso(config.getEndIso());
+    this.startEpochMillis = startEpochMillis;
+    this.endEpochMillis = endEpochMillis;
+    this.suppressedTriggerTypes = config.getSuppressedTriggerTypes();
+
+    this.enabled = config.isEnabled() && (startEpochMillis > 0 && endEpochMillis > 0);
+    if (this.enabled) {
+      log.warn("Enabling quiet periods.  Span in millis: {} to {}, ISO {} to {} (inclusive)",
+               startEpochMillis, endEpochMillis, config.getStartIso(), config.getEndIso());
+      log.warn("Will suppress triggers of types {} during quiet periods.", config.getSuppressedTriggerTypes());
+    }
+
+    PolledMeter.using(registry).withName("quietPeriod.enabled").monitorValue(this, QuietPeriodIndicator::gaugeMonitor);
+    quietPeriodTestId = registry.createId("quietPeriod.tests");
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  private double gaugeMonitor() {
+    return enabled ? 1.0 : 0.0;
+  }
+
+  public boolean inQuietPeriod(long now) {
+    boolean result = enabled && (now >= startEpochMillis && now <= endEpochMillis);
+    registry.counter(quietPeriodTestId.withTag("result", result)).increment();
+    return result;
+  }
+
+  public boolean inQuietPeriod(long now, String triggerType) {
+    return inQuietPeriod(now) && suppressedTriggerTypes.contains(triggerType);
+  }
+
+  private long parseIso(String iso) {
+    if (iso == null) {
+      return -1;
+    }
+    try {
+      Instant instant = Instant.from(ISO_INSTANT.parse(iso));
+      return instant.toEpochMilli();
+    } catch (DateTimeParseException e) {
+      log.warn("Unable to parse {} as an ISO date/time, disabling quiet periods: {}", iso, e.getMessage());
+      return -1;
+    }
+  }
+}

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
@@ -1,13 +1,31 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.echo.pipelinetriggers.orca;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.model.Pipeline;
+import com.netflix.spinnaker.echo.pipelinetriggers.QuietPeriodIndicator;
 import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService.TriggerResponse;
 import com.netflix.spinnaker.fiat.shared.FiatStatus;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import com.netflix.spinnaker.security.User;
 import javax.annotation.PostConstruct;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,15 +49,17 @@ public class PipelineInitiator {
   private final OrcaService orca;
   private final FiatStatus fiatStatus;
   private final ObjectMapper objectMapper;
+  private final QuietPeriodIndicator quietPeriodIndicator;
   private final boolean enabled;
   private final int retryCount;
   private final long retryDelayMillis;
 
   @Autowired
-  public PipelineInitiator(Registry registry,
-                           OrcaService orca,
-                           FiatStatus fiatStatus,
+  public PipelineInitiator(@NonNull Registry registry,
+                           @NonNull OrcaService orca,
+                           @NonNull FiatStatus fiatStatus,
                            ObjectMapper objectMapper,
+                           @NonNull QuietPeriodIndicator quietPeriodIndicator,
                            @Value("${orca.enabled:true}") boolean enabled,
                            @Value("${orca.pipelineInitiatorRetryCount:5}") int retryCount,
                            @Value("${orca.pipelineInitiatorRetryDelayMillis:5000}") long retryDelayMillis) {
@@ -47,6 +67,7 @@ public class PipelineInitiator {
     this.orca = orca;
     this.fiatStatus = fiatStatus;
     this.objectMapper = objectMapper;
+    this.quietPeriodIndicator = quietPeriodIndicator;
     this.enabled = enabled;
     this.retryCount = retryCount;
     this.retryDelayMillis = retryDelayMillis;
@@ -61,18 +82,23 @@ public class PipelineInitiator {
 
   public void startPipeline(Pipeline pipeline) {
     if (enabled) {
-      log.info("Triggering {} due to {}", pipeline, pipeline.getTrigger());
+      if (pipeline.getTrigger() != null &&
+          pipeline.isRespectQuietPeriod() &&
+          quietPeriodIndicator.inQuietPeriod(System.currentTimeMillis(), pipeline.getTrigger().getType())) {
+        log.info("Would trigger {} due to {} but pipeline is set to ignore automatic triggers during quiet periods", pipeline, pipeline.getTrigger());
+      } else {
+        log.info("Triggering {} due to {}", pipeline, pipeline.getTrigger());
 
-      final String templatedPipelineType = "templatedPipeline";
-      if (templatedPipelineType.equals(pipeline.getType())) { // TODO(jacobkiefer): Constantize.
-        log.debug("Planning templated pipeline {} before triggering", pipeline.getId());
-        pipeline = pipeline.withPlan(true);
-        Map resolvedPipelineMap = orca.plan(objectMapper.convertValue(pipeline, Map.class));
-        pipeline = objectMapper.convertValue(resolvedPipelineMap, Pipeline.class);
+        final String templatedPipelineType = "templatedPipeline";
+        if (templatedPipelineType.equals(pipeline.getType())) { // TODO(jacobkiefer): Constantize.
+          log.debug("Planning templated pipeline {} before triggering", pipeline.getId());
+          pipeline = pipeline.withPlan(true);
+          Map resolvedPipelineMap = orca.plan(objectMapper.convertValue(pipeline, Map.class));
+          pipeline = objectMapper.convertValue(resolvedPipelineMap, Pipeline.class);
+        }
+        triggerPipeline(pipeline);
+        registry.counter("orca.requests").increment();
       }
-      triggerPipeline(pipeline);
-      registry.counter("orca.requests").increment();
-
     } else {
       log.info("Would trigger {} due to {} but triggering is disabled", pipeline, pipeline.getTrigger());
     }

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/QuietPeriodIndicatorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/QuietPeriodIndicatorSpec.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pipelinetriggers
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.echo.config.QuietPeriodIndicatorConfigurationProperties
+import spock.lang.Specification
+
+import java.time.Instant
+
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+
+class QuietPeriodIndicatorSpec extends Specification {
+  def registry = new NoopRegistry()
+  def goodStartDate = "2018-01-01T00:00:00Z"
+  def goodEndDate = "2018-02-01T00:00:00Z"
+  def badDate = "flarg"
+  def beforeDate = "2000-01-01T00:00:00Z"
+  def afterDate = "2019-01-01T00:00:00Z"
+  def inRangeDate = "2018-01-19T00:00:00Z"
+
+  def parseIso(String iso) {
+    return Instant.from(ISO_INSTANT.parse(iso)).toEpochMilli()
+  }
+
+  def "is disabled if 'enabled' is false"() {
+    given:
+    QuietPeriodIndicatorConfigurationProperties config = new QuietPeriodIndicatorConfigurationProperties(false, goodStartDate, goodEndDate, Collections.emptyList());
+    QuietPeriodIndicator quietPeriodIndicator = new QuietPeriodIndicator(registry, config)
+
+    expect:
+    !quietPeriodIndicator.isEnabled()
+  }
+
+  def "disabled if start date is invalid"() {
+    given:
+    QuietPeriodIndicatorConfigurationProperties config = new QuietPeriodIndicatorConfigurationProperties(false, badDate, goodEndDate, Collections.emptyList());
+    QuietPeriodIndicator quietPeriodIndicator = new QuietPeriodIndicator(registry, config)
+
+    expect:
+    !quietPeriodIndicator.isEnabled()
+  }
+
+  def "disabled if end date is invalid"() {
+    given:
+    QuietPeriodIndicatorConfigurationProperties config = new QuietPeriodIndicatorConfigurationProperties(false, goodStartDate, badDate, Collections.emptyList());
+    QuietPeriodIndicator quietPeriodIndicator = new QuietPeriodIndicator(registry, config)
+
+    expect:
+    !quietPeriodIndicator.isEnabled()
+  }
+
+  def "ranges work"() {
+    given:
+    QuietPeriodIndicatorConfigurationProperties config = new QuietPeriodIndicatorConfigurationProperties(true, goodStartDate, goodEndDate, Collections.emptyList());
+    QuietPeriodIndicator quietPeriodIndicator = new QuietPeriodIndicator(registry, config)
+
+    expect:
+    !quietPeriodIndicator.inQuietPeriod(parseIso(beforeDate))
+    quietPeriodIndicator.inQuietPeriod(parseIso(inRangeDate))
+    !quietPeriodIndicator.inQuietPeriod(parseIso(afterDate))
+  }
+
+  def "trigger type list is respected"() {
+    given:
+    ArrayList<String> triggerTypes = new ArrayList<>();
+    triggerTypes.add("inTheList")
+    QuietPeriodIndicatorConfigurationProperties config = new QuietPeriodIndicatorConfigurationProperties(true, goodStartDate, goodEndDate, triggerTypes);
+    QuietPeriodIndicator quietPeriodIndicator = new QuietPeriodIndicator(registry, config)
+
+    expect:
+    !quietPeriodIndicator.inQuietPeriod(parseIso(inRangeDate), "notInTheList")
+    quietPeriodIndicator.inQuietPeriod(parseIso(inRangeDate), "inTheList")
+  }
+}

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiatorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiatorSpec.groovy
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.echo.pipelinetriggers.orca
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.echo.model.Pipeline
+import com.netflix.spinnaker.echo.pipelinetriggers.QuietPeriodIndicator
 import com.netflix.spinnaker.fiat.shared.FiatStatus
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -14,12 +15,12 @@ class PipelineInitiatorSpec extends Specification {
   def orca = Mock(OrcaService)
   def fiatStatus = Mock(FiatStatus)
   def objectMapper = Mock(ObjectMapper)
-
+  def quietPeriodIndicator = Mock(QuietPeriodIndicator)
 
   @Unroll
   def "calls orca #orcaCalls times when enabled=#enabled flag"() {
     given:
-    def pipelineInitiator = new PipelineInitiator(registry, orca, fiatStatus, objectMapper, enabled, 5, 5000)
+    def pipelineInitiator = new PipelineInitiator(registry, orca, fiatStatus, objectMapper, quietPeriodIndicator, enabled, 5, 5000)
     def pipeline = Pipeline.builder().application("application").name("name").id("id").type("pipeline").build()
 
     when:
@@ -38,7 +39,7 @@ class PipelineInitiatorSpec extends Specification {
   @Unroll
   def "calls orca #orcaCalls to plan pipeline if templated"() {
     given:
-    def pipelineInitiator = new PipelineInitiator(registry, orca, fiatStatus, objectMapper, true, 5, 5000)
+    def pipelineInitiator = new PipelineInitiator(registry, orca, fiatStatus, objectMapper, quietPeriodIndicator, true, 5, 5000)
     def pipeline = Pipeline.builder()
       .application("application")
       .name("name")


### PR DESCRIPTION
This change allows a single quiet period to be defined in the echo config:

```yaml
quietPeriod:
  enabled: true
  startIso: 2018-11-20T00:00:00Z
  endIso: 2019-01-15T00:00:00Z
  suppressedTriggerTypes:
    - jenkins
    - cron
```

This causes Echo to not allow triggers of those types to start a pipeline if the current time is within the defined time range (inclusive).  No notices beyond log messages will be made that it was suppressed, so nothing will be shown to the user.

A change for deck will be coming up, as well as adding this pipeline flag to Orca's pipeline model once this is approved.