### PR TITLE
fix(stats): MPT tracking

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
@@ -87,6 +87,8 @@ public class Pipeline {
 
   @JsonProperty String errorMessage;
 
+  @JsonProperty Map<String, String> source;
+
   Trigger trigger;
 
   @JsonPOJOBuilder(withPrefix = "")


### PR DESCRIPTION
Part of https://github.com/spinnaker/spinnaker/issues/5302

Goes in tandem with https://github.com/spinnaker/orca/pull/3360

This PR detects if a pipeline was sourced from a Managed Pipeline Template (either V1 or V2) and sets the Execution.Type to match. 