### PR TITLE
fix(mpt): include templateVariables in pipeline model

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
@@ -71,6 +71,8 @@ public class Pipeline {
 
   @JsonProperty Object template;
 
+  @JsonProperty Map<String, Object> templateVariables;
+
   @JsonProperty List<Map<String, Object>> stages;
 
   @JsonProperty List<Map<String, Object>> notifications;


### PR DESCRIPTION
follow up from https://github.com/spinnaker/orca/pull/3335
plumb through the `templateVariables` for triggering to work on mptv2 pipelines that use spel v4
