### PR TITLE
fix(triggers): add missing docker properties to trigger model

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -135,6 +135,8 @@ public class Trigger {
 
   // Configuration for docker triggers
   String account;
+  String organization;
+  String registry;
   String repository;
   String tag;
 


### PR DESCRIPTION
Closes:
-  https://github.com/spinnaker/spinnaker/issues/4955

- https://github.com/spinnaker/spinnaker/issues/4982

When manually re-running an execution, Deck hydrates the manual trigger it creates with properties from the [execution trigger](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx#L291) of the execution being re-run. However, the execution trigger was missing the `registry` field, so Deck was creating an [incomplete reference](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/docker/src/pipeline/trigger/DockerTriggerTemplate.tsx#L70). This was only a problem with re-runs, and not normal manual executions, because in a normal manual execution we build a manual trigger based on the pipeline trigger and not an execution trigger.

This change also adds the missing `organization` property because in order to hydrate the manual trigger with any additional properties from the execution trigger, Deck expects [fields from the pipeline trigger to match those on the execution trigger](https://github.com/spinnaker/deck/blob/master/app/scripts/modules/core/src/pipeline/manualExecution/ManualPipelineExecutionModal.tsx#L300). There are some issues with that logic not directly related to these bugs that I'll resolve in a separate Deck PR.