### PR TITLE
fix(pubsub): Reintroduces 'name' field to google pubsub publishers

### DIFF
--- a/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubSubscriptionController.java
+++ b/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubSubscriptionController.java
@@ -16,10 +16,8 @@
 
 package com.netflix.spinnaker.echo.pubsub;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -27,17 +25,20 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
 /**
  * Controller for configured pub/sub subscriptions.
  */
 @RestController
+@RequestMapping(value = "/pubsub")
 public class PubsubSubscriptionController {
 
   @Autowired
   private PubsubSubscribers pubsubSubscribers;
 
-  @RequestMapping(value = "/pubsub/subscriptions", method = RequestMethod.GET)
+  @Autowired
+  private PubsubPublishers pubsubPublishers;
+
+  @RequestMapping(value = "/subscriptions", method = RequestMethod.GET)
   List<PubsubSubscriptionBySystem> getSubscriptions() {
     return pubsubSubscribers
         .getAll()
@@ -51,10 +52,29 @@ public class PubsubSubscriptionController {
 
   @Data
   @Builder
-  @NoArgsConstructor
-  @AllArgsConstructor
   public static class PubsubSubscriptionBySystem {
     private String pubsubSystem;
     private String subscriptionName;
+  }
+
+  @RequestMapping(value = "/publishers", method = RequestMethod.GET)
+  List<PubsubPublishersBySystem> getPublishers() {
+    return pubsubPublishers
+      .getAll()
+      .stream()
+      .map(p -> PubsubPublishersBySystem.builder()
+        .pubsubSystem(p.getPubsubSystem().toString())
+        .publisherName(p.getName())
+        .topicName(p.getTopicName())
+        .build())
+      .collect(Collectors.toList());
+  }
+
+  @Data
+  @Builder
+  public static class PubsubPublishersBySystem {
+    private String pubsubSystem;
+    private String publisherName;
+    private String topicName;
   }
 }

--- a/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/model/PubsubPublisher.java
+++ b/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/model/PubsubPublisher.java
@@ -21,4 +21,5 @@ import com.netflix.spinnaker.echo.model.pubsub.PubsubSystem;
 public interface PubsubPublisher {
   PubsubSystem getPubsubSystem();
   String getTopicName();
+  String getName();
 }

--- a/echo-pubsub-google/echo-pubsub-google.gradle
+++ b/echo-pubsub-google/echo-pubsub-google.gradle
@@ -17,5 +17,5 @@
 dependencies {
   compile project(':echo-pubsub-core')
   compile project(':echo-notifications')
-  compile 'com.google.cloud:google-cloud-pubsub:1.56.0'
+  compile 'com.google.cloud:google-cloud-pubsub:1.59.0'
 }

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/config/GooglePubsubConfig.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/config/GooglePubsubConfig.java
@@ -82,7 +82,8 @@ public class GooglePubsubConfig {
       .stream()
       .map(publisherConfig -> {
         log.info(
-          "Bootstrapping Google Pubsub Publisher on topic {} in project {} publishing content {}",
+          "Bootstrapping Google Pubsub Publisher named {} on topic {} in project {} publishing content {}",
+          publisherConfig.getName(),
           publisherConfig.getTopicName(),
           publisherConfig.getProject(),
           publisherConfig.getContent());

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/config/GooglePubsubProperties.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/config/GooglePubsubProperties.java
@@ -89,6 +89,9 @@ public class GooglePubsubProperties {
   public static class GooglePubsubPublisherConfig {
 
     @NotEmpty
+    private String name;
+
+    @NotEmpty
     private String topicName;
 
     @NotEmpty

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubNotificationEventListener.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubNotificationEventListener.java
@@ -58,8 +58,8 @@ public class GooglePubsubNotificationEventListener extends AbstractEventNotifica
       .stream()
       .map(p -> (GooglePubsubPublisher) p)
       .filter(p -> p.getContent() == Content.NOTIFICATIONS)
-      .filter(p -> notification.containsKey("topic") && notification.get("topic").toString()
-        .equalsIgnoreCase(p.getTopicName()))
+      .filter(p -> notification.containsKey("publisherName") &&
+        notification.get("publisherName").toString().equalsIgnoreCase(p.getName()))
       .forEach(p -> p.publishEvent(event));
   }
 
@@ -81,12 +81,12 @@ public class GooglePubsubNotificationEventListener extends AbstractEventNotifica
     if (notification.getTo() == null || notification.getTo().isEmpty()) {
       return new Void();
     }
-    String topic = notification.getTo().iterator().next();
+    String publisherName = notification.getTo().iterator().next();
 
     publishers.publishersMatchingType(PubsubSystem.GOOGLE)
       .stream()
       .map(p -> (GooglePubsubPublisher) p)
-      .filter(p -> StringUtils.equalsIgnoreCase(topic, p.getTopicName()))
+      .filter(p -> StringUtils.equalsIgnoreCase(publisherName, p.getName()))
       .forEach(p -> publishNotification(p, notification));
     return new EchoResponse.Void();
   }

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubPublisher.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubPublisher.java
@@ -48,6 +48,8 @@ public class GooglePubsubPublisher implements PubsubPublisher {
 
   private final PubsubSystem pubsubSystem = PubsubSystem.GOOGLE;
 
+  private String name;
+
   private String topicName;
 
   private String fullTopicName;
@@ -60,6 +62,7 @@ public class GooglePubsubPublisher implements PubsubPublisher {
 
   public static GooglePubsubPublisher buildPublisher(GooglePubsubPublisherConfig config, ObjectMapper mapper) {
     GooglePubsubPublisher publisher = new GooglePubsubPublisher();
+    publisher.setName(config.getName());
     ProjectTopicName fullName = ProjectTopicName.of(config.getProject(), config.getTopicName());
     publisher.setTopicName(config.getTopicName());
     publisher.setFullTopicName(fullName.toString());


### PR DESCRIPTION
part of https://github.com/spinnaker/spinnaker/issues/2784

We used to have a operator-defined `name` field, but I took it out in the last revamp. Adding it back in to support the (probably?) niche use case of the same topic name in different projects.

This means that in order to trigger notifications, we match on `publisherName` instead of `topic` in the incoming notification map.