### PR TITLE
perf(pipelines): Use new endpoint to fetch pipeline config

### DIFF
--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/services/Front50Service.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/services/Front50Service.java
@@ -15,9 +15,8 @@ public interface Front50Service {
   @Headers("Accept: application/json")
   List<Pipeline> getPipelines(@Path("application") String application);
 
-  // either an empty list or a singleton of a raw pipeline config
-  @GET("/pipelines/{pipelineId}/history?limit=1")
-  List<Map<String, Object>> getLatestVersion(@Path("pipelineId") String pipelineId);
+  @GET("/pipelines/{pipelineId}/get")
+  Map<String, Object> getPipeline(@Path("pipelineId") String pipelineId);
 
   @POST("/graphql")
   @Headers("Accept: application/json")

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
@@ -221,24 +221,13 @@ public class PipelineCache implements MonitoredPoller {
   // if anything fails during the refresh, we fall back to returning the cached version
   public Pipeline refresh(Pipeline cached) {
     try {
-      List<Map<String, Object>> latestVersion = front50.getLatestVersion(cached.getId());
-      if (latestVersion.isEmpty()) {
-        // if that corresponds to the case where the pipeline has been deleted, maybe we should not
-        // return the
-        // cached version
-        log.warn(
-            "Got empty results back from front50's /pipelines/{}/history?limit=1, falling back to cached={}",
-            cached.getId(),
-            cached);
-        return cached;
-      }
-
-      Optional<Pipeline> processed = process(latestVersion.get(0));
+      Map<String, Object> pipeline = front50.getPipeline(cached.getId());
+      Optional<Pipeline> processed = process(pipeline);
       if (!processed.isPresent()) {
         log.warn(
             "Failed to process raw pipeline, falling back to cached={}\n  latestVersion={}",
             cached,
-            latestVersion);
+            pipeline);
         return cached;
       }
 


### PR DESCRIPTION
The only call from echo to the front50 /pipelines/id/history endpoint passes limit=1. Replace it with the new endpoint /pipelines/id/get that gets the current state of the pipeline config and does so more performantly than the history endpoint.

Requires front50 >= 2.11.0, which is when this new endpoint was added.