### PR TITLE
fix(quietperiod): Allow the quiet period to be set by a dynamic service

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/PipelineTriggerConfiguration.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/PipelineTriggerConfiguration.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -31,7 +30,10 @@ import retrofit.converter.JacksonConverter;
 @Slf4j
 @Configuration
 @ComponentScan(value = "com.netflix.spinnaker.echo.pipelinetriggers")
-@EnableConfigurationProperties(FiatClientConfigurationProperties.class)
+@EnableConfigurationProperties({
+  FiatClientConfigurationProperties.class,
+  QuietPeriodIndicatorConfigurationProperties.class
+})
 public class PipelineTriggerConfiguration {
   private Client retrofitClient;
   private RequestInterceptor requestInterceptor;
@@ -71,12 +73,6 @@ public class PipelineTriggerConfiguration {
       ObjectMapper objectMapper,
       FiatPermissionEvaluator fiatPermissionEvaluator) {
     return new PubsubEventHandler(registry, objectMapper, fiatPermissionEvaluator);
-  }
-
-  @Bean
-  @ConfigurationProperties(prefix = "quiet-period")
-  public QuietPeriodIndicatorConfigurationProperties quietPeriodIndicatorConfigurationProperties() {
-    return new QuietPeriodIndicatorConfigurationProperties();
   }
 
   @Bean

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/QuietPeriodController.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/QuietPeriodController.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pipelinetriggers;
+
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/quietPeriod")
+@RestController
+public class QuietPeriodController {
+  private QuietPeriodIndicator quietPeriodIndicator;
+
+  @Autowired
+  public QuietPeriodController(QuietPeriodIndicator quietPeriodIndicator) {
+    this.quietPeriodIndicator = quietPeriodIndicator;
+  }
+
+  @GetMapping
+  QuietPeriodStatus getQuietPeriodStatus() {
+    QuietPeriodStatus qps = new QuietPeriodStatus();
+
+    qps.isEnabled = quietPeriodIndicator.isEnabled();
+    qps.isInQuietPeriod = quietPeriodIndicator.inQuietPeriod(System.currentTimeMillis());
+    qps.startTime = quietPeriodIndicator.getStartTime();
+    qps.endTime = quietPeriodIndicator.getEndTime();
+
+    return qps;
+  }
+
+  @Data
+  private static class QuietPeriodStatus {
+    private boolean isEnabled;
+    private boolean isInQuietPeriod;
+    private long startTime;
+    private long endTime;
+  }
+}


### PR DESCRIPTION
This change allows setting of the quiet period via spring config or a dynamic config service (without redeploy of the service).
The properties are:

- `quiet-period.start-iso`: start time
- `quiet-period.end-iso`: end time
- `quiet-period.enabled`: global enable/disable flag

Can be set in yml, like so:

```yaml
quietPeriod:
  enabled: true
  startIso: 2020-01-01T21:00:00Z
  endTime: 2020-01-02T21:00:00Z
  suppressedTriggerTypes:
    - cron
    - docker
    - git
    - jenkins
```

note that `suppressedTriggerTypes` can't be set via a dynamic property. Not sure if there is a need for this, so leaving it out for now for simplicity.

This change also adds:
* more verbose logging as to why a pipeline is or is not triggered during the quiet period
* a `GET: /quietPeriod` endpoint that returns the current quiet period status for `deck` (`gate` PR forthcoming)
