### PR TITLE
fix(awspubsub): add error logging

### DIFF
--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
@@ -113,7 +113,12 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
   @Override
   public void run() {
     log.info("Starting " + getWorkerName());
-    initializeQueue();
+    try {
+      initializeQueue();
+    } catch (Exception e) {
+      log.error("Error initializing queue {}", queueARN, e);
+      throw e;
+    }
 
     while (true) {
       try {


### PR DESCRIPTION
If we fail to initialize the queue, everything fails silently. This will log the exception and then continue to fail.