### PR TITLE
fix(core): Don't retry pipeline initiation when receiving a 400

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
@@ -38,6 +38,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import retrofit.RetrofitError;
 import retrofit.RetrofitError.Kind;
+import retrofit.client.Response;
 import rx.Observable;
 import rx.functions.Func1;
 
@@ -154,7 +155,7 @@ public class PipelineInitiator {
   }
 
   private static boolean isRetryable(Throwable error) {
-    if (!(error instanceof  RetrofitError)) {
+    if (!(error instanceof RetrofitError)) {
       return false;
     }
     RetrofitError retrofitError = (RetrofitError) error;
@@ -163,8 +164,9 @@ public class PipelineInitiator {
       return true;
     }
 
-    if (retrofitError.getKind() == Kind.HTTP && retrofitError.getResponse().getStatus() != HttpStatus.BAD_REQUEST.value()) {
-      return true;
+    if (retrofitError.getKind() == Kind.HTTP) {
+      Response response = retrofitError.getResponse();
+      return (response != null && response.getStatus() != HttpStatus.BAD_REQUEST.value());
     }
 
     return false;

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
@@ -34,6 +34,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import retrofit.RetrofitError;
 import retrofit.RetrofitError.Kind;
@@ -153,8 +154,20 @@ public class PipelineInitiator {
   }
 
   private static boolean isRetryable(Throwable error) {
-    return error instanceof RetrofitError &&
-      (((RetrofitError) error).getKind() == Kind.NETWORK || ((RetrofitError) error).getKind() == Kind.HTTP);
+    if (!(error instanceof  RetrofitError)) {
+      return false;
+    }
+    RetrofitError retrofitError = (RetrofitError) error;
+
+    if (retrofitError.getKind() == Kind.NETWORK) {
+      return true;
+    }
+
+    if (retrofitError.getKind() == Kind.HTTP && retrofitError.getResponse().getStatus() != HttpStatus.BAD_REQUEST.value()) {
+      return true;
+    }
+
+    return false;
   }
 
   private static class RetryWithDelay implements Func1<Observable<? extends Throwable>, Observable<?>> {
@@ -173,7 +186,7 @@ public class PipelineInitiator {
     public Observable<?> call(Observable<? extends Throwable> attempts) {
       return attempts
         .flatMap((Func1<Throwable, Observable<?>>) throwable -> {
-          if (++retryCount < maxRetries) {
+          if (isRetryable(throwable) && ++retryCount < maxRetries) {
             log.error("Retrying pipeline trigger, attempt {}/{}", retryCount, maxRetries);
             return Observable.timer(retryDelayMillis, TimeUnit.MILLISECONDS);
           }


### PR DESCRIPTION
When a request to Orca to start a pipeline fails, Echo currently retries a number of times (defaulting to 5). In cases where the failure is due to a problem with the request, we should not retry; gate the retry logic so that we don't retry when receiving a 400 - Bad Request from Orca. In particular, this will stop having pipelines missing artifacts lead to 5 failed executions in the history.

See also https://github.com/spinnaker/orca/pull/2524