### PR TITLE
Parameters in cron triggers

### DIFF
--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/discovery/DiscoveryActivated.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/discovery/DiscoveryActivated.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
 
 /**
- * A component that starts doing something when the instance is up in discovery and stops doing that
+ * A component that starts doing something when the instance is up in Eureka and stops doing that
  * thing when it goes down.
  */
 public interface DiscoveryActivated extends ApplicationListener<RemoteStatusChangedEvent> {

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriberProvider.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriberProvider.java
@@ -21,6 +21,7 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.echo.artifacts.MessageArtifactTranslator;
 import com.netflix.spinnaker.echo.config.AmazonPubsubProperties;
@@ -78,9 +79,8 @@ public class SQSSubscriberProvider implements DiscoveryActivated {
 
   @PostConstruct
   public void start() {
-    if (properties == null) {
-      return;
-    }
+    Preconditions.checkNotNull(
+        properties, "Can't initialize SQSSubscriberProvider with null properties");
 
     ExecutorService executorService =
         Executors.newFixedThreadPool(properties.getSubscriptions().size());

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubPublisher.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubPublisher.java
@@ -84,7 +84,7 @@ public class GooglePubsubPublisher implements PubsubPublisher {
               .build();
       publisher.setPublisher(p);
     } catch (IOException ioe) {
-      log.error("Could not create Google Pubsub Publishers: {}", ioe);
+      log.error("Could not create Google Pubsub Publishers", ioe);
     }
 
     return publisher;
@@ -95,7 +95,7 @@ public class GooglePubsubPublisher implements PubsubPublisher {
     try {
       jsonPayload = mapper.writeValueAsString(event);
     } catch (JsonProcessingException jpe) {
-      log.error("Could not serialize event message: {}", jpe);
+      log.error("Could not serialize event message", jpe);
       return;
     }
 
@@ -146,7 +146,7 @@ public class GooglePubsubPublisher implements PubsubPublisher {
     try {
       jsonPayload = mapper.writeValueAsString(payload);
     } catch (JsonProcessingException jpe) {
-      log.error("Could not serialize event message: {}", jpe);
+      log.error("Could not serialize event message", jpe);
       return;
     }
     publish(jsonPayload, attributes);


### PR DESCRIPTION
Triggers support a parameters map, but for cron triggers it gets lost along the way and never makes it to orca, meaning that only default parameter values can be used for cron triggers.

To work around this, users have been duplicating pipelines with different default values and different triggers. This does not scale for obvious reasons and is just generally cumbersome.