### PR TITLE
fix(pubsub): Don't log all pubsub events

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgent.groovy
@@ -53,7 +53,7 @@ abstract class AbstractEventNotificationAgent implements EchoEventListener {
 
   @Override
   void processEvent(Event event) {
-    if (log.isDebugEnabled() && mapper != null) {
+    if (log.isDebugEnabled() && mapper != null && !event.getDetails().getType().equals("pubsub")) {
       log.debug("Event received: " + mapper.writerWithDefaultPrettyPrinter().writeValueAsString(event))
     }
 


### PR DESCRIPTION
We're now logging all pubsub events in AbstractNotificationAgent; given the volume of these events, turn off this logging for pubsub.