### PR TITLE
fix(pipeline): if map -> Pipeline fails, log and move on

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
@@ -154,30 +154,42 @@ public class PipelineCache implements MonitoredPoller {
     };
 
     return rawPipelines.stream()
-      .map((Map<String, Object> p) -> {
-        if (isV2Pipeline.test(p)) {
-          try {
-            return orca.v2Plan(p);
-          } catch (Exception e) {
-            // Don't fail the entire cache cycle if we fail a plan.
-            log.error("Caught exception while planning templated pipeline: {}", p, e);
-            return Collections.emptyMap();
-          }
-        } else {
-          return p;
-        }
-      })
+      .map((Map<String, Object> p) -> planPipelineIfNeeded(p, isV2Pipeline))
       .filter(m -> !m.isEmpty())
-      .map(m -> {
-        try {
-          return objectMapper.convertValue(m, Pipeline.class);
-        } catch (Exception e) {
-          log.warn("Pipeline failed to be converted to Pipeline.class: {}", m, e);
-          return null;
-        }
-      })
+      .map(m -> convertToPipeline(m))
       .filter(Objects::nonNull)
       .collect(Collectors.toList());
+  }
+
+  /**
+   * If the pipeline is a v2 pipeline, plan that pipeline.
+   * Returns an empty map if the plan fails, so that the pipeline is skipped.
+   */
+  private Map<String, Object> planPipelineIfNeeded(Map<String, Object> pipeline, Predicate<Map<String, Object>> isV2Pipeline) {
+    if (isV2Pipeline.test(pipeline)) {
+      try {
+        return orca.v2Plan(pipeline);
+      } catch (Exception e) {
+        // Don't fail the entire cache cycle if we fail a plan.
+        log.error("Caught exception while planning templated pipeline: {}", pipeline, e);
+        return Collections.emptyMap();
+      }
+    } else {
+      return pipeline;
+    }
+  }
+
+  /**
+   * Converts map to pipeline.
+   * Returns null if conversion fails so that the pipeline is skipped.
+   */
+  private Pipeline convertToPipeline(Map<String, Object> pipeline) {
+    try {
+      return objectMapper.convertValue(pipeline, Pipeline.class);
+    } catch (Exception e) {
+      log.warn("Pipeline failed to be converted to Pipeline.class: {}", pipeline, e);
+      return null;
+    }
   }
 
   @Override


### PR DESCRIPTION
For some reason we had a malformed pipeline with a null name (old). After this PR (https://github.com/spinnaker/echo/pull/504/files#diff-123d58ccbba1de00453419d04e10722e) echo wouldn't start up with that. This adds some logging and filtering to continue ignoring that malformed pipeline, just in case...