### PR TITLE
fix(artifacts): Fix artifact population in manual triggers

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -128,7 +128,7 @@ public class Trigger {
   boolean dryRun = false;
 
   List<Map<String, Object>> notifications;
-  List<Map<String, String>> artifacts;
+  List<Map<String, Object>> artifacts;
 
   /**
    * Unique ID of a trigger that can be used to correlate a pipeline execution with its trigger.

--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -128,6 +128,7 @@ public class Trigger {
   boolean dryRun = false;
 
   List<Map<String, Object>> notifications;
+  List<Map<String, String>> artifacts;
 
   /**
    * Unique ID of a trigger that can be used to correlate a pipeline execution with its trigger.


### PR DESCRIPTION
Some workflows (ex: manual triggers specifying a docker tag) directly inject artifacts into the trigger; we need to add an artifacts field to the Trigger model so that these work properly.