### PR TITLE
fix(pubsub/google): Remove tag from image name

### DIFF
--- a/echo-pubsub-google/src/main/resources/gcb.jinja
+++ b/echo-pubsub-google/src/main/resources/gcb.jinja
@@ -3,7 +3,7 @@
   {
     {% set split = image.name.split(":") %}
     "reference": "{{ split[0] }}@{{ image.digest }}",
-    "name": "{{ image.name }}",
+    "name": "{{ split[0] }}",
     "version": "{{ image.digest }}",
     "type": "docker/image"
   } {% if (not loop.last) or ((artifacts.objects.paths | length) > 0) %} , {% endif %} {% endfor %}


### PR DESCRIPTION
The GCB artifact extractor currently includes the tag in the image name; this conflicts with the general convention of excluding it and leads to issues matching incoming artifacts and replacing artifacts in manifests. Fix this to only include the image name.