### PR TITLE
fix(auth): Only trigger pipeline if service account has access to app

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/PipelineTriggerConfiguration.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/PipelineTriggerConfiguration.java
@@ -5,6 +5,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.PubsubEventHandler;
 import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService;
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
 import com.netflix.spinnaker.fiat.shared.FiatStatus;
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
@@ -65,8 +66,11 @@ public class PipelineTriggerConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(PubsubEventHandler.class)
-  PubsubEventHandler pubsubEventHandler(Registry registry, ObjectMapper objectMapper) {
-    return new PubsubEventHandler(registry, objectMapper);
+  PubsubEventHandler pubsubEventHandler(
+      Registry registry,
+      ObjectMapper objectMapper,
+      FiatPermissionEvaluator fiatPermissionEvaluator) {
+    return new PubsubEventHandler(registry, objectMapper, fiatPermissionEvaluator);
   }
 
   @Bean

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ArtifactoryEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ArtifactoryEventHandler.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.model.Trigger;
 import com.netflix.spinnaker.echo.model.trigger.ArtifactoryEvent;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,8 +39,11 @@ public class ArtifactoryEventHandler extends BaseTriggerEventHandler<Artifactory
   private static final List<String> supportedTriggerTypes =
       Collections.singletonList(ARTIFACTORY_TRIGGER_TYPE);
 
-  public ArtifactoryEventHandler(Registry registry, ObjectMapper objectMapper) {
-    super(registry, objectMapper);
+  public ArtifactoryEventHandler(
+      Registry registry,
+      ObjectMapper objectMapper,
+      FiatPermissionEvaluator fiatPermissionEvaluator) {
+    super(registry, objectMapper, fiatPermissionEvaluator);
   }
 
   @Override

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandler.java
@@ -22,6 +22,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.build.BuildInfoService;
 import com.netflix.spinnaker.echo.model.Trigger;
 import com.netflix.spinnaker.echo.model.trigger.BuildEvent;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import com.netflix.spinnaker.security.User;
@@ -49,8 +50,11 @@ public class BuildEventHandler extends BaseTriggerEventHandler<BuildEvent> {
 
   @Autowired
   public BuildEventHandler(
-      Registry registry, ObjectMapper objectMapper, Optional<BuildInfoService> buildInfoService) {
-    super(registry, objectMapper);
+      Registry registry,
+      ObjectMapper objectMapper,
+      Optional<BuildInfoService> buildInfoService,
+      FiatPermissionEvaluator fiatPermissionEvaluator) {
+    super(registry, objectMapper, fiatPermissionEvaluator);
     this.buildInfoService = buildInfoService;
   }
 

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/DockerEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/DockerEventHandler.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.model.Trigger;
 import com.netflix.spinnaker.echo.model.trigger.DockerEvent;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.Collections;
 import java.util.List;
@@ -40,8 +41,11 @@ public class DockerEventHandler extends BaseTriggerEventHandler<DockerEvent> {
   private static final List<String> supportedTriggerTypes = Collections.singletonList(TRIGGER_TYPE);
 
   @Autowired
-  public DockerEventHandler(Registry registry, ObjectMapper objectMapper) {
-    super(registry, objectMapper);
+  public DockerEventHandler(
+      Registry registry,
+      ObjectMapper objectMapper,
+      FiatPermissionEvaluator fiatPermissionEvaluator) {
+    super(registry, objectMapper, fiatPermissionEvaluator);
   }
 
   @Override

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandler.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.model.Trigger;
 import com.netflix.spinnaker.echo.model.trigger.GitEvent;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -47,8 +48,11 @@ public class GitEventHandler extends BaseTriggerEventHandler<GitEvent> {
       Collections.singletonList(GIT_TRIGGER_TYPE);
 
   @Autowired
-  public GitEventHandler(Registry registry, ObjectMapper objectMapper) {
-    super(registry, objectMapper);
+  public GitEventHandler(
+      Registry registry,
+      ObjectMapper objectMapper,
+      FiatPermissionEvaluator fiatPermissionEvaluator) {
+    super(registry, objectMapper, fiatPermissionEvaluator);
   }
 
   @Override

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandler.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.echo.model.Pipeline;
 import com.netflix.spinnaker.echo.model.Trigger;
 import com.netflix.spinnaker.echo.model.pubsub.MessageDescription;
 import com.netflix.spinnaker.echo.model.trigger.PubsubEvent;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,8 +45,11 @@ public class PubsubEventHandler extends BaseTriggerEventHandler<PubsubEvent> {
       Collections.singletonList(PUBSUB_TRIGGER_TYPE);
 
   @Autowired
-  public PubsubEventHandler(Registry registry, ObjectMapper objectMapper) {
-    super(registry, objectMapper);
+  public PubsubEventHandler(
+      Registry registry,
+      ObjectMapper objectMapper,
+      FiatPermissionEvaluator fiatPermissionEvaluator) {
+    super(registry, objectMapper, fiatPermissionEvaluator);
   }
 
   @Override

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/WebhookEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/WebhookEventHandler.java
@@ -21,6 +21,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.model.Pipeline;
 import com.netflix.spinnaker.echo.model.Trigger;
 import com.netflix.spinnaker.echo.model.trigger.WebhookEvent;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,8 +42,11 @@ public class WebhookEventHandler extends BaseTriggerEventHandler<WebhookEvent> {
   private static final List<String> supportedTriggerTypes = Collections.singletonList(TRIGGER_TYPE);
 
   @Autowired
-  public WebhookEventHandler(Registry registry, ObjectMapper objectMapper) {
-    super(registry, objectMapper);
+  public WebhookEventHandler(
+      Registry registry,
+      ObjectMapper objectMapper,
+      FiatPermissionEvaluator fiatPermissionEvaluator) {
+    super(registry, objectMapper, fiatPermissionEvaluator);
   }
 
   @Override

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ArtifactoryEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ArtifactoryEventHandlerSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.echo.model.Metadata
 import com.netflix.spinnaker.echo.model.Pipeline
 import com.netflix.spinnaker.echo.model.Trigger
 import com.netflix.spinnaker.echo.model.trigger.ArtifactoryEvent
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact
 import spock.lang.Specification
@@ -29,9 +30,14 @@ import spock.lang.Subject
 
 class ArtifactoryEventHandlerSpec extends Specification {
   def handlerSupport = new EventHandlerSupport()
-  
+  def fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
+
   @Subject
-  private ArtifactoryEventHandler eventHandler = new ArtifactoryEventHandler(new NoopRegistry(), new ObjectMapper())
+  private ArtifactoryEventHandler eventHandler = new ArtifactoryEventHandler(new NoopRegistry(), new ObjectMapper(), fiatPermissionEvaluator)
+
+  void setup() {
+    fiatPermissionEvaluator.hasPermission(_ as String, _ as String, "APPLICATION", "EXECUTE") >> true
+  }
 
   def 'getMatchingPipelinesTriggersEnabledArtifactoryPipeline'() {
     given:

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/DockerEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/DockerEventHandlerSpec.groovy
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.echo.model.Pipeline
 import com.netflix.spinnaker.echo.test.RetrofitStubs
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import spock.lang.Specification
 import spock.lang.Subject
@@ -29,9 +30,14 @@ class DockerEventHandlerSpec extends Specification implements RetrofitStubs {
   def registry = new NoopRegistry()
   def objectMapper = new ObjectMapper()
   def handlerSupport = new EventHandlerSupport()
+  def fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
 
   @Subject
-  def eventHandler = new DockerEventHandler(registry, objectMapper)
+  def eventHandler = new DockerEventHandler(registry, objectMapper, fiatPermissionEvaluator)
+
+  void setup() {
+    fiatPermissionEvaluator.hasPermission(_ as String, _ as String, "APPLICATION", "EXECUTE") >> true
+  }
 
   @Unroll
   def "triggers pipelines for successful builds for #triggerType"() {

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandlerSpec.groovy
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.echo.model.Pipeline
 import com.netflix.spinnaker.echo.test.RetrofitStubs
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -28,9 +29,14 @@ class GitEventHandlerSpec extends Specification implements RetrofitStubs {
   def registry = new NoopRegistry()
   def objectMapper = new ObjectMapper()
   def handlerSupport = new EventHandlerSupport()
+  def fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
 
   @Subject
-  def eventHandler = new GitEventHandler(registry, objectMapper)
+  def eventHandler = new GitEventHandler(registry, objectMapper, fiatPermissionEvaluator)
+
+  void setup() {
+    fiatPermissionEvaluator.hasPermission(_ as String, _ as String, "APPLICATION", "EXECUTE") >> true
+  }
 
   @Unroll
   def "triggers pipelines for successful builds for #triggerType"() {

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandlerSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.echo.model.pubsub.MessageDescription
 import com.netflix.spinnaker.echo.model.pubsub.PubsubSystem
 import com.netflix.spinnaker.echo.model.trigger.PubsubEvent
 import com.netflix.spinnaker.echo.test.RetrofitStubs
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact
 import groovy.json.JsonOutput
@@ -35,10 +36,11 @@ class PubsubEventHandlerSpec extends Specification implements RetrofitStubs {
   def registry = new NoopRegistry()
   def objectMapper = new ObjectMapper()
   def handlerSupport = new EventHandlerSupport()
+  def fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
 
   @Shared
   def goodArtifacts = [new Artifact(name: 'myArtifact', type: 'artifactType')]
-  
+
   @Shared
   def badExpectedArtifacts = [
     new ExpectedArtifact(
@@ -73,7 +75,11 @@ class PubsubEventHandlerSpec extends Specification implements RetrofitStubs {
   ]
 
   @Subject
-  def eventHandler = new PubsubEventHandler(registry, objectMapper)
+  def eventHandler = new PubsubEventHandler(registry, objectMapper, fiatPermissionEvaluator)
+
+  void setup() {
+    fiatPermissionEvaluator.hasPermission(_ as String, _ as String, "APPLICATION", "EXECUTE") >> true
+  }
 
   @Unroll
   def "triggers pipelines for successful builds for Google pubsub"() {

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/WebhookEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/WebhookEventHandlerSpec.groovy
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.echo.test.RetrofitStubs
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact
 import spock.lang.Shared
@@ -28,6 +29,7 @@ class WebhookEventHandlerSpec extends Specification implements RetrofitStubs {
   def registry = new NoopRegistry()
   def objectMapper = new ObjectMapper()
   def handlerSupport = new EventHandlerSupport()
+  def fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
 
   @Shared
   def goodExpectedArtifacts = [
@@ -41,7 +43,11 @@ class WebhookEventHandlerSpec extends Specification implements RetrofitStubs {
   ]
 
   @Subject
-  def eventHandler = new WebhookEventHandler(registry, objectMapper)
+  def eventHandler = new WebhookEventHandler(registry, objectMapper, fiatPermissionEvaluator)
+
+  void setup() {
+    fiatPermissionEvaluator.hasPermission(_ as String, _ as String, "APPLICATION", "EXECUTE") >> true
+  }
 
   def 'triggers pipelines for successful builds for webhook'() {
     given:

--- a/echo-test/src/main/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
+++ b/echo-test/src/main/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
@@ -24,6 +24,7 @@ trait RetrofitStubs {
   final String url = "http://echo"
   final Trigger enabledJenkinsTrigger = Trigger.builder().enabled(true).type('jenkins').master('master').job('job').build()
   final Trigger disabledJenkinsTrigger = Trigger.builder().enabled(false).type('jenkins').master('master').job('job').build()
+  final Trigger enabledJenkinsTriggerWithRunAsUser = enabledJenkinsTrigger.withRunAsUser("user@managed-service-account")
   final Trigger enabledTravisTrigger = Trigger.builder().enabled(true).type('travis').master('master').job('job').build()
   final Trigger disabledTravisTrigger = Trigger.builder().enabled(false).type('travis').master('master').job('job').build()
   final Trigger enabledWerckerTrigger = Trigger.builder().enabled(true).type('wercker').master('master').job('job').build()


### PR DESCRIPTION
In the current implementation, Echo will trigger pipelines in Orca even though the `runAsUser` does not have access to the application. This will trigger a round-dance of different errors when Orca tries unsuccessfully to execute the pipeline, so instead, we short circuit the execution in Echo.