### PR TITLE
fix(retrofit): make sure all retrofit clients use Jackson

### DIFF
--- a/echo-artifacts/src/main/java/com/netflix/spinnaker/echo/config/KeelConfig.java
+++ b/echo-artifacts/src/main/java/com/netflix/spinnaker/echo/config/KeelConfig.java
@@ -12,6 +12,7 @@ import retrofit.Endpoint;
 import retrofit.Endpoints;
 import retrofit.RestAdapter;
 import retrofit.RestAdapter.LogLevel;
+import retrofit.converter.JacksonConverter;
 
 @Configuration
 @Slf4j
@@ -33,6 +34,7 @@ public class KeelConfig {
                                  LogLevel retrofitLogLevel) {
     return new RestAdapter.Builder()
       .setEndpoint(keelEndpoint)
+      .setConverter(new JacksonConverter())
       .setClient(ok3Client)
       .setLogLevel(retrofitLogLevel)
       .setLog(new Slf4jRetrofitLogger(KeelService.class)).build()

--- a/echo-core/src/test/groovy/com/netflix/spinnaker/echo/services/Front50ServiceSpec.groovy
+++ b/echo-core/src/test/groovy/com/netflix/spinnaker/echo/services/Front50ServiceSpec.groovy
@@ -4,6 +4,7 @@ import groovy.json.JsonOutput
 import com.netflix.spinnaker.echo.model.Trigger
 import retrofit.Endpoints
 import retrofit.RestAdapter
+import retrofit.converter.JacksonConverter
 import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Subject
@@ -18,6 +19,7 @@ class Front50ServiceSpec extends Specification {
   def client = Stub(Client)
   @Subject front50 = new RestAdapter.Builder()
     .setEndpoint(Endpoints.newFixedEndpoint(endpoint))
+    .setConverter(new JacksonConverter())
     .setClient(client)
     .build()
     .create(Front50Service)

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/BearychatConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/BearychatConfig.groovy
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.echo.config
 
 import com.netflix.spinnaker.echo.bearychat.BearychatService
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger
+import retrofit.converter.JacksonConverter
+
 import static retrofit.Endpoints.newFixedEndpoint
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -47,6 +49,7 @@ class BearychatConfig {
 
     new RestAdapter.Builder()
       .setEndpoint(bearychatEndpoint)
+      .setConverter(new JacksonConverter())
       .setClient(retrofitClient)
       .setLogLevel(retrofitLogLevel)
       .setLog(new Slf4jRetrofitLogger(BearychatService.class))

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/DryRunConfig.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/DryRunConfig.java
@@ -32,6 +32,8 @@ import org.springframework.context.annotation.Configuration;
 import retrofit.Endpoint;
 import retrofit.RestAdapter;
 import retrofit.client.OkClient;
+import retrofit.converter.JacksonConverter;
+
 import static retrofit.Endpoints.newFixedEndpoint;
 
 @Configuration
@@ -55,6 +57,7 @@ public class DryRunConfig {
     log.info("Pipeline dry runs will execute at {}", dryRunEndpoint.getUrl());
     OrcaService orca = new RestAdapter.Builder()
       .setEndpoint(dryRunEndpoint)
+      .setConverter(new JacksonConverter())
       .setClient(new OkClient(okHttpClient))
       .setLogLevel(retrofitLogLevel)
       .setLog(new Slf4jRetrofitLogger(OrcaService.class))

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/GithubConfig.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/GithubConfig.java
@@ -27,6 +27,7 @@ import retrofit.Endpoint;
 import retrofit.Endpoints;
 import retrofit.RestAdapter;
 import retrofit.client.Client;
+import retrofit.converter.JacksonConverter;
 
 @Configuration
 @ConditionalOnProperty("githubStatus.enabled")
@@ -46,6 +47,7 @@ public class GithubConfig {
 
     GithubService githubClient = new RestAdapter.Builder()
       .setEndpoint(githubEndpoint)
+      .setConverter(new JacksonConverter())
       .setClient(retrofitClient)
       .setLogLevel(RestAdapter.LogLevel.FULL)
       .setLog(new Slf4jRetrofitLogger(GithubService.class))

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/GoogleChatConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/GoogleChatConfig.groovy
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Configuration
 import retrofit.Endpoint
 import retrofit.RestAdapter
 import retrofit.client.Client
+import retrofit.converter.JacksonConverter
 
 import static retrofit.Endpoints.newFixedEndpoint
 
@@ -47,6 +48,7 @@ class GoogleChatConfig {
     log.info("Chat service loaded");
 
     def chatClient = new RestAdapter.Builder()
+            .setConverter(new JacksonConverter())
             .setClient(retrofitClient)
             .setEndpoint(chatEndpoint)
             .setLogLevel(retrofitLogLevel)

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/HipchatConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/HipchatConfig.groovy
@@ -18,6 +18,8 @@
 
 package com.netflix.spinnaker.echo.config
 
+import retrofit.converter.JacksonConverter
+
 import static retrofit.Endpoints.newFixedEndpoint
 
 import com.netflix.spinnaker.echo.hipchat.HipchatService
@@ -50,6 +52,7 @@ class HipchatConfig {
 
         new RestAdapter.Builder()
                 .setEndpoint(hipchatEndpoint)
+                .setConverter(new JacksonConverter())
                 .setClient(retrofitClient)
                 .setLogLevel(retrofitLogLevel)
                 .setLog(new Slf4jRetrofitLogger(HipchatService.class))

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/JiraConfig.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/JiraConfig.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Configuration;
 import retrofit.RestAdapter;
 import retrofit.client.Client;
 import retrofit.client.OkClient;
+import retrofit.converter.JacksonConverter;
 
 import static retrofit.Endpoints.newFixedEndpoint;
 
@@ -53,6 +54,7 @@ public class JiraConfig {
 
     RestAdapter.Builder builder = new RestAdapter.Builder()
       .setEndpoint(newFixedEndpoint(jiraProperties.getBaseUrl()))
+      .setConverter(new JacksonConverter())
       .setClient(retrofitClient)
       .setLogLevel(retrofitLogLevel)
       .setLog(new Slf4jRetrofitLogger(JiraService.class));

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/PagerDutyConfig.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/PagerDutyConfig.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Configuration;
 import retrofit.Endpoint;
 import retrofit.RestAdapter;
 import retrofit.client.Client;
+import retrofit.converter.JacksonConverter;
 
 import static retrofit.Endpoints.newFixedEndpoint;
 
@@ -47,6 +48,7 @@ public class PagerDutyConfig {
 
     return new RestAdapter.Builder()
       .setEndpoint(pagerDutyEndpoint)
+      .setConverter(new JacksonConverter())
       .setClient(retrofitClient)
       .setLogLevel(retrofitLogLevel)
       .setLog(new Slf4jRetrofitLogger(PagerDutyService.class))

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Configuration
 import retrofit.Endpoint
 import retrofit.RestAdapter
 import retrofit.client.Client
+import retrofit.converter.JacksonConverter
 
 import static retrofit.Endpoints.newFixedEndpoint
 
@@ -60,6 +61,7 @@ class SlackConfig {
 
     def slackClient = new RestAdapter.Builder()
         .setEndpoint(slackEndpoint)
+        .setConverter(new JacksonConverter())
         .setClient(retrofitClient)
         .setLogLevel(retrofitLogLevel)
         .setLog(new Slf4jRetrofitLogger(SlackClient.class))

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/IgorConfig.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/IgorConfig.java
@@ -29,6 +29,7 @@ import retrofit.Endpoints;
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter.Builder;
 import retrofit.RestAdapter.LogLevel;
+import retrofit.converter.JacksonConverter;
 
 @Configuration
 @ConditionalOnProperty("igor.enabled")
@@ -45,6 +46,7 @@ public class IgorConfig {
     log.info("igor service loaded");
     return new Builder()
       .setEndpoint(igorEndpoint)
+      .setConverter(new JacksonConverter())
       .setClient(ok3Client)
       .setRequestInterceptor(spinnakerRequestInterceptor)
       .setLogLevel(retrofitLogLevel)

--- a/echo-web/src/main/java/com/netflix/spinnaker/echo/config/Front50Config.java
+++ b/echo-web/src/main/java/com/netflix/spinnaker/echo/config/Front50Config.java
@@ -30,6 +30,7 @@ import retrofit.Endpoints;
 import retrofit.RestAdapter.Builder;
 import retrofit.RestAdapter.LogLevel;
 import retrofit.client.OkClient;
+import retrofit.converter.JacksonConverter;
 
 @Configuration
 @Slf4j
@@ -65,8 +66,10 @@ public class Front50Config {
   public Front50Service front50Service(Endpoint front50Endpoint, OkHttpClient okHttpClient,
     LogLevel retrofitLogLevel) {
     log.info("front50 service loaded");
+
     return new Builder()
       .setEndpoint(front50Endpoint)
+      .setConverter(new JacksonConverter())
       .setClient(new OkClient(okHttpClient))
       .setLogLevel(retrofitLogLevel)
       .setLog(new Slf4jRetrofitLogger(Front50Service.class)).build()


### PR DESCRIPTION
GSON is the default converter. It, for some reason, takes a perfectly valid JSON
with integers and parses them as doubles (sometimes). Jackson doesn't do that.
Jackson is better, use it.

