### PR TITLE
fix(triggers): Fix NPE on null application/name

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.echo.model.trigger.ManualEvent.Content;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,8 +73,9 @@ public class ManualEventHandler implements TriggerEventHandler<ManualEvent> {
 
   private boolean pipelineMatches(String application, String nameOrId, Pipeline pipeline) {
     return !pipeline.isDisabled()
-      && pipeline.getApplication().equals(application)
-      && (pipeline.getName().equals(nameOrId) || pipeline.getId().equals(nameOrId));
+        && Objects.equals(pipeline.getApplication(), application)
+        && (Objects.equals(pipeline.getName(), nameOrId)
+            || Objects.equals(pipeline.getId(), nameOrId));
   }
 
   private Pipeline buildTrigger(Pipeline pipeline, Trigger manualTrigger) {


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4548.

If the name or application on a trigger is null, we throw an NPE.  This only happens in the 1.12.x branch, as in 1.13 and beyond the @NonNull annotation on these fields is causing invalid pipelines to fail to deserialize and we thus never check them against triggers.

Add null checks to the 1.12 branch directly to fix the issue here. I'd rather not add these checks in later branches as having the field annotated as @NonNull is a better fix and it's redundant to perform a lot of null checks against @NonNull fields.