### PR TITLE
fix(artifacts): Allow customFormat to be a boolean

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ArtifactPostProcessor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ArtifactPostProcessor.java
@@ -134,7 +134,7 @@ public class ArtifactPostProcessor implements PipelinePostProcessor {
       return Boolean.parseBoolean((String) customFormat);
     }
 
-    throw new RuntimeException("Unexpected customFormat in property file.");
+    throw new RuntimeException("Unexpected customFormat in property file: " + customFormat);
   }
 
   public PostProcessorPriority priority() {

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ArtifactPostProcessor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ArtifactPostProcessor.java
@@ -112,12 +112,29 @@ public class ArtifactPostProcessor implements PipelinePostProcessor {
     }
 
     JinjaTemplate.TemplateType templateType = JinjaTemplate.TemplateType.STANDARD;
-    String customTemplate = (String) properties.get("customFormat");
-    if (Boolean.parseBoolean(customTemplate)) {
+
+    Object customFormat = properties.get("customFormat");
+    if (parseCustomFormat(customFormat)) {
       templateType = JinjaTemplate.TemplateType.CUSTOM;
     }
 
     return jinjaTemplateService.getTemplate(messageFormat, templateType);
+  }
+
+  private boolean parseCustomFormat(Object customFormat) {
+    if (customFormat == null) {
+      return false;
+    }
+
+    if (customFormat instanceof Boolean) {
+      return (Boolean) customFormat;
+    }
+
+    if (customFormat instanceof String) {
+      return Boolean.parseBoolean((String) customFormat);
+    }
+
+    throw new RuntimeException("Unexpected customFormat in property file.");
   }
 
   public PostProcessorPriority priority() {

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ArtifactPostProcessorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ArtifactPostProcessorSpec.groovy
@@ -17,19 +17,23 @@
 package com.netflix.spinnaker.echo.pipelinetriggers.postprocessors
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.echo.model.Trigger
 import com.netflix.spinnaker.echo.pipelinetriggers.artifacts.JinjaTemplateService
 import com.netflix.spinnaker.echo.test.RetrofitStubs
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import spock.lang.Specification
 import spock.lang.Subject
 
 class ArtifactPostProcessorSpec extends Specification implements RetrofitStubs {
   def objectMapper = new ObjectMapper()
   def jinjaTemplateService = GroovyMock(JinjaTemplateService)
+  def existingArtifact = Artifact.builder()
+    .type("testType").name("testName").reference("testReference").build()
 
   @Subject
   def artifactPostProcessor = new ArtifactPostProcessor(objectMapper, jinjaTemplateService)
 
-  def "is (currently) a no-op"() {
+  def "does not modify a pipeline without a template in the property file"() {
     given:
     def inputPipeline = createPipelineWith(enabledJenkinsTrigger)
 
@@ -38,5 +42,39 @@ class ArtifactPostProcessorSpec extends Specification implements RetrofitStubs {
 
     then:
     outputPipeline.id == inputPipeline.id
+  }
+
+  def "leaves existing artifacts in place"() {
+    given:
+    def inputPipeline = createPipelineWith(enabledJenkinsTrigger).withReceivedArtifacts([existingArtifact])
+
+    when:
+    def outputPipeline = artifactPostProcessor.processPipeline(inputPipeline)
+
+    then:
+    outputPipeline.receivedArtifacts.size() == 1
+    outputPipeline.receivedArtifacts[0].name == "testName"
+  }
+
+  def "parses an artifact and appends it to the received artifacts"() {
+    given:
+    def properties = [
+      group: 'test.group',
+      artifact: 'test-artifact',
+      version: '1.0',
+      messageFormat: 'JAR',
+      customFormat: 'false'
+    ]
+    def hydratedTrigger = enabledJenkinsTrigger.withProperties(properties)
+    def inputPipeline = createPipelineWith(enabledJenkinsTrigger)
+      .withTrigger(hydratedTrigger).withReceivedArtifacts([existingArtifact])
+
+    when:
+    def outputPipeline = artifactPostProcessor.processPipeline(inputPipeline)
+
+    then:
+    outputPipeline.receivedArtifacts.size() == 2
+    outputPipeline.receivedArtifacts[0].name == "testName"
+    outputPipeline.receivedArtifacts[1].name == "test-artifact-1.0"
   }
 }

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ArtifactPostProcessorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ArtifactPostProcessorSpec.groovy
@@ -77,4 +77,16 @@ class ArtifactPostProcessorSpec extends Specification implements RetrofitStubs {
     outputPipeline.receivedArtifacts[0].name == "testName"
     outputPipeline.receivedArtifacts[1].name == "test-artifact-1.0"
   }
+
+  def "parseCustomFormat correctly parses booleans and strings"() {
+    expect:
+    result == artifactPostProcessor.parseCustomFormat(customFormat)
+
+    where:
+    customFormat || result
+    true         || true
+    false        || false
+    "true"       || true
+    "false"      || false
+  }
 }


### PR DESCRIPTION
When parsing the customFormat supplied in the property file, we currently assume it is a string. If the property file is supplied as YAML, it could be a boolean.