### PR TITLE
Use annotationProcessor scope for lombok

### DIFF
--- a/echo-core/echo-core.gradle
+++ b/echo-core/echo-core.gradle
@@ -15,6 +15,8 @@
  */
 
 dependencies {
+    annotationProcessor spinnaker.dependency('lombok')
+
     spinnaker.group("retrofitDefault")
 
     compile project(":echo-model")


### PR DESCRIPTION
Hi folks, this happened between gradle 4 and 5:

> Gradle 4.6 (Released 2018-02-28) deprecated annotation processors on the compile classpath in favor of the new annotationProcessor configuration to improve incremental compilation performance. In Gradle 5.0 annotation processors have moved to their own configuration.

lombok dependency comes as transitive in compile configuration from echo-core -> https://dl.bintray.com/spinnaker/spinnaker/com/netflix/spinnaker/echo/echo-core/1.585.2/echo-core-1.585.2.pom

  ```<dependency>
      <groupId>org.projectlombok</groupId>
      <artifactId>lombok</artifactId>
      <version>1.16.20</version>
      <scope>compile</scope>
    </dependency>```

If someone has an application which uses `echo-core` and tries to use `lombok` from it's transitive dependency, it will fail because it won't be processed by gradle  (not being part of `annotationProcessor`).

Ideally, this dependency shouldn't be part of the compile scope to support future versions of Gradle
