### PR TITLE
fix(notifications): Fix precedence of notification handlers in controller

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/controller/NotificationController.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/controller/NotificationController.groovy
@@ -53,7 +53,7 @@ class NotificationController {
   EchoResponse create(@RequestBody Notification notification) {
     notificationServices?.find {
       it.supportsType(notification.notificationType) &&
-        !notification.isInteractive() || it instanceof InteractiveNotificationService
+        (!notification.isInteractive() || it instanceof InteractiveNotificationService)
     }?.handle(notification)
   }
 

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/NotificationControllerSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/NotificationControllerSpec.groovy
@@ -53,7 +53,7 @@ class NotificationControllerSpec extends Specification {
       Mock(Environment)
     )
     notificationController = new NotificationController(
-      notificationServices: [ notificationService, interactiveNotificationService ],
+      notificationServices: [ interactiveNotificationService, notificationService ],
       interactiveNotificationCallbackHandler: interactiveNotificationCallbackHandler
     )
   }
@@ -96,6 +96,22 @@ class NotificationControllerSpec extends Specification {
     then:
     0 * notificationService.handle(notification)
     1 * interactiveNotificationService.handle(notification)
+  }
+
+  void 'only interactive notifications are delegated to interactive notification services'() {
+    given:
+    Notification nonInteractiveNotification = new Notification()
+    nonInteractiveNotification.notificationType = Notification.Type.PAGER_DUTY
+
+    notificationService.supportsType(Notification.Type.PAGER_DUTY) >> true
+    interactiveNotificationService.supportsType(Notification.Type.SLACK) >> true
+
+    when:
+    notificationController.create(nonInteractiveNotification)
+
+    then:
+    1 * notificationService.handle(nonInteractiveNotification)
+    0 * interactiveNotificationService.handle(nonInteractiveNotification)
   }
 
   void 'an incoming callback from the notification service delegates to the appropriate service class'() {


### PR DESCRIPTION
I assumed the logical `&&` would short-circuit the rest of the expression, but obviously not. Reading the [groovy docs](https://docs.groovy-lang.org/latest/html/documentation/core-operators.html#_logical_operators), I would expect it to work, but clearly it doesn't.

I added a test where an interactive notification handler is registered before a non-interactive one, which was the situation we had in our deployment and the reason you see this line in the stack trace in the log, which was the hint that led me to finding the bug:

```
at com.netflix.spinnaker.echo.slack.SlackInteractiveNotificationService.handle(SlackInteractiveNotificationService.groovy)
```
The second hint was that the error we experienced was when trying to send a PagerDuty notification, which should obviously not be handled by the Slack implementation. 😝 