### PR TITLE
refactor(eventhandlers): specify WebhookEvent content expectations in its type

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/trigger/WebhookEvent.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/trigger/WebhookEvent.java
@@ -17,9 +17,11 @@
 package com.netflix.spinnaker.echo.model.trigger;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.util.List;
 import java.util.Map;
 
 @Data
@@ -27,5 +29,12 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WebhookEvent extends TriggerEvent {
   public static final String TYPE = "WEBHOOK";
-  private Map content;
+  private Content content;
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class Content {
+    private List<Artifact> artifacts;
+    private Map<?, ?> parameters;
+  }
 }

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/WebhookEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/WebhookEventHandlerSpec.groovy
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.echo.pipelinetriggers.monitor
+package com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry

--- a/echo-test/src/main/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
+++ b/echo-test/src/main/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.echo.test
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.echo.model.Metadata
 import com.netflix.spinnaker.echo.model.Pipeline
 import com.netflix.spinnaker.echo.model.Trigger
@@ -90,7 +91,7 @@ trait RetrofitStubs {
     def res = new WebhookEvent()
     res.details = new Metadata([type: WebhookEvent.TYPE, source: source])
     res.payload = payload
-    res.content = payload
+    res.content = new ObjectMapper().convertValue(payload, WebhookEvent.Content)
     return res
   }
 

--- a/echo-web/config/echo.yml
+++ b/echo-web/config/echo.yml
@@ -1,14 +1,14 @@
+server:
+  port: 8089
+
 spinnaker:
   cassandra:
     cluster: 'spinnaker'
     keyspace: 'echo'
   baseUrl: 'http://localhost:9000'
 
-echo:
-  baseUrl: 'http://localhost:8080'
-
 front50:
-  baseUrl: 'http://localhost:8081'
+  baseUrl: 'http://localhost:8080'
 
 orca:
   baseUrl: 'http://localhost:8083'


### PR DESCRIPTION
Less use of after-the-fact `ObjectMapper` off of untyped properties.