### PR TITLE
feat(expressions): Allow SpEL expressions in expected artifacts

### DIFF
--- a/echo-pipelinetriggers/echo-pipelinetriggers.gradle
+++ b/echo-pipelinetriggers/echo-pipelinetriggers.gradle
@@ -25,6 +25,7 @@ dependencies {
   compile spinnaker.dependency('korkArtifacts')
   compile spinnaker.dependency('korkSecurity')
   compile spinnaker.dependency('korkWeb')
+  compile spinnaker.dependency('korkExpressions')
 
   compile spinnaker.dependency('bootWeb')
   compile spinnaker.dependency('bootActuator')

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ExpectedArtifactExpressionEvaluationPostProcessor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ExpectedArtifactExpressionEvaluationPostProcessor.java
@@ -1,0 +1,59 @@
+package com.netflix.spinnaker.echo.pipelinetriggers.postprocessors;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.echo.model.Pipeline;
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
+import com.netflix.spinnaker.kork.expressions.ExpressionEvaluationSummary;
+import com.netflix.spinnaker.kork.expressions.ExpressionTransform;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.ParserContext;
+import org.springframework.expression.common.TemplateParserContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Attempts to evaluate expressions in the pipeline's expected artifacts based on the pipeline's execution
+ * context to this point.
+ */
+@Component
+public class ExpectedArtifactExpressionEvaluationPostProcessor implements PipelinePostProcessor {
+  private final ObjectMapper mapper;
+  private final ExpressionParser parser = new SpelExpressionParser();
+  private final ParserContext parserContext = new TemplateParserContext("${", "}");
+
+  public ExpectedArtifactExpressionEvaluationPostProcessor(ObjectMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  @Override
+  public Pipeline processPipeline(Pipeline inputPipeline) {
+    EvaluationContext evaluationContext = new StandardEvaluationContext(inputPipeline);
+
+    return inputPipeline.withExpectedArtifacts(inputPipeline.getExpectedArtifacts().stream()
+      .map(artifact -> {
+        ExpressionEvaluationSummary summary = new ExpressionEvaluationSummary();
+        Map<String, Object> artifactMap = mapper.convertValue(artifact,
+          new TypeReference<Map<String, Object>>() {
+          });
+
+        Map<String, Object> evaluatedArtifact = new ExpressionTransform(parserContext, parser, Function.identity())
+          .transformMap(artifactMap, evaluationContext, summary);
+
+        return summary.getTotalEvaluated() > 0 ?
+          mapper.convertValue(evaluatedArtifact, ExpectedArtifact.class) : artifact;
+      })
+      .collect(Collectors.toList()));
+  }
+
+  @Override
+  public PostProcessorPriority priority() {
+    return PostProcessorPriority.EXPECTED_ARTIFACT_EXPRESSION_EVALUATION;
+  }
+}

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/PostProcessorPriority.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/PostProcessorPriority.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.pipelinetriggers.postprocessors;
 
 public enum PostProcessorPriority implements Comparable<PostProcessorPriority> {
   HIGHEST,
+  EXPECTED_ARTIFACT_EXPRESSION_EVALUATION,
   BUILD_INFO,
   DEFAULT,
   ARTIFACT_EXTRACTION,

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ExpectedArtifactExpressionEvaluationPostProcessorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ExpectedArtifactExpressionEvaluationPostProcessorSpec.groovy
@@ -1,0 +1,65 @@
+package com.netflix.spinnaker.echo.pipelinetriggers.postprocessors
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.echo.model.Trigger
+import com.netflix.spinnaker.echo.test.RetrofitStubs
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+
+class ExpectedArtifactExpressionEvaluationPostProcessorSpec extends Specification implements RetrofitStubs {
+  @Subject
+  def artifactPostProcessor = new ExpectedArtifactExpressionEvaluationPostProcessor(new ObjectMapper())
+
+  @Shared
+  def trigger = Trigger.builder()
+    .enabled(true).type('jenkins')
+    .master('master')
+    .job('job')
+    .buildNumber(100)
+    .build()
+
+  def 'evaluates expressions in expected artifacts'() {
+    given:
+    def artifact = new ExpectedArtifact(
+      matchArtifact: new Artifact(
+        name: '''group:artifact:${trigger['buildNumber']}''',
+        version: '''${trigger['buildNumber']}''',
+        type: 'maven/file',
+      ),
+      id: 'goodId'
+    )
+
+    def inputPipeline = createPipelineWith([artifact], trigger).withTrigger(trigger)
+
+    when:
+    def outputPipeline = artifactPostProcessor.processPipeline(inputPipeline)
+    def evaluatedArtifact = outputPipeline.expectedArtifacts[0].matchArtifact
+
+    then:
+    evaluatedArtifact.name == 'group:artifact:100'
+    evaluatedArtifact.version == '100'
+  }
+
+  def 'unevaluable expressions are left in place'() { // they may be evaluated later in a stage with more context
+    given:
+    def artifact = new ExpectedArtifact(
+      matchArtifact: new Artifact(
+        name: '''group:artifact:${#stage('deploy')['version']}''',
+        type: 'maven/file',
+      ),
+      id: 'goodId'
+    )
+
+    def inputPipeline = createPipelineWith([artifact], trigger).withTrigger(trigger)
+
+    when:
+    def outputPipeline = artifactPostProcessor.processPipeline(inputPipeline)
+    def evaluatedArtifact = outputPipeline.expectedArtifacts[0].matchArtifact
+
+    then:
+    evaluatedArtifact.name == '''group:artifact:${#stage('deploy')['version']}'''
+  }
+}


### PR DESCRIPTION
Echo will now attempt to evaluate any SpEL expressions in expected artifact inputs prior to matching against trigger artifacts.