### PR TITLE
fix(pipelines): Add keepWaitingPipelines to Pipeline model

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
@@ -58,6 +58,9 @@ public class Pipeline {
   boolean limitConcurrent;
 
   @JsonProperty
+  boolean keepWaitingPipelines;
+
+  @JsonProperty
   boolean plan;
 
   @JsonProperty


### PR DESCRIPTION
The Pipeline model is missing keepWaitingPipelines, which means it's ignored on deserialization and setting it on a pipeline has no effect.