### PR TITLE
chore(github): revert mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,0 @@
-pull_request_rules:
-  - name: automatic merge on CI success and review
-    conditions:
-      - status-success=continuous-integration/travis-ci/pr
-      - "label=ready"
-    actions:
-      merge:
-        method: squash
-        strict: smart


### PR DESCRIPTION
Reverts spinnaker/echo#673

I'm fairly certain this turns every reviewer into an approver. (Reviewers have the `triage` permission, which allows them to [add labels](https://help.github.com/en/articles/repository-permission-levels-for-an-organization).)

Merging this without a review, since you did too :wink: 