### PR TITLE
feat(sql): Conditionally allow MySQL Connector to be excluded from the build

### DIFF
--- a/echo-scheduler/echo-scheduler.gradle
+++ b/echo-scheduler/echo-scheduler.gradle
@@ -30,7 +30,10 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-artifacts"
   implementation "com.netflix.spinnaker.kork:kork-sql"
 
-  implementation "mysql:mysql-connector-java"
+  if (!rootProject.hasProperty("excludeSqlDrivers")) {
+    runtimeOnly "mysql:mysql-connector-java"
+  }
+
   implementation "org.springframework:spring-context-support"
   implementation ("org.quartz-scheduler:quartz") {
     exclude group: 'com.zaxxer', module: 'HikariCP-java7'


### PR DESCRIPTION
This change allows a custom build of Spinnaker to exclude the `mysql-connector-java` driver from the generated distribution with a build command like:

`./gradlew echo-web:installDist -x test -PexcludeSqlDrivers`

The driver is included in the build by default, so the build results are not changed for existing open-source and custom builds. 

The Gradle dependency types were changed from `implementation` to `runtimeOnly` to reflect the fact that `mysql-connector-java` is not needed for compilation. 