### PR TITLE
fix(github): Put back github endpoint configuration

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/GithubConfig.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/GithubConfig.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.echo.config;
 import com.netflix.spinnaker.echo.github.GithubService;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,11 +33,12 @@ import retrofit.converter.JacksonConverter;
 @ConditionalOnProperty("github-status.enabled")
 @Slf4j
 public class GithubConfig {
-  static final String GITHUB_STATUS_URL = "https://api.github.com";
+
+  @Value("${github-status.endpoint:'https://api.github.com'}")
+  private String endpoint;
 
   @Bean
   public Endpoint githubEndpoint() {
-    String endpoint = GITHUB_STATUS_URL;
     return Endpoints.newFixedEndpoint(endpoint);
   }
 

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/GithubConfigSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/GithubConfigSpec.groovy
@@ -20,16 +20,4 @@ class GithubConfigSpec extends Specification {
     endpoint.url == ownEndpoint
   }
 
-  def 'test github default endpoint is correctly setted'() {
-    given:
-    String defaultEndpoint = "https://api.github.com"
-    githubConfig.endpoint = defaultEndpoint;
-
-    when:
-    Endpoint endpoint = githubConfig.githubEndpoint()
-
-    then:
-    endpoint.url == defaultEndpoint
-  }
-
 }

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/GithubConfigSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/GithubConfigSpec.groovy
@@ -1,0 +1,35 @@
+package com.netflix.spinnaker.echo.config
+
+import spock.lang.Specification
+import spock.lang.Subject
+import retrofit.Endpoint
+
+class GithubConfigSpec extends Specification {
+  @Subject
+  GithubConfig githubConfig = new GithubConfig()
+
+  def 'test github incoming endpoint is correctly setted'() {
+    given:
+    String ownEndpoint = "https://github.myendpoint.com"
+    githubConfig.endpoint = ownEndpoint;
+
+    when:
+    Endpoint endpoint = githubConfig.githubEndpoint()
+
+    then:
+    endpoint.url == ownEndpoint
+  }
+
+  def 'test github default endpoint is correctly setted'() {
+    given:
+    String defaultEndpoint = "https://api.github.com"
+    githubConfig.endpoint = defaultEndpoint;
+
+    when:
+    Endpoint endpoint = githubConfig.githubEndpoint()
+
+    then:
+    endpoint.url == defaultEndpoint
+  }
+
+}


### PR DESCRIPTION
I restore the endpoint in the Github configuration. If it doesn't receive any value, the default value that already exists will remain.