### PR TITLE
fix(build): whitelist build package to avoid being ignored by gcloud cloudbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.gradle/
 /build
 */build/
+!*/src/**/build/
 .DS_Store
 *.iml
 *.ipr


### PR DESCRIPTION
fix to build images using `cloud builds`

when I attempt to build using gcloud `gcloud builds submit ....` the  archive file uploaded does not include the `build` package. the line in the `.gitignore` `*/build/"` is being used to ignore the package. 

Work around is to white list the package directory.

filed a bug with gcloud build:
https://issuetracker.google.com/issues/141435398