### PR TITLE
fix(events): Guard against NPE when artifacts is not set.

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 import retrofit.RetrofitError;
 
 import java.util.*;
@@ -108,7 +109,7 @@ public class ManualEventHandler implements TriggerEventHandler<ManualEvent> {
       artifacts.addAll(buildInfoService.get().getArtifactsFromBuildEvent(buildEvent, manualTrigger));
     }
 
-    if (artifactInfoService.isPresent() && manualTrigger.getArtifacts().size() != 0) {
+    if (artifactInfoService.isPresent() && !CollectionUtils.isEmpty(manualTrigger.getArtifacts())) {
       List<Artifact> resolvedArtifacts = resolveArtifacts(manualTrigger.getArtifacts());
       artifacts.addAll(resolvedArtifacts);
       // update the artifacts on the manual trigger with the resolved artifacts


### PR DESCRIPTION
We were seeing occasional NPE's during manual execution:
```
java.lang.NullPointerException: null
	at com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.ManualEventHandler.buildTrigger(ManualEventHandler.java:111) ~[echo-pipelinetriggers.jar:na]
	at com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.ManualEventHandler.withMatchingTrigger(ManualEventHandler.java:85) ~[echo-pipelinetriggers.jar:na]
	at com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.ManualEventHandler.withMatchingTrigger(ManualEventHandler.java:49) ~[echo-pipelinetriggers.jar:na]
	at com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.TriggerEventHandler.lambda$getMatchingPipelines$0(TriggerEventHandler.java:67) ~[echo-pipelinetriggers.jar:na]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[na:1.8.0_191]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382) ~[na:1.8.0_191]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[na:1.8.0_191]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[na:1.8.0_191]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[na:1.8.0_191]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:1.8.0_191]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499) ~[na:1.8.0_191]
	at com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.TriggerEventHandler.getMatchingPipelines(TriggerEventHandler.java:70) ~[echo-pipelinetriggers.jar:na]
	at com.netflix.spinnaker.echo.pipelinetriggers.monitor.TriggerMonitor.triggerMatchingPipelines(TriggerMonitor.java:78) ~[echo-pipelinetriggers.jar:na]
	at com.netflix.spinnaker.echo.pipelinetriggers.monitor.TriggerMonitor.processEvent(TriggerMonitor.java:63) ~[echo-pipelinetriggers.jar:na]
	at com.netflix.spinnaker.echo.pipelinetriggers.monitor.TriggerEventListener.processEvent(TriggerEventListener.java:56) ~[echo-pipelinetriggers.jar:na]
	at com.netflix.spinnaker.echo.events.EventPropagator.lambda$null$0(EventPropagator.java:46) ~[echo-core.jar:na]
	at com.netflix.spinnaker.security.AuthenticatedRequest.lambda$propagate$0(AuthenticatedRequest.java:97) ~[kork-security-3.11.0.jar:3.11.0]
	at com.netflix.spinnaker.echo.events.EventPropagator.lambda$processEvent$2(EventPropagator.java:53) ~[echo-core.jar:na]
	at rx.internal.util.ActionSubscriber.onNext(ActionSubscriber.java:39) ~[rxjava-1.3.8.jar:1.3.8]
	at rx.observers.SafeSubscriber.onNext(SafeSubscriber.java:134) ~[rxjava-1.3.8.jar:1.3.8]
	at rx.internal.operators.OperatorObserveOn$ObserveOnSubscriber.call(OperatorObserveOn.java:224) ~[rxjava-1.3.8.jar:1.3.8]
	at rx.internal.schedulers.CachedThreadScheduler$EventLoopWorker$1.call(CachedThreadScheduler.java:230) ~[rxjava-1.3.8.jar:1.3.8]
	at rx.internal.schedulers.ScheduledAction.run(ScheduledAction.java:55) ~[rxjava-1.3.8.jar:1.3.8]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[na:1.8.0_191]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[na:1.8.0_191]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) ~[na:1.8.0_191]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) ~[na:1.8.0_191]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_191]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_191]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_191]
```