### PR TITLE
feat(triggers): add action field to git triggers context

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -171,6 +171,7 @@ public class Trigger {
   String runAsUser;
   String secret;
   String digest;
+  String action;
 
   @Builder.Default boolean rebake = false;
 
@@ -257,6 +258,10 @@ public class Trigger {
 
   public Trigger atNexusSearchName(final String nexusSearchName) {
     return this.toBuilder().nexusSearchName(nexusSearchName).build();
+  }
+
+  public Trigger atAction(final String action) {
+    return this.toBuilder().action(action).build();
   }
 
   @JsonPOJOBuilder(withPrefix = "")

--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/trigger/GitEvent.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/trigger/GitEvent.java
@@ -42,6 +42,7 @@ public class GitEvent extends TriggerEvent {
     private String slug;
     private String hash;
     private String branch;
+    private String action;
     private List<Artifact> artifacts;
   }
 
@@ -53,5 +54,10 @@ public class GitEvent extends TriggerEvent {
   @JsonIgnore
   public String getBranch() {
     return content.branch;
+  }
+
+  @JsonIgnore
+  public String getAction() {
+    return content.action;
   }
 }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandler.java
@@ -115,7 +115,8 @@ public class GitEventHandler extends BaseTriggerEventHandler<GitEvent> {
         trigger
             .atHash(gitEvent.getHash())
             .atBranch(gitEvent.getBranch())
-            .atEventId(gitEvent.getEventId());
+            .atEventId(gitEvent.getEventId())
+            .atAction(gitEvent.getAction());
   }
 
   private boolean matchesPattern(String s, String pattern) {

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandlerSpec.groovy
@@ -71,6 +71,7 @@ class GitEventHandlerSpec extends Specification implements RetrofitStubs {
     matchingPipelines[0].trigger.project == enabledStashTrigger.project
     matchingPipelines[0].trigger.slug == enabledStashTrigger.slug
     matchingPipelines[0].trigger.hash == event.content.hash
+    matchingPipelines[0].trigger.action == event.content.action
 
     where:
     event = createGitEvent("stash")
@@ -90,6 +91,7 @@ class GitEventHandlerSpec extends Specification implements RetrofitStubs {
     matchingPipelines[0].trigger.project == enabledBitBucketTrigger.project
     matchingPipelines[0].trigger.slug == enabledBitBucketTrigger.slug
     matchingPipelines[0].trigger.hash == event.content.hash
+    matchingPipelines[0].trigger.action == event.content.action
 
     where:
     event = createGitEvent("bitbucket")

--- a/echo-test/src/main/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
+++ b/echo-test/src/main/groovy/com/netflix/spinnaker/echo/test/RetrofitStubs.groovy
@@ -70,7 +70,7 @@ trait RetrofitStubs {
 
   GitEvent createGitEvent(String eventSource) {
     def res = new GitEvent()
-    res.content = new GitEvent.Content("project", "slug", "hash", "master", [])
+    res.content = new GitEvent.Content("project", "slug", "hash", "master", "action", [])
     res.details = new Metadata([type: GitEvent.TYPE, source: eventSource])
     return res
   }

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/BitbucketWehbookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/BitbucketWehbookEventHandler.java
@@ -153,6 +153,7 @@ public class BitbucketWehbookEventHandler implements GitWebhookHandler {
     String slug = "";
     String hash = "";
     String branch = "";
+    String action = "";
 
     BitbucketCloudEvent bitbucketCloudEvent =
         objectMapper.convertValue(postedEvent, BitbucketCloudEvent.class);
@@ -183,11 +184,13 @@ public class BitbucketWehbookEventHandler implements GitWebhookHandler {
         }
       }
     }
+    action = emptyOrDefault(event.content.get("event_type").toString(), "");
 
     event.content.put("repoProject", repoProject);
     event.content.put("slug", slug);
     event.content.put("hash", hash);
     event.content.put("branch", branch);
+    event.content.put("action", action);
   }
 
   private void handleBitbucketServerEvent(Event event, Map postedEvent) {
@@ -238,6 +241,7 @@ public class BitbucketWehbookEventHandler implements GitWebhookHandler {
     event.content.put("slug", slug);
     event.content.put("hash", hash);
     event.content.put("branch", branch);
+    event.content.put("action", eventType);
   }
 
   private String emptyOrDefault(String test, String def) {

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GithubWebhookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GithubWebhookEventHandler.java
@@ -86,6 +86,8 @@ public class GithubWebhookEventHandler implements GitWebhookHandler {
     results.put("slug", webhookEvent.getSlug(event, postedEvent));
     results.put("hash", webhookEvent.getHash(event, postedEvent));
     results.put("branch", webhookEvent.getBranch(event, postedEvent));
+    results.put(
+        "action", githubEvent.concat(":").concat(webhookEvent.getAction(event, postedEvent)));
     event.content.putAll(results);
 
     log.info(

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GitlabWehbookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GitlabWehbookEventHandler.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.echo.scm;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.echo.model.Event;
@@ -48,6 +49,7 @@ public class GitlabWehbookEventHandler implements GitWebhookHandler {
     event.content.put("branch", gitlabWebhookEvent.ref.replace("refs/heads/", ""));
     event.content.put("repoProject", gitlabWebhookEvent.project.namespace);
     event.content.put("slug", gitlabWebhookEvent.project.name);
+    event.content.put("action", gitlabWebhookEvent.objectKind);
   }
 
   @Data
@@ -55,6 +57,9 @@ public class GitlabWehbookEventHandler implements GitWebhookHandler {
     String after;
     String ref;
     GitlabProject project;
+
+    @JsonProperty("object_kind")
+    String objectKind;
   }
 
   @Data

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/StashWebhookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/StashWebhookEventHandler.java
@@ -46,6 +46,7 @@ public class StashWebhookEventHandler implements GitWebhookHandler {
         "branch", stashWebhookEvent.refChanges.get(0).refId.replace("refs/heads/", ""));
     event.content.put("repoProject", stashWebhookEvent.repository.project.key);
     event.content.put("slug", stashWebhookEvent.repository.slug);
+    event.content.put("action", "");
   }
 
   public boolean shouldSendEvent(Event event) {

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/github/GithubPullRequestEvent.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/github/GithubPullRequestEvent.java
@@ -29,6 +29,8 @@ public class GithubPullRequestEvent implements GithubWebhookEvent {
   @JsonProperty("pull_request")
   PullRequest pullRequest;
 
+  String action;
+
   // `.repository.full_name`
   @Override
   public String getFullRepoName(Event event, Map postedEvent) {
@@ -78,6 +80,12 @@ public class GithubPullRequestEvent implements GithubWebhookEvent {
         .map(PullRequest::getHead)
         .map(PullRequestHead::getRef)
         .orElse("");
+  }
+
+  // `.action`
+  @Override
+  public String getAction(Event event, Map postedEvent) {
+    return Optional.of(this).map(GithubPullRequestEvent::getAction).orElse("");
   }
 
   @Data

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/github/GithubPushEvent.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/github/GithubPushEvent.java
@@ -28,6 +28,8 @@ public class GithubPushEvent implements GithubWebhookEvent {
   String after;
   String ref;
 
+  public static final String ACTION = "push";
+
   // `.repository.full_name`
   @Override
   public String getFullRepoName(Event event, Map postedEvent) {
@@ -67,6 +69,11 @@ public class GithubPushEvent implements GithubWebhookEvent {
   public String getBranch(Event event, Map postedEvent) {
     // Replace on "" still returns "", which is fine
     return Optional.of(this).map(GithubPushEvent::getRef).orElse("").replace("refs/heads/", "");
+  }
+
+  @Override
+  public String getAction(Event event, Map postedEvent) {
+    return ACTION;
   }
 
   @Data

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/github/GithubWebhookEvent.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/github/GithubWebhookEvent.java
@@ -29,4 +29,6 @@ public interface GithubWebhookEvent {
   String getHash(Event event, Map postedEvent);
 
   String getBranch(Event event, Map postedEvent);
+
+  String getAction(Event event, Map postedEvent);
 }


### PR DESCRIPTION
When dealing with webhook git triggers the event of the webhook does not reach the pipeline contexts. This PR makes this event available in the contexts of the pipeline execution.

This should no affect the current conditional for matching pipelines (source, project, slug, branch), it is just informative like the hash field.

For example: allowing only github events where someone open/close a pull request using check preconditions, or if there is github push event follow a different branch in the pipeline, instead of one for pull request events.

For bitbucket server I used the header [ X-Event-Key ](https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html)

For bitbucket cloud I used the header [X-Event-Key](https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Push)

For gitlab I used the field in the payload named [object_kind](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html)

For github at the moment only supports push and PR, so I used the field named [action](https://developer.github.com/webhooks/#example-delivery) of the payload.

related to https://github.com/spinnaker/orca/pull/3269