### PR TITLE
refactor(triggers): Improve code sharing for manual and build triggers

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandler.java
@@ -26,7 +26,10 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -99,19 +102,9 @@ public class BuildEventHandler extends BaseTriggerEventHandler<BuildEvent> {
   }
 
   protected List<Artifact> getArtifactsFromEvent(BuildEvent event, Trigger trigger) {
-    List<Artifact> buildArtifacts = Optional.ofNullable(event.getContent())
-      .map(BuildEvent.Content::getProject)
-      .map(BuildEvent.Project::getLastBuild)
-      .map(BuildEvent.Build::getArtifacts)
-      .orElse(Collections.emptyList());
-
-    List<Artifact> extractedArtifacts = buildInfoService
-      .map(b -> b.getArtifacts(event, trigger.getPropertyFile()))
-      .orElse(Collections.emptyList());
-
-    List <Artifact> result = new ArrayList<>();
-    result.addAll(buildArtifacts);
-    result.addAll(extractedArtifacts);
-    return result;
+    if (buildInfoService.isPresent()) {
+      return buildInfoService.get().getArtifactsFromBuildEvent(event, trigger);
+    }
+    return Collections.emptyList();
   }
 }


### PR DESCRIPTION
Manual triggers currently don't pass along build artifacts from the 'artifacts' field of the build (as opposed to jinja-extracted artifacts which they do). Update them to do so, making it possible to remove the [special-case logic in Orca](https://github.com/spinnaker/orca/blob/b549b58c213220b604860d9e4625e0ef5296312d/orca-web/src/main/groovy/com/netflix/spinnaker/orca/controllers/OperationsController.groovy#L281) to handle this.

This commit also pushes some logic from the build handler to the `BuildInfoService` so it can be shared.