### PR TITLE
fix(triggers): Remove confusing/unnecessary error log

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
@@ -197,9 +197,6 @@ public class ManualEventHandler implements TriggerEventHandler<ManualEvent> {
       if (Strings.isNullOrEmpty(artifact.getName())
           || Strings.isNullOrEmpty(artifact.getVersion())
           || Strings.isNullOrEmpty(artifact.getLocation())) {
-        log.error(
-            "Artifact does not have enough information to fetch. "
-                + "Artifact must contain name, version, and location.");
         resolvedArtifacts.add(artifact);
       } else {
         try {


### PR DESCRIPTION
## WHAT

This pull request removes confusing/unnecessary error log from `ManualEventHandler#resolveArtifacts`.

## WHY

ref: [feat(artifacts): populate artifacts for manual trigger](https://github.com/spinnaker/echo/pull/509)

The error log was added in the commit:
https://github.com/spinnaker/echo/pull/509/commits/1a6fb33f56235019d4987fda777908173f50fa32#diff-3861ae251662b1f07aee9125cec36ad4R129

But the code was changed in the next commit in the pull request for existing behavior:
https://github.com/spinnaker/echo/pull/509/commits/8c371ce2f7e81f9ed14eb0baf5d67b366d6fcb7a#diff-3861ae251662b1f07aee9125cec36ad4R143

So the error log is unnecessary and confusing.
Actually I was confused with the error log while debugging 😁 
