### PR TITLE
fix(notifications):  Need to maintain enum order

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/api/Notification.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/api/Notification.groovy
@@ -38,7 +38,7 @@ class Notification {
     EMAIL,
     GITHUB_STATUS,
     GOOGLECHAT,
-    UNUSED, // used to be HIPCHAT, which was removed in commit d175913ab
+    HIPCHAT, // DEPRECATED/UNUSED; support was removed in commit d175913ab
     JIRA,
     PAGER_DUTY,
     PUBSUB,

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/api/Notification.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/api/Notification.groovy
@@ -38,6 +38,7 @@ class Notification {
     EMAIL,
     GITHUB_STATUS,
     GOOGLECHAT,
+    UNUSED, // used to be HIPCHAT, which was removed in commit d175913ab
     JIRA,
     PAGER_DUTY,
     PUBSUB,


### PR DESCRIPTION
HIPCHAT was removed from the Enum here, but this enum is duplicated in
other microservices (for example, in Orca,
orca-echo/src/main/groovy/com/netflix/spinnaker/orca/echo/EchoService.groovy
has a copy of the list)

This is a quick fix to repair the numbering scheme.  This should
probably be fully refactored so the enum is either a) specifying actual
values for each type so they maintain consistency going forward, b)
unify in kork somehow, or c) both.
