### PR TITLE
chore(*): Remove stale comments from gradle file

### DIFF
--- a/echo-scheduler/echo-scheduler.gradle
+++ b/echo-scheduler/echo-scheduler.gradle
@@ -15,9 +15,6 @@
  */
 
 dependencies {
-  // NOTE: Quartz 2.3.0 had a breaking change that doesn't recognize certain CRON expression (which pipelines use today)
-  // If you upgrade it to 2.3.0 you will probably have to write a Front50 migrator
-  implementation "org.quartz-scheduler:quartz:2.2.1"
   implementation project(':echo-core')
   implementation project(':echo-model')
   implementation project(':echo-pipelinetriggers')
@@ -34,4 +31,5 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-sql"
 
   implementation "org.springframework:spring-context-support"
+  implementation "org.quartz-scheduler:quartz"
 }


### PR DESCRIPTION
`quartz` now comes from spring bom (pulled in by kork-bom).
Remove the unnecessary pinning of `quartz` (it doesn't work the way it is anyway)

Note: this means that CRON expressions that use step value of 60 (for mins/secs)
or 24 (for hours) will no longer work (it wasn't valid before but previous `quartz`
was less strict about the validation).

There shouldn't be many users affected (if at all) because
a) these are non standard CRON expression anyway
b) most users "write" their expressions from the UI which wouldn't generate these.

We will have a release note for Spinnaker 1.14 about this.