### PR TITLE
fix(bitbucket): use equals for string comparison on event_type

### DIFF
--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/BitbucketWehbookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/BitbucketWehbookEventHandler.java
@@ -201,7 +201,7 @@ public class BitbucketWehbookEventHandler implements GitWebhookHandler {
     }
 
     String eventType = event.content.get("event_type").toString();
-    if (eventType == "repo:refs_changed") {
+    if (eventType.equals("repo:refs_changed")) {
       BitbucketServerRefsChangedEvent refsChangedEvent =
           objectMapper.convertValue(event.content, BitbucketServerRefsChangedEvent.class);
       if (refsChangedEvent.repository != null) {
@@ -215,7 +215,7 @@ public class BitbucketWehbookEventHandler implements GitWebhookHandler {
           branch = emptyOrDefault(change.ref.id, "").replace("refs/heads/", "");
         }
       }
-    } else if (eventType == "pr:merged") {
+    } else if (eventType.equals("pr:merged")) {
       BitbucketServerPrMergedEvent prMergedEvent =
           objectMapper.convertValue(event.content, BitbucketServerPrMergedEvent.class);
       if (prMergedEvent.pullRequest != null && prMergedEvent.pullRequest.toRef != null) {


### PR DESCRIPTION
Use equals for string comparison on bitbucket server event types.

This is currently causing that pipelines configured to automatically trigger on bitbucket server git changes to not get executed.