### PR TITLE
refactor(pubsub): Encapsulate logic for creating events

### DIFF
--- a/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
+++ b/echo-pubsub-aws/src/test/groovy/com/netflix/spinnaker/echo/pubsub/aws/AmazonSQSSubscriberSpec.groovy
@@ -20,13 +20,9 @@ import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sqs.AmazonSQS
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.kork.artifacts.parsing.DefaultJinjavaFactory
-import com.netflix.spinnaker.kork.artifacts.parsing.JinjaArtifactExtractor
-import com.netflix.spinnaker.echo.artifacts.MessageArtifactTranslator
 import com.netflix.spinnaker.echo.config.AmazonPubsubProperties
 import com.netflix.spinnaker.echo.pubsub.PubsubMessageHandler
 import com.netflix.spinnaker.kork.aws.ARN
-import org.springframework.context.ApplicationEventPublisher
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -54,11 +50,7 @@ class AmazonSQSSubscriberSpec extends Specification {
     amazonSNS,
     amazonSQS,
     {true},
-    registry,
-    new MessageArtifactTranslator.Factory(
-      Mock(ApplicationEventPublisher),
-      new JinjaArtifactExtractor.Factory(new DefaultJinjavaFactory())
-    )
+    registry
   )
 
   def 'should unmarshal an sns notification message'() {

--- a/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubEventCreator.java
+++ b/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubEventCreator.java
@@ -46,6 +46,8 @@ public class PubsubEventCreator implements EventCreator {
   }
 
   public Event createEvent(MessageDescription description) {
+    log.trace("Processing pubsub event with payload {}", description.getMessagePayload());
+
     try {
       description.setArtifacts(parseArtifacts(description.getMessagePayload()));
     } catch (FatalTemplateErrorsException e) {

--- a/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubEventCreator.java
+++ b/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubEventCreator.java
@@ -26,6 +26,8 @@ import com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.PubsubEventHand
 import com.netflix.spinnaker.echo.pubsub.model.EventCreator;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.util.*;
@@ -44,8 +46,6 @@ public class PubsubEventCreator implements EventCreator {
   }
 
   public Event createEvent(MessageDescription description) {
-    log.debug("Processing pubsub event with payload {}", description.getMessagePayload());
-
     try {
       description.setArtifacts(parseArtifacts(description.getMessagePayload()));
     } catch (FatalTemplateErrorsException e) {
@@ -80,8 +80,7 @@ public class PubsubEventCreator implements EventCreator {
     }
     List<Artifact> artifacts = messageArtifactTranslator.get().parseArtifacts(messagePayload);
     // Artifact must have at least a reference defined.
-    if (artifacts == null || artifacts.size() == 0
-      || artifacts.get(0).getReference() == null || artifacts.get(0).getReference().equals("")) {
+    if (CollectionUtils.isEmpty(artifacts) || StringUtils.isEmpty(artifacts.get(0).getReference())) {
       return Collections.emptyList();
     }
     return artifacts;

--- a/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubEventCreator.java
+++ b/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubEventCreator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pubsub;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
+import com.netflix.spinnaker.echo.artifacts.MessageArtifactTranslator;
+import com.netflix.spinnaker.echo.model.Event;
+import com.netflix.spinnaker.echo.model.Metadata;
+import com.netflix.spinnaker.echo.model.pubsub.MessageDescription;
+import com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.PubsubEventHandler;
+import com.netflix.spinnaker.echo.pubsub.model.EventCreator;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * An EventCreator that extracts artifacts from an incoming message and creates an event of type pubsub from the
+ * message and artifacts.
+ */
+@Slf4j
+public class PubsubEventCreator implements EventCreator {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final Optional<MessageArtifactTranslator> messageArtifactTranslator;
+
+  public PubsubEventCreator(Optional<MessageArtifactTranslator> messageArtifactTranslator) {
+    this.messageArtifactTranslator = messageArtifactTranslator;
+  }
+
+  public Event createEvent(MessageDescription description) {
+    log.debug("Processing pubsub event with payload {}", description.getMessagePayload());
+
+    try {
+      description.setArtifacts(parseArtifacts(description.getMessagePayload()));
+    } catch (FatalTemplateErrorsException e) {
+      log.error("Template failed to process artifacts for message {}", description, e);
+    }
+
+    Event event = new Event();
+    Map<String, Object> content = new HashMap<>();
+    Metadata details = new Metadata();
+
+    try {
+      event.setPayload(objectMapper.readValue(description.getMessagePayload(), Map.class));
+    } catch (IOException e) {
+      log.warn("Could not parse message payload as JSON", e);
+    }
+
+    content.put("messageDescription", description);
+    details.setType(PubsubEventHandler.PUBSUB_TRIGGER_TYPE);
+
+    if (description.getMessageAttributes() != null) {
+      details.setAttributes(description.getMessageAttributes());
+    }
+
+    event.setContent(content);
+    event.setDetails(details);
+    return event;
+  }
+
+  private List<Artifact> parseArtifacts(String messagePayload) {
+    if (!messageArtifactTranslator.isPresent()) {
+      return Collections.emptyList();
+    }
+    List<Artifact> artifacts = messageArtifactTranslator.get().parseArtifacts(messagePayload);
+    // Artifact must have at least a reference defined.
+    if (artifacts == null || artifacts.size() == 0
+      || artifacts.get(0).getReference() == null || artifacts.get(0).getReference().equals("")) {
+      return Collections.emptyList();
+    }
+    return artifacts;
+  }
+}

--- a/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandler.java
+++ b/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandler.java
@@ -16,63 +16,69 @@
 
 package com.netflix.spinnaker.echo.pubsub;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.events.EventPropagator;
 import com.netflix.spinnaker.echo.model.Event;
-import com.netflix.spinnaker.echo.model.Metadata;
 import com.netflix.spinnaker.echo.model.pubsub.MessageDescription;
-import com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.PubsubEventHandler;
+import com.netflix.spinnaker.echo.pubsub.model.EventCreator;
 import com.netflix.spinnaker.echo.pubsub.model.MessageAcknowledger;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
 import com.netflix.spinnaker.kork.jedis.RedisClientSelector;
-import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.zip.CRC32;
 
 /**
  * Shared cache of received and handled pubsub messages to synchronize clients.
  */
-@Data
-@Service
 @Slf4j
 public class PubsubMessageHandler {
 
   private final EventPropagator eventPropagator;
-  private final ObjectMapper objectMapper;
   private RedisClientDelegate redisClientDelegate;
   private final Registry registry;
+  private final List<EventCreator> eventCreators;
 
   private static final String SET_IF_NOT_EXIST = "NX";
   private static final String SET_EXPIRE_TIME_SECONDS = "EX";
   private static final String SUCCESS = "OK";
-  @Autowired
-  public PubsubMessageHandler(EventPropagator eventPropagator,
-                              ObjectMapper objectMapper,
-                              Optional<RedisClientSelector> redisClientSelector,
-                              Registry registry) {
-    this.eventPropagator = eventPropagator;
-    this.objectMapper = objectMapper;
-    redisClientSelector.ifPresent(selector -> this.redisClientDelegate = selector.primary("default"));
-    this.registry = registry;
+
+  @Service
+  public static class Factory {
+    private final EventPropagator eventPropagator;
+    private final RedisClientDelegate redisClientDelegate;
+    private final Registry registry;
+
+    public Factory(EventPropagator eventPropagator,
+                   Optional<RedisClientSelector> redisClientSelector,
+                   Registry registry) {
+      this.eventPropagator = eventPropagator;
+      this.redisClientDelegate = redisClientSelector.map(selector -> selector.primary("default")).orElse(null);
+      this.registry = registry;
+    }
+
+    public PubsubMessageHandler create(EventCreator eventCreator) {
+      return create(Collections.singletonList(eventCreator));
+    }
+
+    public PubsubMessageHandler create(List<EventCreator> eventCreators) {
+      return new PubsubMessageHandler(eventPropagator, redisClientDelegate, registry, eventCreators);
+    }
   }
 
-  public void handleFailedMessage(MessageDescription description,
-    MessageAcknowledger acknowledger,
-    String identifier,
-    String messageId) {
-    String messageKey = makeProcessingKey(description, messageId);
-    if (tryAck(messageKey, description.getAckDeadlineSeconds(), acknowledger, identifier)) {
-      setMessageHandled(messageKey, identifier, description.getRetentionDeadlineSeconds());
-    }
+  private PubsubMessageHandler(EventPropagator eventPropagator,
+                              RedisClientDelegate redisClientDelegate,
+                              Registry registry,
+                              List<EventCreator> eventCreators) {
+    this.eventPropagator = eventPropagator;
+    this.redisClientDelegate = redisClientDelegate;
+    this.registry = registry;
+    this.eventCreators = eventCreators;
   }
 
   public void handleMessage(MessageDescription description,
@@ -93,7 +99,10 @@ public class PubsubMessageHandler {
 
     String processingKey = makeProcessingKey(description, messageId);
     if (tryAck(processingKey, description.getAckDeadlineSeconds(), acknowledger, identifier)) {
-      processEvent(description);
+      for (EventCreator eventCreator : eventCreators) {
+        Event event = eventCreator.createEvent(description);
+        eventPropagator.processEvent(event);
+      }
       setMessageComplete(completeKey, description.getMessagePayload(), description.getRetentionDeadlineSeconds());
       registry.counter(getProcessedMetricId(description)).increment();
     }
@@ -144,30 +153,6 @@ public class PubsubMessageHandler {
 
   private String makeCompletedKey(MessageDescription description, String messageId) {
     return String.format("{echo:pubsub:completed}:%s:%s:%s", description.getPubsubSystem().toString(), description.getSubscriptionName(), messageId);
-  }
-
-  private void processEvent(MessageDescription description) {
-    log.debug("Processing pubsub event with payload {}", description.getMessagePayload());
-    Event event = new Event();
-    Map<String, Object> content = new HashMap<>();
-    Metadata details = new Metadata();
-
-    try {
-      event.setPayload(objectMapper.readValue(description.getMessagePayload(), Map.class));
-    } catch (IOException e) {
-      log.warn("Could not parse message payload as JSON", e);
-    }
-
-    content.put("messageDescription", description);
-    details.setType(PubsubEventHandler.PUBSUB_TRIGGER_TYPE);
-
-    if (description.getMessageAttributes() != null) {
-      details.setAttributes(description.getMessageAttributes());
-    }
-
-    event.setContent(content);
-    event.setDetails(details);
-    eventPropagator.processEvent(event);
   }
 
   /**

--- a/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandler.java
+++ b/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandler.java
@@ -19,10 +19,10 @@ package com.netflix.spinnaker.echo.pubsub;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.echo.events.EventPropagator;
 import com.netflix.spinnaker.echo.model.Event;
 import com.netflix.spinnaker.echo.model.Metadata;
 import com.netflix.spinnaker.echo.model.pubsub.MessageDescription;
-import com.netflix.spinnaker.echo.pipelinetriggers.monitor.TriggerEventListener;
 import com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.PubsubEventHandler;
 import com.netflix.spinnaker.echo.pubsub.model.MessageAcknowledger;
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate;
@@ -46,7 +46,7 @@ import java.util.zip.CRC32;
 @Slf4j
 public class PubsubMessageHandler {
 
-  private final TriggerEventListener pubsubEventMonitor;
+  private final EventPropagator eventPropagator;
   private final ObjectMapper objectMapper;
   private RedisClientDelegate redisClientDelegate;
   private final Registry registry;
@@ -55,11 +55,11 @@ public class PubsubMessageHandler {
   private static final String SET_EXPIRE_TIME_SECONDS = "EX";
   private static final String SUCCESS = "OK";
   @Autowired
-  public PubsubMessageHandler(TriggerEventListener triggerEventListener,
+  public PubsubMessageHandler(EventPropagator eventPropagator,
                               ObjectMapper objectMapper,
                               Optional<RedisClientSelector> redisClientSelector,
                               Registry registry) {
-    this.pubsubEventMonitor = triggerEventListener;
+    this.eventPropagator = eventPropagator;
     this.objectMapper = objectMapper;
     redisClientSelector.ifPresent(selector -> this.redisClientDelegate = selector.primary("default"));
     this.registry = registry;
@@ -167,7 +167,7 @@ public class PubsubMessageHandler {
 
     event.setContent(content);
     event.setDetails(details);
-    pubsubEventMonitor.processEvent(event);
+    eventPropagator.processEvent(event);
   }
 
   /**

--- a/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/model/EventCreator.java
+++ b/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/model/EventCreator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pubsub.model;
+
+import com.netflix.spinnaker.echo.model.Event;
+import com.netflix.spinnaker.echo.model.pubsub.MessageDescription;
+
+/**
+ * Interface for creating an Event from a MessageDescription.  In general, a PubsubSubscriber is responsible for
+ * creating a MessageDescription from an incoming pubsub message; an EventCreator is then used to create an echo Event
+ * from that MessageDescription.
+ */
+public interface EventCreator {
+  Event createEvent(MessageDescription description);
+}

--- a/echo-pubsub-core/src/test/groovy/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandlerSpec.groovy
+++ b/echo-pubsub-core/src/test/groovy/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandlerSpec.groovy
@@ -18,9 +18,9 @@ package com.netflix.spinnaker.echo.pubsub
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.echo.events.EventPropagator
 import com.netflix.spinnaker.echo.model.pubsub.MessageDescription
 import com.netflix.spinnaker.echo.model.pubsub.PubsubSystem
-import com.netflix.spinnaker.echo.pipelinetriggers.monitor.TriggerEventListener
 import com.netflix.spinnaker.echo.pubsub.model.MessageAcknowledger
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
@@ -47,11 +47,11 @@ class PubsubMessageHandlerSpec extends Specification {
 
   MessageDigest messageDigest = MessageDigest.getInstance("SHA-256")
 
-  TriggerEventListener triggerEventListener = Mock(TriggerEventListener)
+  EventPropagator eventPropagator = Mock(EventPropagator)
 
   @Subject
   PubsubMessageHandler pubsubMessageHandler = new PubsubMessageHandler(
-    triggerEventListener,
+    eventPropagator,
     new ObjectMapper(),
     redisClientSelector,
     new NoopRegistry()
@@ -142,7 +142,7 @@ class PubsubMessageHandlerSpec extends Specification {
     pubsubMessageHandler.handleMessage(description, acker, id, messageId)
 
     then:
-    1 * triggerEventListener.processEvent(_)
+    1 * eventPropagator.processEvent(_)
     1 * acker.ack()
     0 * acker.nack() // Lock acquisition failed.
   }
@@ -166,7 +166,7 @@ class PubsubMessageHandlerSpec extends Specification {
     pubsubMessageHandler.handleMessage(description, acker, id, messageId)
 
     then:
-    1 * triggerEventListener.processEvent(_)
+    1 * eventPropagator.processEvent(_)
     2 * acker.ack() // duplicate is dismissed
   }
 }

--- a/echo-pubsub-core/src/test/groovy/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandlerSpec.groovy
+++ b/echo-pubsub-core/src/test/groovy/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandlerSpec.groovy
@@ -16,11 +16,12 @@
 
 package com.netflix.spinnaker.echo.pubsub
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.echo.artifacts.MessageArtifactTranslator
 import com.netflix.spinnaker.echo.events.EventPropagator
 import com.netflix.spinnaker.echo.model.pubsub.MessageDescription
 import com.netflix.spinnaker.echo.model.pubsub.PubsubSystem
+import com.netflix.spinnaker.echo.pubsub.model.EventCreator
 import com.netflix.spinnaker.echo.pubsub.model.MessageAcknowledger
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
@@ -49,13 +50,16 @@ class PubsubMessageHandlerSpec extends Specification {
 
   EventPropagator eventPropagator = Mock(EventPropagator)
 
-  @Subject
-  PubsubMessageHandler pubsubMessageHandler = new PubsubMessageHandler(
+  PubsubMessageHandler.Factory pubsubMessageHandlerFactory = new PubsubMessageHandler.Factory(
     eventPropagator,
-    new ObjectMapper(),
     redisClientSelector,
     new NoopRegistry()
   )
+
+  EventCreator eventCreator = new PubsubEventCreator(Optional.empty())
+
+  @Subject
+  PubsubMessageHandler pubsubMessageHandler = pubsubMessageHandlerFactory.create(eventCreator)
 
   def setupSpec() {
     embeddedRedis = EmbeddedRedis.embed()

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubSubscriber.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubSubscriber.java
@@ -25,7 +25,6 @@ import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PubsubMessage;
-import com.netflix.spinnaker.echo.artifacts.MessageArtifactTranslator;
 import com.netflix.spinnaker.echo.config.GooglePubsubCredentialsProvider;
 import com.netflix.spinnaker.echo.config.GooglePubsubProperties.GooglePubsubSubscription;
 import com.netflix.spinnaker.echo.model.pubsub.MessageDescription;
@@ -33,16 +32,12 @@ import com.netflix.spinnaker.echo.model.pubsub.PubsubSystem;
 import com.netflix.spinnaker.echo.pubsub.PubsubMessageHandler;
 import com.netflix.spinnaker.echo.pubsub.model.PubsubSubscriber;
 import com.netflix.spinnaker.echo.pubsub.utils.NodeIdentity;
-import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
 public class GooglePubsubSubscriber implements PubsubSubscriber {
@@ -90,9 +85,7 @@ public class GooglePubsubSubscriber implements PubsubSubscriber {
     return String.format("projects/%s/subscriptions/%s", project, name);
   }
 
-  public static GooglePubsubSubscriber buildSubscriber(GooglePubsubSubscription subscription,
-                                                       PubsubMessageHandler pubsubMessageHandler,
-                                                       MessageArtifactTranslator.Factory messageArtifactTranslatorFactory) {
+  public static GooglePubsubSubscriber buildSubscriber(GooglePubsubSubscription subscription, PubsubMessageHandler pubsubMessageHandler) {
     String subscriptionName = subscription.getSubscriptionName();
     String project = subscription.getProject();
     String jsonPath = subscription.getJsonPath();
@@ -100,9 +93,7 @@ public class GooglePubsubSubscriber implements PubsubSubscriber {
     GooglePubsubMessageReceiver messageReceiver = new GooglePubsubMessageReceiver(
       subscription.getAckDeadlineSeconds(),
       subscription.getName(),
-      pubsubMessageHandler,
-      subscription.readTemplatePath(),
-      messageArtifactTranslatorFactory
+      pubsubMessageHandler
     );
 
     Credentials credentials = null;
@@ -161,17 +152,12 @@ public class GooglePubsubSubscriber implements PubsubSubscriber {
 
     private NodeIdentity identity = new NodeIdentity();
 
-    private MessageArtifactTranslator messageArtifactTranslator;
-
     public GooglePubsubMessageReceiver(Integer ackDeadlineSeconds,
                                        String subscriptionName,
-                                       PubsubMessageHandler pubsubMessageHandler,
-                                       InputStream templateStream,
-                                       MessageArtifactTranslator.Factory messageArtifactTranslatorFactory) {
+                                       PubsubMessageHandler pubsubMessageHandler) {
       this.ackDeadlineSeconds = ackDeadlineSeconds;
       this.subscriptionName = subscriptionName;
       this.pubsubMessageHandler = pubsubMessageHandler;
-      this.messageArtifactTranslator = messageArtifactTranslatorFactory.createJinja(templateStream);
     }
 
     @Override
@@ -189,16 +175,6 @@ public class GooglePubsubSubscriber implements PubsubSubscriber {
         .retentionDeadlineSeconds(7 * 24 * 60 * 60) // Expire key after max retention time, which is 7 days.
         .build();
       GoogleMessageAcknowledger acknowledger = new GoogleMessageAcknowledger(consumer);
-
-      try {
-        List<Artifact> artifacts = messageArtifactTranslator.parseArtifacts(messagePayload);
-        description.setArtifacts(artifacts);
-        log.info("artifacts {}", String.join(", ", artifacts.stream().map(Artifact::toString).collect(Collectors.toList())));
-      } catch (Exception e) {
-        log.error("Failed to process artifacts: {}", e.getMessage(), e);
-        pubsubMessageHandler.handleFailedMessage(description, acknowledger, identity.getIdentity(), messageId);
-        return;
-      }
 
       pubsubMessageHandler.handleMessage(description, acknowledger, identity.getIdentity(), messageId);
     }


### PR DESCRIPTION
* feat(pubsub): Send pubsub events through eventPropagator 

  Currently all pubsub events are sent directly to the trigger event listener, rather than to the general eventPropagator (which notifies all event listeners). This means that pubsub events can never do anything other than start pipelines. (Other incoming events, such as webhooks or build notifications are sent to the general eventPropagator.)

  In order to allow pubsub messages to do other things than start pipelines, send the resulting event to the eventPropagator so that other listeners can act on these events.

* refactor(pubsub): Encapsulate logic for creating events 

  The logic for extracting artifacts from pubsub events and for creating events from the message is embedded in the logic for handling these messages. In order to allow more general events to be created from pubsub messages, create an interface EventCreator that handles creating an event from a pubsub MessageDescription.

  The initial implementation of EventCreator will extract artifacts and create exactly the same event as prior to this change, allowing us to remove the code from the pubsub subscribers and handler.

  When setting up a subscription it is now possible to pass in a custom EventCreator so that messages read from that subscription create arbitrary event types.
