### PR TITLE
fix(discovery): make spring config order explicit to fix Conditional bean loading

### DIFF
--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/config/EchoCoreConfig.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/config/EchoCoreConfig.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.echo.config;
 import com.netflix.spinnaker.echo.discovery.DiscoveryPollingConfiguration;
 import com.netflix.spinnaker.echo.events.EchoEventListener;
 import com.netflix.spinnaker.echo.events.EventPropagator;
+import com.netflix.spinnaker.kork.PlatformComponents;
 import com.netflix.spinnaker.kork.artifacts.parsing.DefaultJinjavaFactory;
 import com.netflix.spinnaker.kork.artifacts.parsing.JinjaArtifactExtractor;
 import com.netflix.spinnaker.kork.artifacts.parsing.JinjavaFactory;
@@ -37,7 +38,7 @@ import org.springframework.context.annotation.Import;
   "com.netflix.spinnaker.echo.build",
   "com.netflix.spinnaker.echo.events",
 })
-@Import(DiscoveryPollingConfiguration.class)
+@Import({PlatformComponents.class, DiscoveryPollingConfiguration.class})
 public class EchoCoreConfig {
   private ApplicationContext context;
 


### PR DESCRIPTION
References PlatformComponents before DiscoveryPollingConfiguration to resolve
ConditionalOnBean and ConditionalOnMissingBean not finding DiscoveryClient