### PR TITLE
refactor(artifacts): Use builder to create artifacts

### DIFF
--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandlerSpec.groovy
@@ -37,18 +37,18 @@ class ManualEventHandlerSpec extends Specification implements RetrofitStubs {
   def artifactInfoService = Mock(ArtifactInfoService)
   def pipelineCache = Mock(PipelineCache)
 
-  Artifact artifact = new Artifact(
-    "deb",
-    false,
-    "my-package",
-    "v1.1.1",
-    "https://artifactory/my-package/",
-    "https://artifactory/my-package/",
-    [:],
-    "account",
-    "provenance",
-    "123456"
-  )
+  Artifact artifact = Artifact.builder()
+    .type("deb")
+    .customKind(false)
+    .name("my-package")
+    .version("v1.1.1")
+    .location("https://artifactory/my-package/")
+    .reference("https://artifactory/my-package/")
+    .metadata([:])
+    .artifactAccount("account")
+    .provenance("provenance")
+    .uuid("123456")
+    .build()
 
   @Subject
   def eventHandler = new ManualEventHandler(

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandlerSpec.groovy
@@ -39,39 +39,38 @@ class PubsubEventHandlerSpec extends Specification implements RetrofitStubs {
   def fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
 
   @Shared
-  def goodArtifacts = [new Artifact(name: 'myArtifact', type: 'artifactType')]
+  def goodArtifact = Artifact.builder().name('myArtifact').type('artifactType').build()
+  def badArtifact = Artifact.builder().name('myBadArtifact').type('artifactType').build()
+
+  @Shared
+  def goodArtifacts = [goodArtifact]
 
   @Shared
   def badExpectedArtifacts = [
-    new ExpectedArtifact(
-      matchArtifact: new Artifact(
-        name: 'myBadArtifact',
-        type: 'artifactType',
-      ),
-      id: 'badId'
-    )
+    ExpectedArtifact.builder()
+      .matchArtifact(badArtifact)
+      .id('badId')
+      .build()
   ]
 
   @Shared
   def goodExpectedArtifacts = [
-    new ExpectedArtifact(
-      matchArtifact: new Artifact(
-        name: 'myArtifact',
-        type: 'artifactType',
-      ),
-      id: 'goodId'
-    )
+    ExpectedArtifact.builder()
+      .matchArtifact(goodArtifact)
+      .id('goodId')
+      .build()
   ]
 
   @Shared
   def goodRegexExpectedArtifacts = [
-    new ExpectedArtifact(
-      matchArtifact: new Artifact(
-        name: 'myArtifact',
-        type: 'artifact.*',
-      ),
-      id: 'goodId'
-    )
+    ExpectedArtifact.builder()
+      .matchArtifact(
+        Artifact.builder()
+        .name('myArtifact')
+        .type('artifact.*')
+        .build())
+      .id('goodId')
+      .build()
   ]
 
   @Subject

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/WebhookEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/WebhookEventHandlerSpec.groovy
@@ -33,13 +33,14 @@ class WebhookEventHandlerSpec extends Specification implements RetrofitStubs {
 
   @Shared
   def goodExpectedArtifacts = [
-      new ExpectedArtifact(
-          matchArtifact: new Artifact(
-              name: 'myArtifact',
-              type: 'artifactType',
-          ),
-          id: 'goodId'
-      )
+      ExpectedArtifact.builder()
+        .matchArtifact(
+          Artifact.builder()
+            .name('myArtifact')
+            .type('artifactType')
+            .build())
+        .id('goodId')
+        .build()
   ]
 
   @Subject

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ExpectedArtifactExpressionEvaluationPostProcessorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/postprocessors/ExpectedArtifactExpressionEvaluationPostProcessorSpec.groovy
@@ -23,14 +23,15 @@ class ExpectedArtifactExpressionEvaluationPostProcessorSpec extends Specificatio
 
   def 'evaluates expressions in expected artifacts'() {
     given:
-    def artifact = new ExpectedArtifact(
-      matchArtifact: new Artifact(
-        name: '''group:artifact:${trigger['buildNumber']}''',
-        version: '''${trigger['buildNumber']}''',
-        type: 'maven/file',
-      ),
-      id: 'goodId'
-    )
+    def artifact = ExpectedArtifact.builder()
+      .matchArtifact(
+        Artifact.builder()
+          .name('''group:artifact:${trigger['buildNumber']}''')
+          .version('''${trigger['buildNumber']}''')
+          .type('maven/file')
+          .build())
+      .id('goodId')
+      .build()
 
     def inputPipeline = createPipelineWith([artifact], trigger).withTrigger(trigger)
 
@@ -45,13 +46,14 @@ class ExpectedArtifactExpressionEvaluationPostProcessorSpec extends Specificatio
 
   def 'unevaluable expressions are left in place'() { // they may be evaluated later in a stage with more context
     given:
-    def artifact = new ExpectedArtifact(
-      matchArtifact: new Artifact(
-        name: '''group:artifact:${#stage('deploy')['version']}''',
-        type: 'maven/file',
-      ),
-      id: 'goodId'
-    )
+    def artifact = ExpectedArtifact.builder()
+      .matchArtifact(
+        Artifact.builder()
+          .name('''group:artifact:${#stage('deploy')['version']}''')
+          .type('maven/file')
+          .build())
+        .id('goodId')
+        .build()
 
     def inputPipeline = createPipelineWith([artifact], trigger).withTrigger(trigger)
 


### PR DESCRIPTION
The all-arg and no-arg constructors for Artifact were deprecated in spinnaker/kork#429. Replace their usages with a builder.