### PR TITLE
fix(email): fix email parser to not fail on multiple addresses

### DIFF
--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/email/EmailNotificationServiceSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/email/EmailNotificationServiceSpec.groovy
@@ -96,6 +96,6 @@ class EmailNotificationServiceSpec extends Specification {
     ['receiver@localhost']                    | ['some-addr@localhost']                            || ['receiver@localhost']                      || ['some-addr@localhost']
     ['receiver@localhost another@localhost']  | ['some-addr@localhost some-other-addr@localhost']  || ['receiver@localhost', 'another@localhost'] || ['some-addr@localhost', 'some-other-addr@localhost']
     ['receiver@localhost,another@localhost']  | ['some-addr@localhost,some-other-addr@localhost']  || ['receiver@localhost', 'another@localhost'] || ['some-addr@localhost', 'some-other-addr@localhost']
-    ['receiver@localhost, another@localhost'] | ['some-addr@localhost, some-other-addr@localhost'] || ['receiver@localhost', 'another@localhost'] || ['some-addr@localhost', 'some-other-addr@localhost']
+    ['receiver@localhost; another@localhost'] | ['some-addr@localhost, some-other-addr@localhost'] || ['receiver@localhost', 'another@localhost'] || ['some-addr@localhost', 'some-other-addr@localhost']
   }
 }


### PR DESCRIPTION
If a pipeline specified two email addresses in the notification that email notification
will not be sent.
This change moves the email address splitting/parsing logic to the least common denominator -
the `send` function since it can be called either by handling an email event directly or
indirectly via pipeline/stage events

Also, adding the ability to split on semicolons in email addresses