### PR TITLE
fix(triggers): prevent double-triggering for pipelines with >1 triggers

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
@@ -89,8 +89,7 @@ public class ManualEventHandler implements TriggerEventHandler<ManualEvent> {
     return objectMapper.convertValue(event, ManualEvent.class);
   }
 
-  @Override
-  public Optional<Pipeline> withMatchingTrigger(ManualEvent manualEvent, Pipeline pipeline) {
+  private Optional<Pipeline> withMatchingTrigger(ManualEvent manualEvent, Pipeline pipeline) {
     Content content = manualEvent.getContent();
     String application = content.getApplication();
     String pipelineNameOrId = content.getPipelineNameOrId();

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/TriggerEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/TriggerEventHandler.java
@@ -54,35 +54,13 @@ public interface TriggerEventHandler<T extends TriggerEvent> {
   T convertEvent(Event event);
 
   /**
-   * Determines whether the given pipeline should be triggered by the given event, and if so returns
-   * the fully-formed pipeline (with the trigger set) that should be executed.
-   * @param event The triggering event
-   * @param pipeline The pipeline to potentially trigger
-   * @return An Optional containing the pipeline to be triggered, or empty if it should not be triggered
-   */
-  Optional<Pipeline> withMatchingTrigger(T event, Pipeline pipeline);
-
-  /**
    * Given a list of pipelines and an event, returns the pipelines that should be triggered
    * by the event
    * @param event The triggering event
    * @param pipelineCache a source for pipelines and triggers to consider
    * @return The pipelines that should be triggered
    */
-  default List<Pipeline> getMatchingPipelines(T event, PipelineCache pipelineCache) throws TimeoutException {
-    if (!isSuccessfulTriggerEvent(event)) {
-      return Collections.emptyList();
-    }
-
-    Map<String, List<Trigger>> triggers = pipelineCache.getEnabledTriggersSync();
-    return supportedTriggerTypes().stream()
-      .flatMap(triggerType -> Optional.ofNullable(triggers.get(triggerType)).orElse(Collections.emptyList()).stream())
-      .map(Trigger::getParent)
-      .map(p -> withMatchingTrigger(event, p))
-      .filter(Optional::isPresent)
-      .map(Optional::get)
-      .collect(Collectors.toList());
-  }
+  List<Pipeline> getMatchingPipelines(T event, PipelineCache pipelineCache) throws TimeoutException;
 
   /**
    * Given a pipeline, gets any additional tags that should be associated with metrics recorded

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandlerSpec.groovy
@@ -101,6 +101,27 @@ class BuildEventHandlerSpec extends Specification implements RetrofitStubs {
     }
   }
 
+  def "an event triggers a pipeline with 2 triggers only once"() {
+    given:
+    def pipeline = Pipeline.builder()
+      .application("application")
+      .name("pipeline")
+      .id("id")
+      .triggers([
+        enabledJenkinsTrigger,
+        enabledJenkinsTrigger.withJob("someOtherJob")])
+      .build()
+    def cache = handlerSupport.pipelineCache(pipeline)
+    def event = createBuildEventWith(SUCCESS)
+
+    when:
+    def matchingPipelines = eventHandler.getMatchingPipelines(event, cache)
+
+    then:
+    matchingPipelines.size() == 1
+    matchingPipelines.get(0).trigger.job == "job"
+  }
+
   @Unroll
   def "does not trigger pipelines for #description builds"() {
     when:
@@ -233,6 +254,8 @@ class BuildEventHandlerSpec extends Specification implements RetrofitStubs {
     outputTrigger.buildInfo.equals(BUILD_INFO)
     outputTrigger.properties.equals(PROPERTIES)
   }
+
+
 
   def getBuildEvent() {
     def build = new BuildEvent.Build(number: BUILD_NUMBER, building: false, result: SUCCESS)

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandlerSpec.groovy
@@ -255,8 +255,6 @@ class BuildEventHandlerSpec extends Specification implements RetrofitStubs {
     outputTrigger.properties.equals(PROPERTIES)
   }
 
-
-
   def getBuildEvent() {
     def build = new BuildEvent.Build(number: BUILD_NUMBER, building: false, result: SUCCESS)
     def project = new BuildEvent.Project(name: JOB_NAME, lastBuild: build)


### PR DESCRIPTION
A pipeline with 2 triggers and an event matching one of them could
actually be triggered twice. The problem is that withMatchingTrigger
would consider the event and all triggers of the pipeline, and it would
be called once for each trigger.

The key fix is to matchTriggerFor(event) in getMatchingPipelines().
As a result, we can change the inputs of getMatchingPipelines to an event
and a matching trigger instead of an event and a pipeline (with all its
triggers).
