### PR TITLE
fix(error handling): mark executions failed

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
@@ -81,6 +81,8 @@ public class Pipeline {
 
   @JsonProperty Object appConfig;
 
+  @JsonProperty String errorMessage;
+
   Trigger trigger;
 
   @JsonPOJOBuilder(withPrefix = "")

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/TriggerMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/TriggerMonitor.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.echo.pipelinetriggers.monitor;
 
+import com.google.common.base.Strings;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.events.EchoEventListener;
@@ -74,7 +75,7 @@ public class TriggerMonitor<T extends TriggerEvent> implements EchoEventListener
     try {
       List<Pipeline> matchingPipelines = eventHandler.getMatchingPipelines(event, pipelineCache);
       matchingPipelines.stream()
-          .filter(p -> p.getErrorMessage() == null)
+          .filter(p -> Strings.isNullOrEmpty(p.getErrorMessage()))
           .map(pipelinePostProcessorHandler::process)
           .forEach(
               p -> {
@@ -83,7 +84,7 @@ public class TriggerMonitor<T extends TriggerEvent> implements EchoEventListener
               });
 
       matchingPipelines.stream()
-          .filter(p -> p.getErrorMessage() != null)
+          .filter(p -> !Strings.isNullOrEmpty(p.getErrorMessage()))
           .forEach(pipelineInitiator::recordPipelineFailure);
     } catch (TimeoutException e) {
       log.error("Failed to get pipeline configs", e);

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaService.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaService.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.echo.model.Pipeline;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.util.Collection;
 import java.util.Map;
+import retrofit.client.Response;
 import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.POST;
@@ -30,6 +31,9 @@ public interface OrcaService {
 
   @POST("/orchestrate")
   TriggerResponse trigger(@Body Pipeline pipeline);
+
+  @POST("/fail")
+  Response recordFailure(@Body Pipeline pipeline);
 
   @POST("/plan")
   Map plan(@Body Map pipelineConfig, @Query("resolveArtifacts") boolean resolveArtifacts);

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
@@ -103,6 +103,10 @@ public class PipelineInitiator {
     EVENT
   }
 
+  public void recordPipelineFailure(Pipeline pipeline) {
+    orca.recordFailure(pipeline);
+  }
+
   public void startPipeline(Pipeline pipeline, TriggerSource triggerSource) {
     if (enabled) {
       try {


### PR DESCRIPTION
We need a way to indicate failures in materializing a pipeline.
If `echo` fails to materialize a pipeline during a trigger the failure needs to be recorded
in `orca` otherwise, the failure appears "silent" to the user because the UI is unable to
show any errors unless they are associated with an execution.
This is especially bad if, say, there is a typo in the properties file in the jenkins trigger
Starting the pipeline appears to do nothing and the user is confused.

This change captures errors during artifact resolution and sends them to `orca` to capture for the user
>NOTE: depends on related `orca` PR: https://github.com/spinnaker/orca/pull/3126
