### PR TITLE
feat(artifacts): Use property to select template

### DIFF
--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ArtifactPostProcessorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ArtifactPostProcessorSpec.groovy
@@ -17,14 +17,17 @@
 package com.netflix.spinnaker.echo.pipelinetriggers.postprocessors
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.echo.pipelinetriggers.artifacts.JinjaTemplateService
 import com.netflix.spinnaker.echo.test.RetrofitStubs
 import spock.lang.Specification
 import spock.lang.Subject
 
 class ArtifactPostProcessorSpec extends Specification implements RetrofitStubs {
   def objectMapper = new ObjectMapper()
+  def jinjaTemplateService = GroovyMock(JinjaTemplateService)
+
   @Subject
-  def artifactPostProcessor = new ArtifactPostProcessor(objectMapper)
+  def artifactPostProcessor = new ArtifactPostProcessor(objectMapper, jinjaTemplateService)
 
   def "is (currently) a no-op"() {
     given:


### PR DESCRIPTION
As a first pass, let's allow users to select a Jinja template to extract artifacts from a Jenkins job by exporting the template to use as a property. We'll likely want to provide other ways of configuring this in the future, but this is a lightweight way to get started, and will allow users to start using this feature.