### PR TITLE
fix(slack): Allow specifying full url for webhooks integration

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
@@ -41,7 +41,7 @@ import static retrofit.Endpoints.newFixedEndpoint
 @CompileStatic
 class SlackConfig {
 
-  final static String SLACK_INCOMING_WEBHOOK = 'https://hooks.slack.com'
+  final static String SLACK_INCOMING_WEBHOOK = 'https://hooks.slack.com/services'
   final static String SLACK_CHAT_API = 'https://slack.com'
 
   @Value('${slack.base-url:}')

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackClient.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackClient.groovy
@@ -33,7 +33,7 @@ interface SlackClient {
   /**
    * Documentation: https://api.slack.com/incoming-webhooks
    */
-  @POST('/services/{token}')
+  @POST('/{token}')
   Response sendUsingIncomingWebHook(
     @Path(value = "token", encode = false) String token,
     @Body SlackRequest slackRequest)

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/SlackConfigSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/config/SlackConfigSpec.groovy
@@ -19,12 +19,12 @@ class SlackConfigSpec extends Specification {
     endpoint.url == expectedEndpoint
 
     where:
-    token                                          | expectedEndpoint          | expectedUseIncomingWebHook
-    "myOldFashionToken"                            | "https://slack.com"       | false
-    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | "https://hooks.slack.com" | true
-    "OLD/FASHION"                                  | "https://slack.com"       | false
-    ""                                             | "https://slack.com"       | false
-    null                                           | "https://slack.com"       | false
+    token                                          | expectedEndpoint                   | expectedUseIncomingWebHook
+    "myOldFashionToken"                            | "https://slack.com"                | false
+    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | "https://hooks.slack.com/services" | true
+    "OLD/FASHION"                                  | "https://slack.com"                | false
+    ""                                             | "https://slack.com"                | false
+    null                                           | "https://slack.com"                | false
   }
 
   def 'test slack incoming web hook base url is defined'() {
@@ -41,13 +41,13 @@ class SlackConfigSpec extends Specification {
     endpoint.url == expectedEndpoint
 
     where:
-    token                                          | baseUrl               | expectedEndpoint          | expectedUseIncomingWebHook
-    "myOldFashionToken"                            | "https://example.com" | "https://example.com"     | false
-    "myOldFashionToken"                            | ""                    | "https://slack.com"       | false
-    "myOldFashionToken"                            | null                  | "https://slack.com"       | false
-    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | "https://example.com" | "https://example.com"     | true
-    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | ""                    | "https://hooks.slack.com" | true
-    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | null                  | "https://hooks.slack.com" | true
+    token                                          | baseUrl               | expectedEndpoint                   | expectedUseIncomingWebHook
+    "myOldFashionToken"                            | "https://example.com" | "https://example.com"              | false
+    "myOldFashionToken"                            | ""                    | "https://slack.com"                | false
+    "myOldFashionToken"                            | null                  | "https://slack.com"                | false
+    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | "https://example.com" | "https://example.com"              | true
+    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | ""                    | "https://hooks.slack.com/services" | true
+    "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" | null                  | "https://hooks.slack.com/services" | true
   }
 
   def 'test slack incoming web hook when forceUseIncomingWebhook'() {


### PR DESCRIPTION
In a previous PR we addressed spinnaker/spinnaker#4634 by allowing to specify the baseURL for slack. Unfortunately we're always posting to BASE_URL/services/TOKEN because of the way the client is declared.

With this patch I move the /services part to the base url and we append the token to the end of the url, this way the user can provide the full url to their webhook endpoint.

E.g: https://example.com/webhooks, we'll send a post request for https://example.com/webhooks/${token} instead of https://example.com/webhooks/services/${token} as we would currently do.
