### PR TITLE
fix(core): Spring does not override default configuration files.

### DIFF
--- a/echo-web/echo-web.gradle
+++ b/echo-web/echo-web.gradle
@@ -15,7 +15,7 @@
  */
 
 ext {
-  springConfigLocation = System.getProperty('spring.config.location', "${System.getProperty('user.home')}/.spinnaker/")
+  springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/")
   springProfiles = System.getProperty('spring.profiles.active', "test,local")
 }
 
@@ -58,6 +58,6 @@ dependencies {
 }
 
 run {
-    systemProperty('spring.config.location', project.springConfigLocation)
+    systemProperty('spring.config.additional-location', project.springConfigLocation)
     systemProperty('spring.profiles.active', project.springProfiles)
 }

--- a/echo-web/src/main/java/com/netflix/spinnaker/echo/Application.java
+++ b/echo-web/src/main/java/com/netflix/spinnaker/echo/Application.java
@@ -44,7 +44,7 @@ public class Application extends SpringBootServletInitializer {
     defaults.put("netflix.environment", "test");
     defaults.put("netflix.account", "${netflix.environment}");
     defaults.put("netflix.stack", "test");
-    defaults.put("spring.config.location", "${user.home}/.spinnaker/");
+    defaults.put("spring.config.additional-location", "${user.home}/.spinnaker/");
     defaults.put("spring.application.name", "echo");
     defaults.put("spring.config.name", "spinnaker,${spring.application.name}");
     defaults.put("spring.profiles.active", "${netflix.environment},local");


### PR DESCRIPTION
In the Spring Boot 2 upgrade, `spring.config.location` overrides all other config locations. The equivalent property is now called `spring.config.additional-location`.
This fix allows the app the to run without additional config files. 