### PR TITLE
feat(artifacts): Artifact extraction template for Docker

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/StandardJinjaTemplate.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/StandardJinjaTemplate.java
@@ -19,7 +19,8 @@ package com.netflix.spinnaker.echo.pipelinetriggers.artifacts;
 import java.io.InputStream;
 
 public enum StandardJinjaTemplate implements JinjaTemplate {
-  JAR("/jar.jinja");
+  JAR("/jar.jinja"),
+  DOCKER("/docker.jinja");
 
   private String jarPath;
 

--- a/echo-pipelinetriggers/src/main/resources/docker.jinja
+++ b/echo-pipelinetriggers/src/main/resources/docker.jinja
@@ -1,0 +1,9 @@
+[
+  {
+    {% set referenceParts = properties.image.split(':') -%}
+    "reference": "{{ properties.image }}",
+    "name": "{{ referenceParts[0] }}",
+    "version": "{{ referenceParts[1] }}",
+    "type": "docker/image"
+  }
+]


### PR DESCRIPTION
Provides a standard artifact extraction template to extract a Docker
image artifact from build properties.

Example property file:

```properties
image=path/to/registry:tag
messageFormat=DOCKER
```