### PR TITLE
fix(mpt): fix planing of v1 pipelines for manual triggers

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
@@ -100,5 +100,13 @@ public class Pipeline {
 
   @JsonPOJOBuilder(withPrefix = "")
   public static final class PipelineBuilder {
+    @JsonProperty("config")
+    private void unpackConfig(Map<String, Object> config) {
+      if (config == null) {
+        return;
+      }
+      this.config = config;
+      schema = (String) config.get("schema");
+    }
   }
 }


### PR DESCRIPTION
We saw that manual triggering of V1 pipelines stopped working because schema wasn't being set correctly.

More specifically, echo gets a pipeline and then calls out to orca to plan. On this conversion (https://github.com/spinnaker/orca/blob/master/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/PipelineTemplatePreprocessor.kt#L62) the `objectMapper` is not correctly pulling out the `schema` field from the `config` map (https://github.com/spinnaker/orca/blob/master/orca-pipelinetemplate/src/main/java/com/netflix/spinnaker/orca/pipelinetemplate/TemplatedPipelineRequest.java#L42). This used to not be a problem because in echo `Pipeline` did not have `schema` field (introduced in https://github.com/spinnaker/echo/pull/504/files). Adding `schema` to the echo definition of pipelines without also pulling out the `schema` from `config` seemed to lead to `schema` never getting extracted, and v1 pipelines failing to manually trigger.

This fixes that issue.