### PR TITLE
refactor(slack):  Add trace logging of Slack responses

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
@@ -51,12 +51,15 @@ class SlackNotificationService implements NotificationService {
   EchoResponse.Void handle(Notification notification) {
     def text = notificationTemplateEngine.build(notification, NotificationTemplateEngine.Type.BODY)
     notification.to.each {
+      def response
       String address = it.startsWith('#') ? it : "#${it}"
       if (sendCompactMessages) {
-        slack.sendCompactMessage(token, new CompactSlackMessage(text), address, true)
+        response = slack.sendCompactMessage(token, new CompactSlackMessage(text), address, true)
       } else {
-        slack.sendMessage(token, new SlackAttachment("Spinnaker Notification", text), address, true)
+        response = slack.sendMessage(token, new SlackAttachment("Spinnaker Notification", text), address, true)
       }
+      log.trace("Received response from Slack: {} {} for message '{}'. {}",
+        response?.status, response?.reason, text, response?.body)
     }
 
     new EchoResponse.Void()


### PR DESCRIPTION
Adds debug-level logging for Slack notifications, useful for debugging Slack integration problems (authentication errors, etc).

Resubmitted/Rebased PR (ref.  https://github.com/spinnaker/echo/pull/588 )