### PR TITLE
fix(expressions): Fix NPE in artifact expression evaluation

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ExpectedArtifactExpressionEvaluationPostProcessor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ExpectedArtifactExpressionEvaluationPostProcessor.java
@@ -14,6 +14,8 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -36,7 +38,12 @@ public class ExpectedArtifactExpressionEvaluationPostProcessor implements Pipeli
   public Pipeline processPipeline(Pipeline inputPipeline) {
     EvaluationContext evaluationContext = new StandardEvaluationContext(inputPipeline);
 
-    return inputPipeline.withExpectedArtifacts(inputPipeline.getExpectedArtifacts().stream()
+    List<ExpectedArtifact> expectedArtifacts = inputPipeline.getExpectedArtifacts();
+    if (expectedArtifacts == null) {
+      expectedArtifacts = Collections.emptyList();
+    }
+
+    return inputPipeline.withExpectedArtifacts(expectedArtifacts.stream()
       .map(artifact -> {
         ExpressionEvaluationSummary summary = new ExpressionEvaluationSummary();
         Map<String, Object> artifactMap = mapper.convertValue(artifact,

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ExpectedArtifactExpressionEvaluationPostProcessorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ExpectedArtifactExpressionEvaluationPostProcessorSpec.groovy
@@ -62,4 +62,14 @@ class ExpectedArtifactExpressionEvaluationPostProcessorSpec extends Specificatio
     then:
     evaluatedArtifact.name == '''group:artifact:${#stage('deploy')['version']}'''
   }
+
+  def 'no exception is thrown when expectedArtifacts is null'() {
+    def inputPipeline = createPipelineWith(null, trigger).withTrigger(trigger)
+
+    when:
+    artifactPostProcessor.processPipeline(inputPipeline)
+
+    then:
+    noExceptionThrown()
+  }
 }


### PR DESCRIPTION
While the UI always populates expectedArtifacts on new pipelines, this isn't enforced server-side so it's possible for a pipeline to have null expectedArtifacts.

Our integration tests were throwing an NPE when trying to start pipelines without expectedArtifacts explicitly set.