### PR TITLE
feat(gcb): Call igor to extract artifacts when triggering

### DIFF
--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/services/IgorService.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/services/IgorService.java
@@ -60,4 +60,8 @@ public interface IgorService {
       @Path("buildId") String buildId,
       @Query("status") String status,
       @Body TypedInput build);
+
+  @PUT("/gcb/artifacts/extract/{account}")
+  List<Artifact> extractGoogleCloudBuildArtifacts(
+      @Path("account") String account, @Body TypedInput build);
 }

--- a/echo-pubsub-google/echo-pubsub-google.gradle
+++ b/echo-pubsub-google/echo-pubsub-google.gradle
@@ -20,7 +20,10 @@ dependencies {
   implementation project(':echo-model')
   implementation project(':echo-pubsub-core')
   implementation project(':echo-notifications')
+  implementation "com.squareup.retrofit:retrofit"
   implementation 'com.google.cloud:google-cloud-pubsub:1.59.0'
+  implementation "com.netflix.spinnaker.kork:kork-artifacts"
+  implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation 'org.apache.commons:commons-lang3'
   implementation 'org.springframework.boot:spring-boot-autoconfigure'
   implementation "javax.validation:validation-api"

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/config/GoogleCloudBuildConfig.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/config/GoogleCloudBuildConfig.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.echo.pubsub.GoogleCloudBuildEventCreator;
 import com.netflix.spinnaker.echo.pubsub.PubsubEventCreator;
 import com.netflix.spinnaker.echo.pubsub.PubsubMessageHandler;
 import com.netflix.spinnaker.echo.pubsub.PubsubSubscribers;
+import com.netflix.spinnaker.echo.pubsub.google.GoogleCloudBuildArtifactExtractor;
 import com.netflix.spinnaker.echo.pubsub.google.GooglePubsubSubscriber;
 import com.netflix.spinnaker.echo.pubsub.model.PubsubSubscriber;
 import java.util.ArrayList;
@@ -46,6 +47,7 @@ public class GoogleCloudBuildConfig {
   private final GoogleCloudBuildEventCreator googleCloudBuildEventCreator;
   @Valid private final GoogleCloudBuildProperties googleCloudBuildProperties;
   private final MessageArtifactTranslator.Factory messageArtifactTranslatorFactory;
+  private final GoogleCloudBuildArtifactExtractor.Factory googleCloudBuildArtifactExtractorFactory;
 
   @PostConstruct
   void googleCloudBuildSubscribers() {
@@ -69,11 +71,11 @@ public class GoogleCloudBuildConfig {
                   account.getSubscriptionName(),
                   account.getProject());
 
-              Optional<MessageArtifactTranslator> messageArtifactTranslator =
-                  Optional.ofNullable(subscription.readTemplatePath())
-                      .map(messageArtifactTranslatorFactory::createJinja);
+              MessageArtifactTranslator messageArtifactTranslator =
+                  messageArtifactTranslatorFactory.create(
+                      googleCloudBuildArtifactExtractorFactory.create(account.getName()));
               PubsubEventCreator pubsubEventCreator =
-                  new PubsubEventCreator(messageArtifactTranslator);
+                  new PubsubEventCreator(Optional.of(messageArtifactTranslator));
 
               PubsubMessageHandler pubsubMessageHandler =
                   pubsubMessageHandlerFactory.create(

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GoogleCloudBuildArtifactExtractor.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GoogleCloudBuildArtifactExtractor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pubsub.google;
+
+import com.netflix.spinnaker.echo.services.IgorService;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.artifacts.parsing.ArtifactExtractor;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import retrofit.mime.TypedByteArray;
+import retrofit.mime.TypedInput;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class GoogleCloudBuildArtifactExtractor implements ArtifactExtractor {
+  private final String account;
+  private final IgorService igorService;
+  private final RetrySupport retrySupport;
+
+  @Component
+  @ConditionalOnProperty("gcb.enabled")
+  @RequiredArgsConstructor
+  public static class Factory {
+    private final IgorService igorService;
+    private final RetrySupport retrySupport;
+
+    public GoogleCloudBuildArtifactExtractor create(String account) {
+      return new GoogleCloudBuildArtifactExtractor(account, igorService, retrySupport);
+    }
+  }
+
+  @Override
+  public List<Artifact> getArtifacts(String messagePayload) {
+    TypedInput build =
+        new TypedByteArray("application/json", messagePayload.getBytes(StandardCharsets.UTF_8));
+    return retrySupport.retry(
+        () -> igorService.extractGoogleCloudBuildArtifacts(account, build), 5, 2000, false);
+  }
+}


### PR DESCRIPTION
Extracting artifacts using a Jinja template does not properly work when a GCB build produces GCS artifacts. This is because the build saves a manifest file to GCS, and we need to read the manifest file to find the location of each produced artifact.

The functionality to do this was recently added to igor; if we're listening to a GCB pubsub topic, use a custom artifact extractor that asks igor to get the artifacts from the build.