### PR TITLE
feat(slack): Make slack base url configurable

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
@@ -55,12 +55,12 @@ class SlackConfig {
     String endpoint;
 
     if (StringUtils.isNotBlank(slackBaseUrl)) {
-      log.info("Using Slack base url: {}.", slackBaseUrl)
       endpoint = slackBaseUrl
     } else {
-      log.info("Using Slack incoming webhooks: {}.", useIncomingWebHook)
       endpoint = useIncomingWebHook ? SLACK_INCOMING_WEBHOOK : SLACK_CHAT_API;
     }
+
+    log.info("Using Slack {}: {}.", useIncomingWebHook ? "incoming webhook" : "chat api", endpoint)
 
     newFixedEndpoint(endpoint)
   }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
@@ -54,7 +54,7 @@ class SlackConfig {
   Endpoint slackEndpoint(@Qualifier("useIncomingWebHook") boolean useIncomingWebHook) {
     String endpoint;
 
-    if (slackBaseUrl != null && slackBaseUrl != "") {
+    if (StringUtils.isNotBlank(slackBaseUrl)) {
       log.info("Using Slack base url: {}.", slackBaseUrl)
       endpoint = slackBaseUrl
     } else {

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
@@ -47,8 +47,8 @@ class SlackConfig {
   @Value('${slack.base-url:}')
   String slackBaseUrl
 
-  @Value('${slack.compatibleAPI:false}')
-  Boolean slackCompatibleAPI
+  @Value('${slack.force-use-incoming-webhook:false}')
+  Boolean forceUseIncomingWebhook;
 
   @Bean
   Endpoint slackEndpoint(@Qualifier("useIncomingWebHook") boolean useIncomingWebHook) {
@@ -87,7 +87,11 @@ class SlackConfig {
 
   @Bean(name="useIncomingWebHook")
   boolean useIncomingWebHook(@Value('${slack.token:}') String token) {
-    return slackCompatibleAPI || (StringUtils.isNotBlank(token) && token.count("/") >= 2)
+    return forceUseIncomingWebhook || isIncomingWebhookToken(token)
+  }
+
+  def boolean isIncomingWebhookToken(String token) {
+    return (StringUtils.isNotBlank(token) && token.count("/") >= 2)
   }
 
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
@@ -44,10 +44,24 @@ class SlackConfig {
   final static String SLACK_INCOMING_WEBHOOK = 'https://hooks.slack.com'
   final static String SLACK_CHAT_API = 'https://slack.com'
 
+  @Value('${slack.base-url:}')
+  String slackBaseUrl
+
+  @Value('${slack.compatibleAPI:false}')
+  Boolean slackCompatibleAPI
+
   @Bean
   Endpoint slackEndpoint(@Qualifier("useIncomingWebHook") boolean useIncomingWebHook) {
-    log.info("Using Slack incoming webhooks: {}.", useIncomingWebHook)
-    String endpoint = useIncomingWebHook ? SLACK_INCOMING_WEBHOOK : SLACK_CHAT_API;
+    String endpoint;
+
+    if (slackBaseUrl != null && slackBaseUrl != "") {
+      log.info("Using Slack base url: {}.", slackBaseUrl)
+      endpoint = slackBaseUrl
+    } else {
+      log.info("Using Slack incoming webhooks: {}.", useIncomingWebHook)
+      endpoint = useIncomingWebHook ? SLACK_INCOMING_WEBHOOK : SLACK_CHAT_API;
+    }
+
     newFixedEndpoint(endpoint)
   }
 
@@ -73,7 +87,7 @@ class SlackConfig {
 
   @Bean(name="useIncomingWebHook")
   boolean useIncomingWebHook(@Value('${slack.token:}') String token) {
-    return StringUtils.isNotBlank(token) && token.count("/") >= 2
+    return slackCompatibleAPI || (StringUtils.isNotBlank(token) && token.count("/") >= 2)
   }
 
 }

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/SlackConfigSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/SlackConfigSpec.groovy
@@ -4,7 +4,8 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 class SlackConfigSpec extends Specification {
-  @Subject SlackConfig slackConfig = new SlackConfig()
+  @Subject
+  SlackConfig slackConfig = new SlackConfig()
 
   def 'test slack incoming web hook is inferred correctly'() {
     given:
@@ -24,5 +25,50 @@ class SlackConfigSpec extends Specification {
     "OLD/FASHION"                                  | "https://slack.com"       | false
     ""                                             | "https://slack.com"       | false
     null                                           | "https://slack.com"       | false
+  }
+
+  def 'test slack incoming web hook base url is defined'() {
+    given:
+
+    when:
+    slackConfig.setSlackBaseUrl(baseUrl)
+    def useIncomingHook = slackConfig.useIncomingWebHook(token)
+    def endpoint = slackConfig.slackEndpoint(useIncomingHook)
+
+
+    then:
+    useIncomingHook == expectedUseIncomingWebHook
+    endpoint.url == expectedEndpoint
+
+    where:
+    token                                          | baseUrl               | expectedEndpoint          | expectedUseIncomingWebHook
+    "myOldFashionToken"                            | "https://example.com" | "https://example.com"     | false
+    "myOldFashionToken"                            | ""                    | "https://slack.com"       | false
+    "myOldFashionToken"                            | null                  | "https://slack.com"       | false
+    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | "https://example.com" | "https://example.com"     | true
+    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | ""                    | "https://hooks.slack.com" | true
+    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | null                  | "https://hooks.slack.com" | true
+  }
+
+  def 'test slack incoming web hook when slackCompatible API is used'() {
+    given:
+    slackConfig.slackCompatibleAPI = true
+    slackConfig.slackBaseUrl = 'https://example.com'
+
+    when:
+    def useIncomingHook = slackConfig.useIncomingWebHook(token)
+    def endpoint = slackConfig.slackEndpoint(useIncomingHook)
+
+    then:
+    useIncomingHook == expectedUseIncomingWebHook
+    endpoint.url == expectedEndpoint
+
+    where:
+    token                                          | expectedEndpoint      | expectedUseIncomingWebHook
+    "myOldFashionToken"                            | "https://example.com" | true
+    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | "https://example.com" | true
+    "OLD/FASHION"                                  | "https://example.com" | true
+    ""                                             | "https://example.com" | true
+    null                                           | "https://example.com" | true
   }
 }

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/SlackConfigSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/SlackConfigSpec.groovy
@@ -50,9 +50,9 @@ class SlackConfigSpec extends Specification {
     "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | null                  | "https://hooks.slack.com" | true
   }
 
-  def 'test slack incoming web hook when slackCompatible API is used'() {
+  def 'test slack incoming web hook when forceUseIncomingWebhook'() {
     given:
-    slackConfig.slackCompatibleAPI = true
+    slackConfig.forceUseIncomingWebhook = true
     slackConfig.slackBaseUrl = 'https://example.com'
 
     when:


### PR DESCRIPTION
Allow slack notifications to be sent to compatible implementations.

spinnaker/spinnaker#4634
