### PR TITLE
chore(webhooks): cleanup unnecessary annotations

### DIFF
--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GithubWebhookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GithubWebhookEventHandler.java
@@ -64,7 +64,6 @@ public class GithubWebhookEventHandler implements GitWebhookHandler {
   }
 
   @Data
-  @JsonIgnoreProperties(ignoreUnknown = true)
   private static class GithubWebhookEvent {
     String after;
     String ref;
@@ -72,14 +71,12 @@ public class GithubWebhookEventHandler implements GitWebhookHandler {
   }
 
   @Data
-  @JsonIgnoreProperties(ignoreUnknown = true)
   private static class GithubWebhookRepository {
      GithubOwner owner;
      String name;
   }
 
   @Data
-  @JsonIgnoreProperties(ignoreUnknown = true)
   private static class GithubOwner {
     String name;
   }

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GitlabWehbookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GitlabWehbookEventHandler.java
@@ -52,7 +52,6 @@ public class GitlabWehbookEventHandler implements GitWebhookHandler {
   }
 
   @Data
-  @JsonIgnoreProperties(ignoreUnknown = true)
   private static class GitlabWebhookEvent {
     String after;
     String ref;
@@ -60,7 +59,6 @@ public class GitlabWehbookEventHandler implements GitWebhookHandler {
   }
 
   @Data
-  @JsonIgnoreProperties(ignoreUnknown = true)
   private static class GitlabProject {
     String name;
     String namespace;

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/StashWebhookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/StashWebhookEventHandler.java
@@ -54,28 +54,24 @@ public class StashWebhookEventHandler implements GitWebhookHandler {
   }
 
   @Data
-  @JsonIgnoreProperties(ignoreUnknown = true)
   private static class StashWebhookEvent {
     List<StashRefChanges> refChanges;
     StashRepository repository;
   }
 
   @Data
-  @JsonIgnoreProperties(ignoreUnknown = true)
   private static class StashRefChanges {
     String toHash;
     String refId;
   }
 
   @Data
-  @JsonIgnoreProperties(ignoreUnknown = true)
   private static class StashRepository {
     String slug;
     StashProject project;
   }
 
   @Data
-  @JsonIgnoreProperties(ignoreUnknown = true)
   private static class StashProject {
     String key;
   }


### PR DESCRIPTION
cleans up unnecessary annotations in `SCMWebhookHandler`
implementations.