### PR TITLE
feat(stats): Adds circuit breaker logic via resilience4j

### DIFF
--- a/echo-telemetry/echo-telemetry.gradle
+++ b/echo-telemetry/echo-telemetry.gradle
@@ -16,8 +16,6 @@
 
 dependencies {
   implementation project(':echo-model')
-  implementation project(':echo-notifications')
-  implementation 'com.google.guava:guava'
   implementation 'com.google.protobuf:protobuf-java-util'
   implementation "com.netflix.spinnaker.kork:kork-proto"
   implementation 'com.netflix.spinnaker.kork:kork-web'

--- a/echo-web/config/echo.yml
+++ b/echo-web/config/echo.yml
@@ -24,3 +24,17 @@ webhooks:
   artifacts:
     enabled: false
     sources: []
+
+resilience4j.circuitbreaker:
+  instances:
+    telemetry:
+      # Startup config...
+      registerHealthIndicator: true
+      # Warming up...
+      minimumNumberOfCalls: 5
+      slidingWindowSize: 10
+      slidingWindowType: COUNT_BASED
+      # When tripped...
+      waitDurationInOpenState: 12h
+      # Try to get back to a working state...
+      permittedNumberOfCallsInHalfOpenState: 1

--- a/halconfig/echo.yml
+++ b/halconfig/echo.yml
@@ -34,3 +34,17 @@ scheduler:
 redis:
   connection: ${services.redis.baseUrl:redis://localhost:6379}
   enabled: ${services.redis.enabled:false}
+
+resilience4j.circuitbreaker:
+  instances:
+    telemetry:
+      # Startup config...
+      registerHealthIndicator: true
+      # Warming up...
+      minimumNumberOfCalls: 5
+      slidingWindowSize: 10
+      slidingWindowType: COUNT_BASED
+      # When tripped...
+      waitDurationInOpenState: 12h
+      # Try to get back to a working state...
+      permittedNumberOfCallsInHalfOpenState: 1


### PR DESCRIPTION
This should prevent sending pings to the stats collector in case the environment is air gapped or the endpoint is actually down. 

Side note: resilience4j is pretty neat, and 1.0.0 was just released. Opened https://github.com/spinnaker/kork/pull/382 to add `resilience4j-circuitbreaker` to the next kork release.

Fixes https://github.com/spinnaker/spinnaker/issues/4864