### PR TITLE
fix(triggers): Ensure build number is present

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
@@ -101,8 +101,9 @@ public class ManualEventHandler implements TriggerEventHandler<ManualEvent> {
     List<Artifact> artifacts = new ArrayList<>();
     String master = manualTrigger.getMaster();
     String job = manualTrigger.getJob();
-    if (buildInfoService.isPresent() && StringUtils.isNoneEmpty(master, job)) {
-      BuildEvent buildEvent = buildInfoService.get().getBuildEvent(master, job, manualTrigger.getBuildNumber());
+    Integer buildNumber = manualTrigger.getBuildNumber();
+    if (buildInfoService.isPresent() && StringUtils.isNoneEmpty(master, job) && buildNumber != null) {
+      BuildEvent buildEvent = buildInfoService.get().getBuildEvent(master, job, buildNumber);
       trigger = trigger
         .withBuildInfo(buildInfoService.get().getBuildInfo(buildEvent))
         .withProperties(buildInfoService.get().getProperties(buildEvent, manualTrigger.getPropertyFile()));


### PR DESCRIPTION
If the trigger payload has a `job` and `master` but not the `buildNumber`
echo will fail to kick off a pipeline without any warning
