### PR TITLE
feat(tasks): allow notifications for tasks

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/BearychatNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/BearychatNotificationAgent.groovy
@@ -49,52 +49,47 @@ class BearychatNotificationAgent extends AbstractEventNotificationAgent {
 
   @Override
   void sendNotifications(Map preference, String application, Event event, Map config, String status) {
-    try {
-      String buildInfo = ''
+    String buildInfo = ''
 
-      if (config.type == 'pipeline' || config.type == 'stage') {
-        if (event.content?.execution?.trigger?.buildInfo?.url) {
-          buildInfo = """build #<a href="${event.content.execution.trigger.buildInfo.url}">${
-            event.content.execution.trigger.buildInfo.number as Integer
-          }</a> """
-        }
+    if (config.type == 'pipeline' || config.type == 'stage') {
+      if (event.content?.execution?.trigger?.buildInfo?.url) {
+        buildInfo = """build #<a href="${event.content.execution.trigger.buildInfo.url}">${
+          event.content.execution.trigger.buildInfo.number as Integer
+        }</a> """
       }
-      log.info('Sending bearychat message {} for {} {} {} {}', kv('address', preference.address), kv('application', application), kv('type', config.type), kv('status', status), kv('executionId', event.content?.execution?.id))
-
-
-      String message = ''
-
-      if (config.type == 'stage') {
-        String stageName = event.content.name ?: event.content?.context?.stageDetails?.name
-        message = """Stage $stageName for """
-      }
-
-      String link = "${spinnakerUrl}/#/applications/${application}/${config.type == 'stage' ? 'executions/details' : config.link }/${event.content?.execution?.id}"
-
-      message +=
-        """${WordUtils.capitalize(application)}'s ${
-          event.content?.execution?.name ?: event.content?.execution?.description
-        } ${buildInfo} ${config.type == 'task' ? 'task' : 'pipeline'} ${status == 'starting' ? 'is' : 'has'} ${
-          status == 'complete' ? 'completed successfully' : status
-        }.  To see more details, please visit: ${link}"""
-
-      String customMessage = event.content?.context?.customMessage
-      if (customMessage) {
-        message = customMessage
-          .replace("{{executionId}}", (String) event.content.execution?.id ?: "")
-          .replace("{{link}}", link ?: "")
-      }
-
-      List<BearychatUserInfo> userList = bearychatService.getUserList(token)
-      String userid = userList.find {it.email == preference.address}.id
-      CreateP2PChannelResponse channelInfo = bearychatService.createp2pchannel(token,new CreateP2PChannelPara(user_id: userid))
-      String channelId = channelInfo.vchannel_id
-      bearychatService.sendMessage(token,new SendMessagePara(vchannel_id: channelId,
-        text: message,
-        attachments: "" ))
-
-    } catch (Exception e) {
-      log.error('failed to send bearychat message ', e)
     }
+    log.info('Sending bearychat message {} for {} {} {} {}', kv('address', preference.address), kv('application', application), kv('type', config.type), kv('status', status), kv('executionId', event.content?.execution?.id))
+
+
+    String message = ''
+
+    if (config.type == 'stage') {
+      String stageName = event.content.name ?: event.content?.context?.stageDetails?.name
+      message = """Stage $stageName for """
+    }
+
+    String link = "${spinnakerUrl}/#/applications/${application}/${config.type == 'stage' ? 'executions/details' : config.link }/${event.content?.execution?.id}"
+
+    message +=
+      """${WordUtils.capitalize(application)}'s ${
+        event.content?.execution?.name ?: event.content?.execution?.description
+      } ${buildInfo} ${config.type == 'task' ? 'task' : 'pipeline'} ${status == 'starting' ? 'is' : 'has'} ${
+        status == 'complete' ? 'completed successfully' : status
+      }.  To see more details, please visit: ${link}"""
+
+    String customMessage = event.content?.context?.customMessage
+    if (customMessage) {
+      message = customMessage
+        .replace("{{executionId}}", (String) event.content.execution?.id ?: "")
+        .replace("{{link}}", link ?: "")
+    }
+
+    List<BearychatUserInfo> userList = bearychatService.getUserList(token)
+    String userid = userList.find {it.email == preference.address}.id
+    CreateP2PChannelResponse channelInfo = bearychatService.createp2pchannel(token,new CreateP2PChannelPara(user_id: userid))
+    String channelId = channelInfo.vchannel_id
+    bearychatService.sendMessage(token,new SendMessagePara(vchannel_id: channelId,
+      text: message,
+      attachments: "" ))
   }
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
@@ -46,75 +46,70 @@ class SlackNotificationAgent extends AbstractEventNotificationAgent {
 
   @Override
   void sendNotifications(Map preference, String application, Event event, Map config, String status) {
-    try {
-      String buildInfo = ' '
+    String buildInfo = ' '
 
-      String color = '#CCCCCC'
+    String color = '#CCCCCC'
 
-      if (status == 'failed') {
-        color = '#B82525'
-      }
-
-      if (status == 'starting') {
-        color = '#2275B8'
-      }
-
-      if (status == 'complete') {
-        color = '#769D3E'
-      }
-
-      if (config.type == 'pipeline' || config.type == 'stage') {
-        if (event.content?.execution?.trigger?.buildInfo?.url) {
-          buildInfo = """ build <${event.content.execution.trigger.buildInfo.url}|${
-            event.content.execution.trigger.buildInfo.number as Integer
-          }> """
-        }
-      }
-
-      log.info('Sending Slack message {} for {} {} {} {}', kv('address', preference.address), kv('application', application), kv('type', config.type), kv('status', status), kv('executionId', event.content?.execution?.id))
-
-      String body = ''
-
-      if (config.type == 'stage') {
-        String stageName = event.content.name ?: event.content?.context?.stageDetails?.name
-        body = """Stage $stageName for """
-      }
-
-      String link = "${spinnakerUrl}/#/applications/${application}/${config.type == 'stage' ? 'executions/details' : config.link }/${event.content?.execution?.id}"
-
-      body +=
-        """${capitalize(application)}'s <${link}|${
-          event.content?.execution?.name ?: event.content?.execution?.description
-        }>${buildInfo}${config.type == 'task' ? 'task' : 'pipeline'} ${status == 'starting' ? 'is' : 'has'} ${
-          status == 'complete' ? 'completed successfully' : status
-        }"""
-
-      if (preference.message?."$config.type.$status"?.text) {
-        body += "\n\n" + preference.message."$config.type.$status".text
-      }
-
-      String customMessage = preference.customMessage ?: event.content?.context?.customMessage
-      if (customMessage) {
-        body = customMessage
-          .replace("{{executionId}}", (String) event.content.execution?.id ?: "")
-          .replace("{{link}}", link ?: "")
-      }
-
-      String address = preference.address.startsWith('#') ? preference.address : "#${preference.address}"
-
-      Response response
-      if (sendCompactMessages) {
-        response = slackService.sendCompactMessage(token, new CompactSlackMessage(body, color), address, true)
-      } else {
-        String title = getNotificationTitle(config.type, application, status)
-        response = slackService.sendMessage(token, new SlackAttachment(title, body, color), address, true)
-      }
-      log.info("Received response from Slack: {} {} for execution id {}. {}",
-        response?.status, response?.reason, event.content?.execution?.id, response?.body)
-
-    } catch (Exception e) {
-      log.error('failed to send slack message ', e)
+    if (status == 'failed') {
+      color = '#B82525'
     }
+
+    if (status == 'starting') {
+      color = '#2275B8'
+    }
+
+    if (status == 'complete') {
+      color = '#769D3E'
+    }
+
+    if (config.type == 'pipeline' || config.type == 'stage') {
+      if (event.content?.execution?.trigger?.buildInfo?.url) {
+        buildInfo = """ build <${event.content.execution.trigger.buildInfo.url}|${
+          event.content.execution.trigger.buildInfo.number as Integer
+        }> """
+      }
+    }
+
+    log.info('Sending Slack message {} for {} {} {} {}', kv('address', preference.address), kv('application', application), kv('type', config.type), kv('status', status), kv('executionId', event.content?.execution?.id))
+
+    String body = ''
+
+    if (config.type == 'stage') {
+      String stageName = event.content.name ?: event.content?.context?.stageDetails?.name
+      body = """Stage $stageName for """
+    }
+
+    String link = "${spinnakerUrl}/#/applications/${application}/${config.type == 'stage' ? 'executions/details' : config.link }/${event.content?.execution?.id}"
+
+    body +=
+      """${capitalize(application)}'s <${link}|${
+        event.content?.execution?.name ?: event.content?.execution?.description
+      }>${buildInfo}${config.type == 'task' ? 'task' : 'pipeline'} ${status == 'starting' ? 'is' : 'has'} ${
+        status == 'complete' ? 'completed successfully' : status
+      }"""
+
+    if (preference.message?."$config.type.$status"?.text) {
+      body += "\n\n" + preference.message."$config.type.$status".text
+    }
+
+    String customMessage = preference.customMessage ?: event.content?.context?.customMessage
+    if (customMessage) {
+      body = customMessage
+        .replace("{{executionId}}", (String) event.content.execution?.id ?: "")
+        .replace("{{link}}", link ?: "")
+    }
+
+    String address = preference.address.startsWith('#') ? preference.address : "#${preference.address}"
+
+    Response response
+    if (sendCompactMessages) {
+      response = slackService.sendCompactMessage(token, new CompactSlackMessage(body, color), address, true)
+    } else {
+      String title = getNotificationTitle(config.type, application, status)
+      response = slackService.sendMessage(token, new SlackAttachment(title, body, color), address, true)
+    }
+    log.info("Received response from Slack: {} {} for execution id {}. {}",
+      response?.status, response?.reason, event.content?.execution?.id, response?.body)
   }
 
   /**

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/TwilioNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/TwilioNotificationAgent.groovy
@@ -41,46 +41,41 @@ class TwilioNotificationAgent extends AbstractEventNotificationAgent {
 
   @Override
   void sendNotifications(Map preference, String application, Event event, Map config, String status) {
-    try {
-      String name = event.content?.execution?.name ?: event.content?.execution?.description
-      String link = "${spinnakerUrl}/#/applications/${application}/${config.type == 'stage' ? 'executions/details' : config.link}/${event.content?.execution?.id}"
+    String name = event.content?.execution?.name ?: event.content?.execution?.description
+    String link = "${spinnakerUrl}/#/applications/${application}/${config.type == 'stage' ? 'executions/details' : config.link}/${event.content?.execution?.id}"
 
-      String buildInfo = ''
+    String buildInfo = ''
 
-      if (config.type == 'pipeline') {
-        if (event.content?.execution?.trigger?.buildInfo?.url) {
-          buildInfo = """build #${event.content.execution.trigger.buildInfo.number as Integer} """
-        }
+    if (config.type == 'pipeline') {
+      if (event.content?.execution?.trigger?.buildInfo?.url) {
+        buildInfo = """build #${event.content.execution.trigger.buildInfo.number as Integer} """
       }
-
-      log.info("Twilio: sms for ${preference.address} - ${link}")
-
-      String message = ''
-
-      if (config.type == 'stage') {
-        String stageName = event.content.name ?: event.content?.context?.stageDetails?.name
-        message = """Stage $stageName for """
-      }
-
-      message +=
-        """${WordUtils.capitalize(application)}'s ${
-          event.content?.execution?.name ?: event.content?.execution?.description
-        } ${buildInfo} ${config.type == 'task' ? 'task' : 'pipeline'} ${buildInfo} ${
-          status == 'starting' ? 'is' : 'has'
-        } ${
-          status == 'complete' ? 'completed successfully' : status
-        } ${link}"""
-
-      twilioService.sendMessage(
-        account,
-        from,
-        preference.address,
-        message
-      )
-
-    } catch (Exception e) {
-      log.error('failed to send sms message ', e)
     }
+
+    log.info("Twilio: sms for ${preference.address} - ${link}")
+
+    String message = ''
+
+    if (config.type == 'stage') {
+      String stageName = event.content.name ?: event.content?.context?.stageDetails?.name
+      message = """Stage $stageName for """
+    }
+
+    message +=
+      """${WordUtils.capitalize(application)}'s ${
+        event.content?.execution?.name ?: event.content?.execution?.description
+      } ${buildInfo} ${config.type == 'task' ? 'task' : 'pipeline'} ${buildInfo} ${
+        status == 'starting' ? 'is' : 'has'
+      } ${
+        status == 'complete' ? 'completed successfully' : status
+      } ${link}"""
+
+    twilioService.sendMessage(
+      account,
+      from,
+      preference.address,
+      message
+    )
   }
 
   @Override

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgentSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgentSpec.groovy
@@ -71,6 +71,9 @@ class AbstractEventNotificationAgentSpec extends Specification {
     // notifications ON, another check for cancelled pipeline (should skip notifications)
     fakePipelineEvent("orca:pipeline:failed", "WHATEVER", "pipeline.failed", [canceled: true]) || 0
 
+    fakeOrchestrationEvent("orca:orchestration:complete", "SUCCEEDED", "orchestration.complete")|| 1
+    fakeOrchestrationEvent("orca:orchestration:failed", "TERMINAL", "orchestration.failed")     || 1
+
     // notifications OFF, stage complete
     fakeStageEvent("orca:stage:complete", null)                                               || 0
     // notifications OFF, stage failed
@@ -96,6 +99,27 @@ class AbstractEventNotificationAgentSpec extends Specification {
         execution: [
           id: "1",
           name: "foo-pipeline",
+          status: status
+        ]
+      ]
+    ]
+
+    if (notifyWhen) {
+      eventProps.content.execution << [notifications: [[type: "fake", when: "${notifyWhen}"]]]
+    }
+
+    eventProps.content.execution << extraExecutionProps
+
+    return new Event(eventProps)
+  }
+
+  private def fakeOrchestrationEvent(String type, String status, String notifyWhen, Map extraExecutionProps = [:]) {
+    def eventProps = [
+      details: [type: type],
+      content: [
+        execution: [
+          id: "1",
+          name: "foo-orchestration",
           status: status
         ]
       ]


### PR DESCRIPTION
Right now we can't send notifications for tasks. Why? Not sure. This code is 2015 vintage.  

This PR adds support for sending notifications for tasks:

```json
"trigger": {
		"notifications": [
			{
				"address": "#myslackchannel",
				"level": "pipeline",
				"type": "slack",
				"when": [
					"orchestration.starting",
					"orchestration.complete",
					"orchestration.failed"
				]
			}
		]
	},
```

It also moves some error handling from subclasses to the parent class because of 💁style.