### PR TITLE
fix(gcb): Allow anonymous calls to igor

### DIFF
--- a/echo-pubsub-google/echo-pubsub-google.gradle
+++ b/echo-pubsub-google/echo-pubsub-google.gradle
@@ -24,6 +24,7 @@ dependencies {
   implementation 'com.google.cloud:google-cloud-pubsub:1.59.0'
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
+  implementation "com.netflix.spinnaker.kork:kork-security"
   implementation 'org.apache.commons:commons-lang3'
   implementation 'org.springframework.boot:spring-boot-autoconfigure'
   implementation "javax.validation:validation-api"

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GoogleCloudBuildArtifactExtractor.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GoogleCloudBuildArtifactExtractor.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.echo.services.IgorService;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.parsing.ArtifactExtractor;
 import com.netflix.spinnaker.kork.core.RetrySupport;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -56,7 +57,12 @@ public class GoogleCloudBuildArtifactExtractor implements ArtifactExtractor {
         new TypedByteArray("application/json", messagePayload.getBytes(StandardCharsets.UTF_8));
     try {
       return retrySupport.retry(
-          () -> igorService.extractGoogleCloudBuildArtifacts(account, build), 5, 2000, false);
+          () ->
+              AuthenticatedRequest.allowAnonymous(
+                  () -> igorService.extractGoogleCloudBuildArtifacts(account, build)),
+          5,
+          2000,
+          false);
     } catch (Exception e) {
       log.error("Failed to fetch artifacts for build: {}", e);
       return Collections.emptyList();


### PR DESCRIPTION
Since the GCB functionality was written, we've started logging messages every time an intra-microservice call is anonymous. When calling igor in response to a PubSub message, we don't have any authentication context and need to make an anonymous call, so wrap these calls in an allowAnonymous call.