### PR TITLE
fix(notifications): Fix selection of interactive vs. non-interactive handler

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/controller/NotificationController.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/controller/NotificationController.groovy
@@ -53,7 +53,9 @@ class NotificationController {
   EchoResponse create(@RequestBody Notification notification) {
     notificationServices?.find {
       it.supportsType(notification.notificationType) &&
-        (!notification.isInteractive() || it instanceof InteractiveNotificationService)
+        // Only delegate interactive notifications to interactive notification services, and vice-versa.
+        // This allows us to support two implementations in parallel for the same notification type.
+        ((it instanceof InteractiveNotificationService) ? notification.isInteractive() : !notification.isInteractive())
     }?.handle(notification)
   }
 


### PR DESCRIPTION
Fixes a bug in the logical condition to select the correct notification service based on whether the notification is interactive or not and the service supports it.