### PR TITLE
fix(notification/slack): fix missing logger

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
@@ -20,11 +20,13 @@ import com.netflix.spinnaker.echo.api.Notification
 import com.netflix.spinnaker.echo.controller.EchoResponse
 import com.netflix.spinnaker.echo.notification.NotificationService
 import com.netflix.spinnaker.echo.notification.NotificationTemplateEngine
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
+@Slf4j
 @Component
 @ConditionalOnProperty('slack.enabled')
 class SlackNotificationService implements NotificationService {


### PR DESCRIPTION
was causing slack notifications to repeat endlessly as the notification would be
sent, but the log statement afterwords would fail and return an error back to
orca which would retry.