### PR TITLE
feat(artifacts): Add classifier to jar artifact

### DIFF
--- a/echo-pipelinetriggers/src/main/resources/jar.jinja
+++ b/echo-pipelinetriggers/src/main/resources/jar.jinja
@@ -1,8 +1,10 @@
 [
   {
-    "reference": "{{ properties.group }}:{{ properties.artifact }}:{{ properties.version }}",
+    {% set repotype = properties.repotype | default('maven') -%}
+    {% set reference = [properties.group, properties.artifact, properties.version, properties.classifier] | select('defined') | join(':') -%}
+    "reference": "{{ reference }}",
     "name": "{{ properties.artifact }}-{{ properties.version }}",
     "version": "{{ properties.version }}",
-    "type": "jar/archive"
+    "type": "{{ repotype }}/file"
   }
 ]


### PR DESCRIPTION
Adds the ability to set an optional classifier on a jar artifact. Also changes the artifact type from jar/archive to repotype/file where repotype defaults to maven.