### PR TITLE
chore(dependencies): update korkVersion

### DIFF
--- a/echo-pubsub-aws/echo-pubsub-aws.gradle
+++ b/echo-pubsub-aws/echo-pubsub-aws.gradle
@@ -22,6 +22,7 @@ dependencies {
   implementation "com.amazonaws:aws-java-sdk-sqs"
   implementation "com.netflix.spinnaker.kork:kork-core"
   implementation "com.netflix.spinnaker.kork:kork-aws"
+  implementation "com.netflix.spinnaker.kork:kork-pubsub-aws"
   implementation "com.netflix.spectator:spectator-api"
   implementation "javax.validation:validation-api"
 }

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
@@ -32,7 +32,7 @@ import com.netflix.spinnaker.echo.pubsub.PubsubMessageHandler;
 import com.netflix.spinnaker.echo.pubsub.model.PubsubSubscriber;
 import com.netflix.spinnaker.echo.pubsub.utils.NodeIdentity;
 import com.netflix.spinnaker.kork.aws.ARN;
-import com.netflix.spinnaker.kork.aws.pubsub.PubSubUtils;
+import com.netflix.spinnaker.kork.pubsub.aws.PubSubUtils;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@
 fiatVersion=1.14.0
 enablePublishing=false
 spinnakerGradleVersion=7.0.1
-korkVersion=7.18.1
+korkVersion=7.23.0
 org.gradle.parallel=true


### PR DESCRIPTION
This is for consistency with the other spin services. Mainly so that plugins can be written the same way across services. It would be nice to keep kork versions consistent for a release.
