### PR TITLE
fix(triggers): avoid single event causing >1 executions of same pipeline

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.Value;
 import lombok.experimental.Wither;
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
 @Wither
 @ToString(of = {"id", "parent", "type", "master", "job", "cronExpression", "source", "project", "slug", "account", "repository", "tag", "parameters", "payloadConstraints", "attributeConstraints", "branch", "runAsUser", "subscriptionName", "pubsubSystem", "expectedArtifactIds", "payload", "status", "artifactName", "link", "linkText"}, includeFieldNames = false)
 @Value
+@EqualsAndHashCode(exclude = "parent")
 public class Trigger {
   public enum Type {
     CRON("cron"),

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BaseTriggerEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BaseTriggerEventHandler.java
@@ -64,6 +64,7 @@ public abstract class BaseTriggerEventHandler<T extends TriggerEvent> implements
       .map(trigger -> withMatchingTrigger(event, trigger))
       .filter(Optional::isPresent)
       .map(Optional::get)
+      .distinct()
       .collect(Collectors.toList());
   }
 

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ArtifactoryEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ArtifactoryEventHandlerSpec.groovy
@@ -76,7 +76,9 @@ class ArtifactoryEventHandlerSpec extends Specification {
     Pipeline artifactoryPipeline = createPipelineWith(Collections.singletonList(createEnabledArtifactoryTrigger()))
 
     when:
-    List<Pipeline> matchingPipelines = eventHandler.getMatchingPipelines(artifactoryEvent, handlerSupport.pipelineCache(artifactoryPipeline, artifactoryPipeline))
+    List<Pipeline> matchingPipelines = eventHandler.getMatchingPipelines(artifactoryEvent, handlerSupport.pipelineCache(
+      artifactoryPipeline,
+      artifactoryPipeline.withName("another pipeline with the same trigger")))
 
     then:
     matchingPipelines.size() == 2

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandlerSpec.groovy
@@ -122,6 +122,27 @@ class BuildEventHandlerSpec extends Specification implements RetrofitStubs {
     matchingPipelines.get(0).trigger.job == "job"
   }
 
+  def "an event triggers a pipeline with 2 matching triggers only once"() {
+    given:
+    def pipeline = Pipeline.builder()
+      .application("application")
+      .name("pipeline")
+      .id("id")
+      .triggers([
+        enabledJenkinsTrigger,
+        enabledJenkinsTrigger])
+      .build()
+    def cache = handlerSupport.pipelineCache(pipeline)
+    def event = createBuildEventWith(SUCCESS)
+
+    when:
+    def matchingPipelines = eventHandler.getMatchingPipelines(event, cache)
+
+    then:
+    matchingPipelines.size() == 1
+  }
+
+
   @Unroll
   def "does not trigger pipelines for #description builds"() {
     when:


### PR DESCRIPTION
This has always been the behavior so far, but matching events on a per
trigger basis (introduced recently) could result in a multiple triggers
matching for the same pipeline. I could not think of a case where this
was an actually desired outcome, so let's keep the existing behavior.
