### PR TITLE
fix(webhooks):  Test for empty ref on Git hooks

### DIFF
--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GithubWebhookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GithubWebhookEventHandler.java
@@ -63,7 +63,11 @@ public class GithubWebhookEventHandler implements GitWebhookHandler {
         objectMapper.convertValue(postedEvent, GithubWebhookEvent.class);
 
     event.content.put("hash", githubWebhookEvent.after);
-    event.content.put("branch", githubWebhookEvent.ref.replace("refs/heads/", ""));
+    if (githubWebhookEvent.ref == null) {
+      event.content.put("branch", "");
+    } else {
+      event.content.put("branch", githubWebhookEvent.ref.replace("refs/heads/", ""));
+    }
     event.content.put("repoProject", githubWebhookEvent.repository.owner.name);
     event.content.put("slug", githubWebhookEvent.repository.name);
   }


### PR DESCRIPTION
Some Git webhooks don't have a "ref" field, which is assumed in this
handler.  Sets the branch to empty string in this case (presuming other
code is expecting to find a non-null value further downstream).

