### PR TITLE
feat(extension): Add event parser extension for echo-rest

### DIFF
--- a/echo-api/echo-api.gradle
+++ b/echo-api/echo-api.gradle
@@ -1,0 +1,6 @@
+dependencies {
+  api "com.netflix.spinnaker.kork:kork-plugins-api"
+
+  compileOnly("org.projectlombok:lombok")
+  annotationProcessor("org.projectlombok:lombok")
+}

--- a/echo-api/src/main/java/com/netflix/spinnaker/echo/extension/rest/RestEventParser.java
+++ b/echo-api/src/main/java/com/netflix/spinnaker/echo/extension/rest/RestEventParser.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.extension.rest;
+
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.pf4j.ExtensionPoint;
+
+@Alpha
+public interface RestEventParser extends ExtensionPoint {
+
+  /**
+   * Parse an Event prior to POST to the configured URL
+   *
+   * @param event {@link Event}
+   * @return Map, which conforms to the RestEventListener API
+   */
+  Map parse(Event event);
+
+  @Data
+  class Event {
+    public Metadata details;
+    public Map<String, Object> content;
+    public String rawContent;
+    public Map<String, Object> payload;
+    public String eventId;
+  }
+
+  @Data
+  @AllArgsConstructor
+  @NoArgsConstructor
+  class Metadata {
+    private String source;
+    private String type;
+    private String created;
+    private String organization;
+    private String project;
+    private String application;
+    private String _content_id;
+    private Map<String, List> requestHeaders;
+    private Map<String, String> attributes;
+  }
+}

--- a/echo-rest/echo-rest.gradle
+++ b/echo-rest/echo-rest.gradle
@@ -21,6 +21,7 @@ dependencies {
   implementation "com.squareup.okhttp:okhttp-urlconnection"
   implementation "com.squareup.okhttp:okhttp-apache"
   implementation project(':echo-model')
+  implementation project(':echo-api')
 
   implementation "commons-codec:commons-codec"
 

--- a/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/config/RestConfig.groovy
+++ b/echo-rest/src/main/groovy/com/netflix/spinnaker/echo/config/RestConfig.groovy
@@ -89,7 +89,11 @@ class RestConfig {
   }
 
   @Bean
-  RestUrls restServices(RestProperties restProperties, RestClientFactory clientFactory, LogLevel retrofitLogLevel, RequestInterceptorAttacher requestInterceptorAttacher, HeadersFromFile headersFromFile) {
+  RestUrls restServices(RestProperties restProperties,
+                        RestClientFactory clientFactory,
+                        LogLevel retrofitLogLevel,
+                        RequestInterceptorAttacher requestInterceptorAttacher,
+                        HeadersFromFile headersFromFile) {
 
     RestUrls restUrls = new RestUrls()
 

--- a/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/RestEventListenerSpec.groovy
+++ b/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/RestEventListenerSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.echo.events
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.echo.config.RestUrls
 import com.netflix.spinnaker.echo.model.Event
+import com.netflix.spinnaker.echo.extension.rest.RestEventParser
 import com.netflix.spinnaker.echo.rest.RestService
 import spock.lang.Specification
 import spock.lang.Subject
@@ -26,8 +27,10 @@ import spock.lang.Subject
 
 class RestEventListenerSpec extends Specification {
 
+  Optional<RestEventParser> restEventParser = Optional.empty()
+
   @Subject
-  RestEventListener listener = new RestEventListener(null, null, new NoopRegistry())
+  RestEventListener listener = new RestEventListener(null, null, restEventParser, new NoopRegistry())
   Event event = new Event(content: ['uno': 'dos'])
   RestService restService
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-include 'echo-artifacts',
+include 'echo-api',
+        'echo-artifacts',
         'echo-bom',
         'echo-core',
         'echo-model',


### PR DESCRIPTION
Alpha PF4J extension for parsing Echo events prior to POST to configured service.  This implementation is quite simple at the moment.

Current implementation will override any additional configuration (like `wrap`).  However, as this progresses I would like to see this extension point work with existing configurations and allow multiple parsers for multiple configured URLs.

If things progress well, the more powerful extension point would be `EchoEventListener` which would allow us to decompose echo event listeners into discrete plugins.