### PR TITLE
fix(bitbucket): Log when Bitbucket event unknown

### DIFF
--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/BitbucketWehbookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/BitbucketWehbookEventHandler.java
@@ -66,6 +66,11 @@ public class BitbucketWehbookEventHandler implements GitWebhookHandler {
       handleBitbucketCloudEvent(event, postedEvent);
     } else if (looksLikeBitbucketServer(event)) {
       handleBitbucketServerEvent(event, postedEvent);
+    } else {
+      // Could not determine what type of Bitbucket event this was.
+      log.info("Could not determine Bitbucket type {}",
+        kv("event_type", event.content.get("event_type")));
+      return;
     }
 
     String fullRepoName = getFullRepoName(event);
@@ -92,13 +97,15 @@ public class BitbucketWehbookEventHandler implements GitWebhookHandler {
           kv("event_type", event.content.get("event_type").toString()),
           kv(
               "hook_id",
-              event.content.containsKey("hook_id") ? event.content.get("hook_id").toString() : ""),
+            event.content.containsKey("hook_id") ? event.content.get("hook_id").toString() : ""),
           kv(
               "request_id",
               event.content.containsKey("request_id")
                   ? event.content.get("request_id").toString()
                   : ""),
-          kv("branch", event.content.get("branch").toString()));
+          kv("branch",
+             event.content.containsKey("branch") ? event.content.get("branch").toString() : "")
+      );
     }
   }
 

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/BitbucketWehbookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/BitbucketWehbookEventHandler.java
@@ -68,8 +68,9 @@ public class BitbucketWehbookEventHandler implements GitWebhookHandler {
       handleBitbucketServerEvent(event, postedEvent);
     } else {
       // Could not determine what type of Bitbucket event this was.
-      log.info("Could not determine Bitbucket type {}",
-        kv("event_type", event.content.get("event_type")));
+      log.info(
+          "Could not determine Bitbucket type {}",
+          kv("event_type", event.content.get("event_type")));
       return;
     }
 
@@ -97,15 +98,15 @@ public class BitbucketWehbookEventHandler implements GitWebhookHandler {
           kv("event_type", event.content.get("event_type").toString()),
           kv(
               "hook_id",
-            event.content.containsKey("hook_id") ? event.content.get("hook_id").toString() : ""),
+              event.content.containsKey("hook_id") ? event.content.get("hook_id").toString() : ""),
           kv(
               "request_id",
               event.content.containsKey("request_id")
                   ? event.content.get("request_id").toString()
                   : ""),
-          kv("branch",
-             event.content.containsKey("branch") ? event.content.get("branch").toString() : "")
-      );
+          kv(
+              "branch",
+              event.content.containsKey("branch") ? event.content.get("branch").toString() : ""));
     }
   }
 


### PR DESCRIPTION
There are rare cases (often when the /bitbucket endpoint is used instead
of /stash) where the bitbucket event type doesn't match _either_ the
Cloud or Server types; this can cause an NPE in the subsequent log
message because "branch" doesn't get set (this was also fixed, although
should probably not happen any more).  In this case, we log the fact
that we couldn't determine the Cloud/Server type based on the event_type
(noting the event_type we _did_ get) and return.
