### PR TITLE
fix(trigger): Fixed configuration for manual pipeline triggers

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -65,6 +65,10 @@ public class Trigger {
   String type;
   boolean enabled;
 
+  // Configuration for pipeline triggers
+  String parentPipelineId;
+  String paraentPipelineApplication;
+
   // Configuration for git triggers
   String project;
   String slug;


### PR DESCRIPTION
Manually triggering a pipeline with a pipeline trigger fails because the pipeline trigger attributes are not deserialized and passed downstream to orca which needs those attributes to retrieve artifacts from upstream pipeline. This fix adds these attributes to the trigger model so they get deserialized and passed downstream.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
