### PR TITLE
feat(artifacts): populate artifacts for manual trigger

### DIFF
--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/artifacts/ArtifactInfoService.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/artifacts/ArtifactInfoService.java
@@ -1,0 +1,43 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.echo.artifacts;
+
+import com.netflix.spinnaker.echo.services.IgorService;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+
+import java.util.List;
+
+/**
+ * Given an artifact, fetch the details from an artifact provider
+ */
+public class ArtifactInfoService {
+
+  private final IgorService igorService;
+
+  public ArtifactInfoService(IgorService igorService) {
+    this.igorService = igorService;
+  }
+
+  public List<String> getVersions(String provider, String packageName) {
+    return igorService.getVersions(provider, packageName);
+  }
+
+  public Artifact getArtifactByVersion(String provider, String packageName, String version) {
+    return igorService.getArtifactByVersion(provider, packageName, version);
+  }
+}

--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/config/ArtifactInfoConfig.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/config/ArtifactInfoConfig.java
@@ -1,0 +1,33 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.echo.config;
+
+import com.netflix.spinnaker.echo.artifacts.ArtifactInfoService;
+import com.netflix.spinnaker.echo.services.IgorService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty("igor.enabled")
+public class ArtifactInfoConfig {
+  @Bean
+  ArtifactInfoService artifactInfoService(IgorService igorService) {
+    return new ArtifactInfoService(igorService);
+  }
+}

--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/config/BuildInfoConfig.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/config/BuildInfoConfig.java
@@ -1,0 +1,34 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.echo.config;
+
+import com.netflix.spinnaker.echo.build.BuildInfoService;
+import com.netflix.spinnaker.echo.services.IgorService;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty("igor.enabled")
+public class BuildInfoConfig {
+  @Bean
+  BuildInfoService buildInfoService(IgorService igorService, RetrySupport retrySupport) {
+    return new BuildInfoService(igorService, retrySupport);
+  }
+}

--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/services/IgorService.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/services/IgorService.java
@@ -41,4 +41,13 @@ public interface IgorService {
     @Query("propertyFile") String propertyFile,
     @Path("master") String master,
     @Path(value = "job", encode = false) String job);
+
+  @GET("/artifacts/{provider}/{packageName}")
+  List<String> getVersions(@Path("provider") String provider,
+                           @Path("packageName") String packageName);
+
+  @GET("/artifacts/{provider}/{packageName}/{version}")
+  Artifact getArtifactByVersion(@Path("provider") String provider,
+                                @Path("packageName") String packageName,
+                                @Path("version") String version);
 }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import com.netflix.spinnaker.echo.artifacts.ArtifactInfoService;
 import com.netflix.spinnaker.echo.build.BuildInfoService;
 import com.netflix.spinnaker.echo.model.Event;
 import com.netflix.spinnaker.echo.model.Pipeline;
@@ -25,8 +27,12 @@ import com.netflix.spinnaker.echo.model.trigger.BuildEvent;
 import com.netflix.spinnaker.echo.model.trigger.ManualEvent;
 import com.netflix.spinnaker.echo.model.trigger.ManualEvent.Content;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -39,12 +45,24 @@ import java.util.*;
  * looks for the pipeline whose application and id/name match the manual execution request.
  */
 @Component
