### PR TITLE
fix(stats): Deregister the telemetry circuit breaker from the health indicator

### DIFF
--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryEventListener.java
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryEventListener.java
@@ -178,7 +178,7 @@ public class TelemetryEventListener implements EchoEventListener {
           TELEMETRY_REGISTRY_NAME,
           cnpe.getMessage());
     } catch (Exception e) {
-      log.warn("Could not send Telemetry event {}", event, e);
+      log.debug("Could not send Telemetry event {}", event, e);
     }
   }
 

--- a/echo-web/config/echo.yml
+++ b/echo-web/config/echo.yml
@@ -28,8 +28,8 @@ webhooks:
 resilience4j.circuitbreaker:
   instances:
     telemetry:
-      # Startup config...
-      registerHealthIndicator: true
+      # This needs to stay false, because if the telemetry endpoint goes down, Echo goes unhealthy (no good!)
+      registerHealthIndicator: false
       # Warming up...
       minimumNumberOfCalls: 5
       slidingWindowSize: 10

--- a/echo-web/src/test/java/com/netflix/spinnaker/echo/telemetry/TelemetrySpec.java
+++ b/echo-web/src/test/java/com/netflix/spinnaker/echo/telemetry/TelemetrySpec.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.telemetry;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.netflix.spinnaker.echo.Application;
+import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService;
+import com.netflix.spinnaker.echo.services.Front50Service;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {Application.class})
+@TestPropertySource(properties = {"spring.config.location=classpath:echo-test.yml"})
+public class TelemetrySpec {
+  @MockBean Front50Service front50Service;
+
+  @MockBean OrcaService orcaService;
+
+  @Autowired WebApplicationContext wac;
+
+  @Autowired CircuitBreakerRegistry circuitBreakerRegistry;
+
+  MockMvc mockMvc;
+
+  @BeforeEach
+  public void setup() {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+  }
+
+  @Test
+  public void telemetryDownEchoStillHealthyTest() throws Exception {
+    mockMvc.perform(get("/health")).andExpect(status().isOk());
+
+    // Simulate the stats endpoint going down, tripping the circuit breaker.
+    CircuitBreaker cb =
+        circuitBreakerRegistry.circuitBreaker(TelemetryEventListener.TELEMETRY_REGISTRY_NAME);
+    cb.transitionToOpenState();
+
+    mockMvc.perform(get("/health")).andExpect(status().isOk());
+  }
+}

--- a/echo-web/src/test/resources/echo-test.yml
+++ b/echo-web/src/test/resources/echo-test.yml
@@ -6,3 +6,9 @@ front50:
 
 orca:
   baseUrl: 'http://localhost:8083'
+
+resilience4j.circuitbreaker:
+  instances:
+    telemetry:
+      # This needs to stay false, because if the telemetry endpoint goes down, Echo goes unhealthy (no good!)
+      registerHealthIndicator: false


### PR DESCRIPTION
Back in October, the telemetry endpoint went down, causing our nightly tests to start failing. The root cause was that the resiliance4j circuit breaker library was hooked up to the Spring Boot health endpoint, so when the breaker was tripped (yay that this part worked as intended), it caused Echo's `/health` endpoint to start returning 503s, and thus traffic to it was halted in a Kubernetes environment.

The fix is to not register the circuit breaker with the health endpoint. I added a system test to confirm this (heavy handed, yes, but I don't know how else to test this dependency) and for good measure, I added a unit test that throws various Retrofit errors.

tag: https://github.com/spinnaker/spinnaker/issues/5144