### PR TITLE
fix(cron): fix to not fire the same cron job on multiple instances

### DIFF
--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/config/SchedulerConfiguration.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/config/SchedulerConfiguration.groovy
@@ -114,6 +114,7 @@ class SchedulerConfiguration {
         if (sqlEnabled) {
           Properties props = new Properties()
           props.put("org.quartz.jobStore.isClustered", "true")
+          props.put("org.quartz.jobStore.acquireTriggersWithinLock", "true")
           schedulerFactoryBean.setQuartzProperties(props)
         }
         schedulerFactoryBean.setGlobalTriggerListeners(triggerListener)


### PR DESCRIPTION
it seems that `read-committed` on mysql doesn't have strong enough locking for
quartz to ensure only one clustered instance picks up a given cron trigger.
[Documentation](http://www.quartz-scheduler.org/documentation/quartz-2.1.7/configuration/ConfigJobStoreTX.html) suggests to set `acquireTriggersWithinLock` to `true`

(also see https://github.com/quartz-scheduler/quartz/issues/107)