### PR TITLE
fix(slack): send token on postMessage in request body

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackClient.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackClient.groovy
@@ -25,7 +25,7 @@ interface SlackClient {
   @FormUrlEncoded
   @POST('/api/chat.postMessage')
   Response sendMessage(
-    @Query('token') String token,
+    @Field('token') String token,
     @Field('attachments') String attachments,
     @Field('channel') String channel,
     @Field('as_user') boolean asUser)

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackServiceSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackServiceSpec.groovy
@@ -87,6 +87,7 @@ class SlackServiceSpec extends Specification {
 
     then: "the HTTP URL and payload intercepted are the ones expected"
     actualUrl.get() == expectedUrl
+    getField(params, "token").value == "oldStyleToken"
     attachmentsJson[0]["title"] == "Title"
     attachmentsJson[0]["text"] == "the text"
     attachmentsJson[0]["fallback"] == "the text"
@@ -97,7 +98,7 @@ class SlackServiceSpec extends Specification {
 
     where:
     token           | expectedUrl
-    "oldStyleToken" | "https://slack.com/api/chat.postMessage?token=oldStyleToken"
+    "oldStyleToken" | "https://slack.com/api/chat.postMessage"
   }
 
   def static getField(Collection<NameValuePair> params, String fieldName) {


### PR DESCRIPTION
Since the request URL gets logged with the default configuration, let's put the token in the request body.

There is still an issue that using the incoming webhook approach probably logs the token; I will leave that as an exercise for someone who uses that to fix.