-@RequiredArgsConstructor
 public class ManualEventHandler implements TriggerEventHandler<ManualEvent> {
   private static final String MANUAL_TRIGGER_TYPE = "manual";
+  private static final Logger log = LoggerFactory.getLogger(ManualEventHandler.class);
 
   private final ObjectMapper objectMapper;
   private final Optional<BuildInfoService> buildInfoService;
+  private final Optional<ArtifactInfoService> artifactInfoService;
+
+  @Autowired
+  public ManualEventHandler(
+    ObjectMapper objectMapper,
+    Optional<BuildInfoService> buildInfoService,
+    Optional<ArtifactInfoService> artifactInfoService
+  ) {
+    this.objectMapper = objectMapper;
+    this.buildInfoService = buildInfoService;
+    this.artifactInfoService = artifactInfoService;
+  }
 
   @Override
   public boolean handleEventType(String eventType) {
@@ -74,10 +92,10 @@ public class ManualEventHandler implements TriggerEventHandler<ManualEvent> {
       && (pipeline.getName().equals(nameOrId) || pipeline.getId().equals(nameOrId));
   }
 
-  private Pipeline buildTrigger(Pipeline pipeline, Trigger manualTrigger) {
+  protected Pipeline buildTrigger(Pipeline pipeline, Trigger manualTrigger) {
     List<Map<String, Object>> notifications = buildNotifications(pipeline.getNotifications(), manualTrigger.getNotifications());
     Trigger trigger = manualTrigger.atPropagateAuth(true);
-    List<Artifact> artifacts = Collections.emptyList();
+    List<Artifact> artifacts = new ArrayList<>();
     String master = manualTrigger.getMaster();
     String job = manualTrigger.getJob();
     if (buildInfoService.isPresent() && StringUtils.isNoneEmpty(master, job)) {
@@ -85,12 +103,45 @@ public class ManualEventHandler implements TriggerEventHandler<ManualEvent> {
       trigger = trigger
         .withBuildInfo(buildInfoService.get().getBuildInfo(buildEvent))
         .withProperties(buildInfoService.get().getProperties(buildEvent, manualTrigger.getPropertyFile()));
-      artifacts = buildInfoService.get().getArtifactsFromBuildEvent(buildEvent, manualTrigger);
+      artifacts.addAll(buildInfoService.get().getArtifactsFromBuildEvent(buildEvent, manualTrigger));
+    }
+
+    if (artifactInfoService.isPresent() && manualTrigger.getArtifacts().size() != 0) {
+      List<Artifact> resolvedArtifacts = resolveArtifacts(manualTrigger.getArtifacts());
+      artifacts.addAll(resolvedArtifacts);
+      // Remove the artifact lookup information. It will be replaced with the full artifacts if they can be resolved.
+      trigger = trigger.withArtifacts(Collections.emptyList());
     }
     return pipeline
       .withTrigger(trigger)
       .withNotifications(notifications)
       .withReceivedArtifacts(artifacts);
+  }
+
+  protected List<Artifact> resolveArtifacts(List<Map<String, Object>> manualTriggerArtifacts) {
+    List<Artifact> resolvedArtifacts = new ArrayList<>();
+    for (Map a : manualTriggerArtifacts) {
+      Artifact artifact =  objectMapper.convertValue(a, Artifact.class);
+
+      if (Strings.isNullOrEmpty(artifact.getName()) ||
+        Strings.isNullOrEmpty(artifact.getVersion()) ||
+        Strings.isNullOrEmpty(artifact.getLocation())) {
+        log.error("Artifact does not have enough information to fetch. " +
+          "Artifact must contain name, version, and location.");
+      } else {
+        try {
+          Artifact resolvedArtifact = artifactInfoService.get()
+            .getArtifactByVersion(artifact.getLocation(), artifact.getName(), artifact.getVersion());
+          if (resolvedArtifact != null) {
+            resolvedArtifacts.add(resolvedArtifact);
+          }
+        } catch (NotFoundException e) {
+          log.error("Artifact " + artifact.getName() + " " + artifact.getVersion() +
+            " not found in image provider " + artifact.getLocation());
+        }
+      }
+    }
+    return resolvedArtifacts;
   }
 
   private List<Map<String, Object>> buildNotifications(List<Map<String, Object>> pipelineNotifications, List<Map<String, Object>> triggerNotifications) {

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandlerSpec.groovy
@@ -1,0 +1,137 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.echo.artifacts.ArtifactInfoService
+import com.netflix.spinnaker.echo.build.BuildInfoService
+import com.netflix.spinnaker.echo.model.Pipeline
+import com.netflix.spinnaker.echo.model.Trigger
+import com.netflix.spinnaker.echo.test.RetrofitStubs
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+import spock.lang.Subject
+
+class ManualEventHandlerSpec extends Specification implements RetrofitStubs {
+  def objectMapper = new ObjectMapper()
+  def buildInfoService = Mock(BuildInfoService)
+  def artifactInfoService = Mock(ArtifactInfoService)
+
+  private static final Logger log = LoggerFactory.getLogger(ManualEventHandler.class)
+
+  Artifact artifact = new Artifact(
+    "deb",
+    false,
+    "my-package",
+    "v1.1.1",
+    "https://artifactory/my-package/",
+    "https://artifactory/my-package/",
+    [:],
+    "account",
+    "provenance",
+    "123456"
+  )
+
+  @Subject
+  def eventHandler = new ManualEventHandler(
+    objectMapper,
+    Optional.of(buildInfoService),
+    Optional.of(artifactInfoService)
+  )
+
+  def "should replace artifact with full version if it exists"() {
+    given:
+    Map<String, Object> triggerArtifact = [
+      name: "my-package",
+      version: "v1.1.1",
+      location: "artifactory"
+    ]
+
+    Trigger trigger = Trigger.builder().enabled(true).type("artifact").artifactName("my-package").build()
+    Pipeline inputPipeline = createPipelineWith(trigger)
+    Trigger manualTrigger = Trigger.builder().type("manual").artifacts([triggerArtifact]).build()
+
+    when:
+    artifactInfoService.getArtifactByVersion("artifactory", "my-package", "v1.1.1") >> artifact
+    def resolvedPipeline = eventHandler.buildTrigger(inputPipeline, manualTrigger)
+
+    then:
+    resolvedPipeline.receivedArtifacts.size() == 1
+    resolvedPipeline.receivedArtifacts.first().name == "my-package"
+  }
+
+  def "should resolve artifact if it exists"() {
+    given:
+    Map<String, Object> triggerArtifact = [
+      name: "my-package",
+      version: "v1.1.1",
+      location: "artifactory"
+    ]
+    List<Map<String, Object>> triggerArtifacts = [triggerArtifact]
+
+    when:
+    artifactInfoService.getArtifactByVersion("artifactory", "my-package", "v1.1.1") >> artifact
+    List<Artifact> resolvedArtifacts = eventHandler.resolveArtifacts(triggerArtifacts)
+
+    then:
+    resolvedArtifacts.size() == 1
+    resolvedArtifacts.first().name == "my-package"
+  }
+
+  def "should not resolve artifact if it doesn't exist"() {
+    given:
+    Map<String, Object> triggerArtifact = [
+      name: "my-package",
+      version: "v2.2.2",
+      location: "artifactory"
+    ]
+    List<Map<String, Object>> triggerArtifacts = [triggerArtifact]
+
+    when:
+    artifactInfoService.getArtifactByVersion("artifactory", "my-package", "v2.2.2") >> { throw new NotFoundException() }
+    List<Artifact> resolvedArtifacts = eventHandler.resolveArtifacts(triggerArtifacts)
+
+    then:
+    resolvedArtifacts.size() == 0
+  }
+
+  def "should remove artifact if it doesn't exist"() {
+    given:
+    Map<String, Object> triggerArtifact = [
+      name: "my-package",
+      version: "v2.2.2",
+      location: "artifactory"
+    ]
+    Trigger trigger = Trigger.builder().enabled(true).type("artifact").artifactName("my-package").build()
+    Pipeline inputPipeline = createPipelineWith(trigger)
+    Trigger manualTrigger = Trigger.builder().type("manual").artifacts([triggerArtifact]).build()
+
+    when:
+    artifactInfoService.getArtifactByVersion("artifactory", "my-package", "v2.2.2") >> { throw new NotFoundException() }
+    def resolvedPipeline = eventHandler.buildTrigger(inputPipeline, manualTrigger)
+
+    then:
+    resolvedPipeline.receivedArtifacts.size() == 0
+  }
+
+}
+
+


### PR DESCRIPTION
Make config for build and artifact services explicit.
Add a function to resolve artifacts.

If a manual trigger body looks like:
```
"trigger": {
	    "type": "manual",
	    "dryRun": false,
	    "user": "emburns@netflix.com",
	    "artifacts": [{
        "name": "my-package",
        "version": "v1.1.1",
        "location": "artifactory"
      }]
		}
``` 
Then we will try to resolve the artifact. If that artifact doesn't exist, or you don't have any providers which match the location in `igor`, then the artifact won't be found and it will be removed from the manual trigger. 

@jkschneider for the manual artifactory trigger you'll need to implement lookup logic in `igor` and the ui bits that will add this half fleshed out artifact into the manual trigger.

@ezimanyi thoughts on if using the artifacts field on the trigger to provide a partially fleshed out artifact is the right strategy? I thought it was okay because it's pretty clear to the user and easy to reason about. It also gives us all the right fields to parse many artifacts from different places.
