### PR TITLE
fix(slack): Left-over fixes from interactive notifications

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
@@ -103,7 +103,7 @@ class SlackNotificationAgent extends AbstractEventNotificationAgent {
 
     Response response
     if (sendCompactMessages) {
-      response = slackService.sendCompactMessage(token, new CompactSlackMessage(body, color), address, true)
+      response = slackService.sendCompactMessage(new CompactSlackMessage(body, color), address, true)
     } else {
       String title = getNotificationTitle(config.type, application, status)
       response = slackService.sendMessage(new SlackAttachment(title, body, color), address, true)

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackInteractiveNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackInteractiveNotificationService.groovy
@@ -100,7 +100,7 @@ class SlackInteractiveNotificationService extends SlackNotificationService imple
   @Override
   Notification.InteractiveActionCallback parseInteractionCallback(RequestEntity<String> request) {
     // TODO(lfp): This currently doesn't work -- troubleshooting with Slack support.
-    //slack.verifySignature(request)
+    slackAppService.verifySignature(request)
 
     Map payload = parseSlackPayload(request.getBody())
     log.debug("Received callback event from Slack of type ${payload.type}")

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackInteractiveNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackInteractiveNotificationService.groovy
@@ -99,12 +99,11 @@ class SlackInteractiveNotificationService extends SlackNotificationService imple
 
   @Override
   Notification.InteractiveActionCallback parseInteractionCallback(RequestEntity<String> request) {
-    // TODO(lfp): This currently doesn't work -- troubleshooting with Slack support.
+    // Before anything else, verify the signature on the request
     slackAppService.verifySignature(request)
 
     Map payload = parseSlackPayload(request.getBody())
     log.debug("Received callback event from Slack of type ${payload.type}")
-    slackAppService.verifyToken(payload.token)
 
     if (payload.actions.size > 1) {
       log.warn("Expected a single selected action from Slack, but received ${payload.actions.size}")

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
@@ -50,6 +50,7 @@ class SlackNotificationService implements NotificationService {
 
   @Override
   EchoResponse.Void handle(Notification notification) {
+    log.debug("Handling Slack notification to ${notification.to}")
     def text = notificationTemplateEngine.build(notification, NotificationTemplateEngine.Type.BODY)
     notification.to.each {
       def response

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackInteractiveNotificationServiceSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackInteractiveNotificationServiceSpec.groovy
@@ -52,7 +52,7 @@ class SlackInteractiveNotificationServiceSpec extends Specification {
       URLEncoder.encode(getClass().getResource("/slack/callbackRequestBody.txt").text)
 
     RequestEntity<String> request = new RequestEntity<>(
-      slackRequestBody, new HttpHeaders(), HttpMethod.POST, new URI("/notifications/callbaks"))
+      slackRequestBody, new HttpHeaders(), HttpMethod.POST, new URI("/notifications/callbacks"))
 
     slackAppService.verifyToken(*_) >> { }
     slackAppService.getUserInfo(*_) >> new SlackService.SlackUserInfo(email: "john@doe.com")
@@ -80,7 +80,7 @@ class SlackInteractiveNotificationServiceSpec extends Specification {
       URLEncoder.encode(getClass().getResource("/slack/callbackRequestBody.txt").text)
 
     RequestEntity<String> request = new RequestEntity<>(
-      slackRequestBody, new HttpHeaders(), HttpMethod.POST, new URI("/notifications/callbaks"))
+      slackRequestBody, new HttpHeaders(), HttpMethod.POST, new URI("/notifications/callbacks"))
 
     slackAppService.verifyToken(*_) >> { }
     slackAppService.getUserInfo(*_) >> { throw new Exception("oops!") }
@@ -106,7 +106,7 @@ class SlackInteractiveNotificationServiceSpec extends Specification {
     given:
     String slackRequestBody = "content=suspicious"
     RequestEntity<String> request = new RequestEntity<>(
-      slackRequestBody, new HttpHeaders(), HttpMethod.POST, new URI("/notifications/callbaks"))
+      slackRequestBody, new HttpHeaders(), HttpMethod.POST, new URI("/notifications/callbacks"))
 
     when:
     service.parseInteractionCallback(request)
@@ -121,7 +121,7 @@ class SlackInteractiveNotificationServiceSpec extends Specification {
       URLEncoder.encode(getClass().getResource("/slack/callbackRequestBody.txt").text)
 
     RequestEntity<String> request = new RequestEntity<>(
-      slackRequestBody, new HttpHeaders(), HttpMethod.POST, new URI("/notifications/callbaks"))
+      slackRequestBody, new HttpHeaders(), HttpMethod.POST, new URI("/notifications/callbacks"))
 
     slackAppService.verifyToken(*_) >> { throw new InvalidRequestException() }
     slackAppService.getUserInfo(*_) >> { }
@@ -139,7 +139,7 @@ class SlackInteractiveNotificationServiceSpec extends Specification {
     String slackRequestBody = "payload=" + URLEncoder.encode(payload, "UTF-8")
 
     RequestEntity<String> request = new RequestEntity<>(
-      slackRequestBody, new HttpHeaders(), HttpMethod.POST, new URI("/notifications/callbaks"))
+      slackRequestBody, new HttpHeaders(), HttpMethod.POST, new URI("/notifications/callbacks"))
 
     slackAppService.verifyToken(*_) >> { }
     slackAppService.getUserInfo(*_) >> { }

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackInteractiveNotificationServiceSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackInteractiveNotificationServiceSpec.groovy
@@ -115,7 +115,7 @@ class SlackInteractiveNotificationServiceSpec extends Specification {
     thrown(InvalidRequestException)
   }
 
-  def "failing to verify the token from Slack throws an exception"() {
+  def "failing to verify the signature from Slack throws an exception"() {
     given:
     String slackRequestBody = "payload=" +
       URLEncoder.encode(getClass().getResource("/slack/callbackRequestBody.txt").text)
@@ -123,7 +123,7 @@ class SlackInteractiveNotificationServiceSpec extends Specification {
     RequestEntity<String> request = new RequestEntity<>(
       slackRequestBody, new HttpHeaders(), HttpMethod.POST, new URI("/notifications/callbacks"))
 
-    slackAppService.verifyToken(*_) >> { throw new InvalidRequestException() }
+    slackAppService.verifySignature(*_) >> { throw new InvalidRequestException() }
     slackAppService.getUserInfo(*_) >> { }
 
     when:


### PR DESCRIPTION
Fixes the following:
1. Fix and enable signature verification for Slack callbacks: turns out Spring was messing with the URL-encoded payload for some reason (or so it seems -- at least I couldn't find any other culprits on the path of the request processing). I was unable to find a matching issue against Spring although there were other problems reported with inconsistent URL encoding behavior.
2. Left-over refactored method call that I missed to update before.