### PR TITLE
feat(triggers) Adds support for payloadConstraints on property files for build triggers

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandler.java
@@ -144,7 +144,7 @@ public class BuildEventHandler extends BaseTriggerEventHandler<BuildEvent> {
     return Collections.emptyList();
   }
 
-  static User getKorkUser(Trigger trigger) {
+  private User getKorkUser(Trigger trigger) {
     User user = new User();
     if (trigger.getRunAsUser() != null) {
       user.setEmail(trigger.getRunAsUser());

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandler.java
@@ -17,6 +17,8 @@
 
 package com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers;
 
+import static com.netflix.spinnaker.echo.pipelinetriggers.artifacts.ArtifactMatcher.isConstraintInPayload;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.build.BuildInfoService;
@@ -26,10 +28,7 @@ import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import com.netflix.spinnaker.security.User;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
@@ -122,7 +121,8 @@ public class BuildEventHandler extends BaseTriggerEventHandler<BuildEvent> {
     return trigger ->
         isBuildTrigger(trigger)
             && trigger.getJob().equals(jobName)
-            && trigger.getMaster().equals(master);
+            && trigger.getMaster().equals(master)
+            && checkPayloadConstraintsMet(buildEvent, trigger);
   }
 
   private boolean isBuildTrigger(Trigger trigger) {
@@ -144,11 +144,37 @@ public class BuildEventHandler extends BaseTriggerEventHandler<BuildEvent> {
     return Collections.emptyList();
   }
 
+  protected Map getPropertiesFromEvent(BuildEvent event, Trigger trigger) {
+    if (buildInfoService.isPresent()) {
+      try {
+        return AuthenticatedRequest.propagate(
+                () -> buildInfoService.get().getProperties(event, "build_vars"),
+                getKorkUser(trigger))
+            .call();
+      } catch (Exception e) {
+        log.warn("Unable to get artifacts from event {}, trigger {}", event, trigger, e);
+      }
+    }
+    return Collections.emptyMap();
+  }
+
   private User getKorkUser(Trigger trigger) {
     User user = new User();
     if (trigger.getRunAsUser() != null) {
       user.setEmail(trigger.getRunAsUser());
     }
     return user;
+  }
+
+  private boolean checkPayloadConstraintsMet(BuildEvent event, Trigger trigger) {
+    if (trigger.getPayloadConstraints() == null) {
+      return true; // No constraints, can trigger build
+    }
+
+    // Constraints are present, check they are all met
+    Map buildProperties = getPropertiesFromEvent(event, trigger);
+    boolean constraintsMet =
+        isConstraintInPayload(trigger.getPayloadConstraints(), buildProperties);
+    return constraintsMet;
   }
 }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandler.java
@@ -160,7 +160,8 @@ public class BuildEventHandler extends BaseTriggerEventHandler<BuildEvent> {
     // Constraints are present, check they are all met
     Map buildProperties = getPropertiesFromEvent(event, trigger);
     boolean constraintsMet =
-        isConstraintInPayload(trigger.getPayloadConstraints(), buildProperties);
+        buildProperties != null
+            && isConstraintInPayload(trigger.getPayloadConstraints(), buildProperties);
     if (!constraintsMet) {
       log.info(
           "Constraints {} not met by build properties {}",
@@ -174,7 +175,7 @@ public class BuildEventHandler extends BaseTriggerEventHandler<BuildEvent> {
     if (buildInfoService.isPresent()) {
       try {
         return AuthenticatedRequest.propagate(
-                () -> buildInfoService.get().getProperties(event, "build_vars"),
+                () -> buildInfoService.get().getProperties(event, trigger.getPropertyFile()),
                 getKorkUser(trigger))
             .call();
       } catch (Exception e) {

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.model.Pipeline;
-import com.netflix.spinnaker.echo.model.Trigger;
 import com.netflix.spinnaker.echo.pipelinetriggers.QuietPeriodIndicator;
 import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService.TriggerResponse;
 import com.netflix.spinnaker.fiat.model.Authorization;
@@ -117,11 +116,6 @@ public class PipelineInitiator {
                 System.currentTimeMillis(), pipeline.getTrigger().getType())) {
           log.info(
               "Would trigger {} due to {} but pipeline is set to ignore automatic triggers during quiet periods",
-              pipeline,
-              pipeline.getTrigger());
-        } else if (!this.checkPayloadConstraintsMet(pipeline.getTrigger())) {
-          log.info(
-              "Would trigger {} due to {} but pipeline constraints have not been met",
               pipeline,
               pipeline.getTrigger());
         } else {
@@ -354,67 +348,6 @@ public class PipelineInitiator {
     }
 
     return "N/A";
-  }
-
-  private boolean checkPayloadConstraintsMet(Trigger trigger) {
-    // Only check Jenkins
-    if (!trigger.getType().equals("jenkins") && !trigger.getType().equals("manual")) {
-      return true;
-    }
-
-    Map<String, String> payloadConstraints = trigger.getPayloadConstraints();
-    Map<String, Object> properties = trigger.getProperties();
-    if (payloadConstraints == null || payloadConstraints.isEmpty()) {
-      log.debug("No payload constraints for trigger {}", trigger);
-      return true; // No constraints to check
-    }
-
-    // Constraints, but not properties given
-    if (properties == null || properties.isEmpty()) {
-      log.debug(
-          "Trigger {} has payload constraints {} but no properties were found in the build",
-          trigger,
-          payloadConstraints);
-      return false;
-    }
-
-    // Check all constraints in properties map
-    for (Map.Entry<String, String> entry : payloadConstraints.entrySet()) {
-      String key = entry.getKey();
-      String value = entry.getValue();
-      // Find the corresponding property, make sure it's not null
-      if (!properties.containsKey(key)) {
-        log.debug(
-            "Missing payload constraint {} in properties {} for trigger {}",
-            key,
-            properties,
-            trigger);
-        return false;
-      }
-      Object propertyValue = properties.get(key);
-      if (propertyValue == null) {
-        log.debug(
-            "Null payload constraint {} in properties {} for trigger {}", key, properties, trigger);
-        return false;
-      }
-      // Check values match
-      if (propertyValue.equals(value)) {
-        log.debug(
-            "Payload constraint met for {}, property value {} for trigger {}",
-            key,
-            properties,
-            trigger);
-      } else {
-        log.debug(
-            "Payload constraint NOT met for {}, property value {} for trigger {}",
-            key,
-            properties,
-            trigger);
-        return false;
-      }
-    }
-
-    return true; // All constraints were met
   }
 
   private static boolean isRetryableError(Throwable error) {

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandlerSpec.groovy
@@ -31,7 +31,12 @@ class BuildEventHandlerSpec extends Specification implements RetrofitStubs {
     abc: 123
   ]
   static Map<String, Object> PROPERTIES = [
-    def: 456
+    def: 456,
+    branch: "feature/my-thing"
+  ]
+  static Map<String, Object> CONSTRAINTS = [
+    def: "^[0-9]*\$", // def must be a positive number,
+    branch: "^(feature)/.*\$" // only trigger on branch name like "feature/***"
   ]
 
   @Subject
@@ -261,6 +266,26 @@ class BuildEventHandlerSpec extends Specification implements RetrofitStubs {
     outputTrigger.properties.equals(PROPERTIES)
   }
 
+ def "checks constraints on property file if defined"() {
+    given:
+    def trigger = enabledJenkinsTrigger
+      .withMaster(MASTER_NAME)
+      .withJob(JOB_NAME)
+      .withBuildNumber(BUILD_NUMBER)
+      .withPropertyFile(PROPERTY_FILE)
+      .withPayloadConstraints(CONSTRAINTS)
+
+    def inputPipeline = createPipelineWith(enabledJenkinsTrigger).withTrigger(trigger)
+    def event = getBuildEvent()
+
+    when:
+    def matchTriggerPredicate = eventHandler.matchTriggerFor(event).test(trigger)
+
+    then:
+    1 * igorService.getPropertyFile(BUILD_NUMBER, PROPERTY_FILE, MASTER_NAME, JOB_NAME) >> PROPERTIES
+    matchTriggerPredicate.equals(true)
+  }
+
   def "retries on failure to communicate with igor"() {
     given:
     def trigger = enabledJenkinsTrigger
@@ -270,7 +295,7 @@ class BuildEventHandlerSpec extends Specification implements RetrofitStubs {
       .withPropertyFile(PROPERTY_FILE)
 
     def inputPipeline = createPipelineWith(enabledJenkinsTrigger).withTrigger(trigger)
-    def event = getBuildEvent()
+    def event = getBuildEvent().withProperties()
 
     when:
     def outputTrigger = eventHandler.buildTrigger(event).apply(trigger)

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BuildEventHandlerSpec.groovy
@@ -295,7 +295,7 @@ class BuildEventHandlerSpec extends Specification implements RetrofitStubs {
       .withPropertyFile(PROPERTY_FILE)
 
     def inputPipeline = createPipelineWith(enabledJenkinsTrigger).withTrigger(trigger)
-    def event = getBuildEvent().withProperties()
+    def event = getBuildEvent()
 
     when:
     def outputTrigger = eventHandler.buildTrigger(event).apply(trigger)


### PR DESCRIPTION
Implements [Spinnaker Issue #5053](https://github.com/spinnaker/spinnaker/issues/5053)

Use case is conditionally triggering pipelines after a successful Jenkins build.  For example, Jenkins may be setup for builds on all branches but Spinnaker pipelines should only be master.  More complex use cases are possible too, like triggering 'stage' pipelines on feature/* branches or when a Jenkins build has something like `deploy_target=stage`.

* Adds support for payloadConstrains: {} dictionary for Build triggers (e.g. Jenkins).  
* If payloadConstraints are present, then properties in the properties file must pass the constraints to trigger a build
* Regexp is supported (works the same as webhook and pub/sub payloadConstraints)
* Does not support Manual Pipeline triggers (ie: if build 30 fails constraints it can still be manually triggered after the fact)
* Only tested with Jenkins

I think it will work with other build systems as long as they support properties, but unfortunately I don't have any available to test.




