### PR TITLE
fix(stats): Fix NPE when pipeline explicitly sends 'source=null'

### DIFF
--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryEventListener.java
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryEventListener.java
@@ -114,7 +114,8 @@ public class TelemetryEventListener implements EchoEventListener {
         Execution.Type.valueOf(
             parseEnum(Execution.Type.getDescriptor(), execution.getType().toUpperCase()));
 
-    if ("templatedPipeline".equalsIgnoreCase(execution.getSource().getType())) {
+    if (execution.getSource() != null
+        && "templatedPipeline".equalsIgnoreCase(execution.getSource().getType())) {
       if ("v1".equalsIgnoreCase(execution.getSource().getVersion())) {
         executionType = Execution.Type.MANAGED_PIPELINE_TEMPLATE_V1;
       } else if ("v2".equalsIgnoreCase(execution.getSource().getVersion())) {

--- a/echo-telemetry/src/test/groovy/com/netflix/spinnaker/echo/telemetry/TelemetryEventListenerSpec.groovy
+++ b/echo-telemetry/src/test/groovy/com/netflix/spinnaker/echo/telemetry/TelemetryEventListenerSpec.groovy
@@ -44,6 +44,7 @@ class TelemetryEventListenerSpec extends Specification {
         trigger: [
           type: "GIT"
         ],
+        source: null,
         stages : [
           [
             type               : "deploy",


### PR DESCRIPTION
It seems the explicitly set `source=null` comes across the wire to Echo often enough that it halted all testing stats for the past few days. Had `source` been not set the default object would be fine.

This will need to be cherry picked into 1.18

