### PR TITLE
fix(webhooks): handle NPE when source invalid (#552)

### DIFF
--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/controllers/WebhooksController.groovy
@@ -75,7 +75,13 @@ class WebhooksController {
     }
 
     if (type == 'git') {
-      GitWebhookHandler handler = scmWebhookHandler.getHandler(source)
+      GitWebhookHandler handler
+      try {
+        handler = scmWebhookHandler.getHandler(source)
+      } catch (Exception e) {
+        log.error("Unable to handle SCM source: {}", source)
+        throw e
+      }
       handler.handle(event, postedEvent)
       // shouldSendEvent should be called after the event
       // has been processed

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/ScmWebhookHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/ScmWebhookHandler.java
@@ -33,9 +33,9 @@ public class ScmWebhookHandler {
 
   public GitWebhookHandler getHandler(String source) {
     return webhookEventHandlers.stream()
-      .filter(h -> h.handles(source))
-      .findFirst()
-      .orElse(null);
+        .filter(h -> h.handles(source))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("Invalid SCM handler source" + source));
   }
 
 }


### PR DESCRIPTION
handle an NPM when calling the webhook controller with an invalid
source.
