### PR TITLE
refactor(logging): Log better messages when events fail

### DIFF
--- a/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/RestEventListenerSpec.groovy
+++ b/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/RestEventListenerSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.echo.events
 
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.echo.config.RestUrls
 import com.netflix.spinnaker.echo.model.Event
 import com.netflix.spinnaker.echo.rest.RestService
@@ -26,7 +27,7 @@ import spock.lang.Subject
 class RestEventListenerSpec extends Specification {
 
   @Subject
-  RestEventListener listener = new RestEventListener()
+  RestEventListener listener = new RestEventListener(null, null, new NoopRegistry())
   Event event = new Event(content: ['uno': 'dos'])
   RestService restService
 


### PR DESCRIPTION
Currently we log the whole event first which can be quite large and thus overloads our log provider (truncating the message)
Split the log into parts such as the important bits are first and the rest can get truncated
