### PR TITLE
chore(stats): Rename Spring config props from telemetry to stats

### DIFF
--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/config/TelemetryConfig.java
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/config/TelemetryConfig.java
@@ -36,7 +36,7 @@ import retrofit.converter.JacksonConverter;
 
 @Slf4j
 @Configuration
-@ConditionalOnProperty("telemetry.enabled")
+@ConditionalOnProperty("stats.enabled")
 @EnableConfigurationProperties(TelemetryConfig.TelemetryConfigProps.class)
 public class TelemetryConfig {
 
@@ -67,7 +67,7 @@ public class TelemetryConfig {
   }
 
   @Data
-  @ConfigurationProperties(prefix = "telemetry")
+  @ConfigurationProperties(prefix = "stats")
   public static class TelemetryConfigProps {
 
     public static final String DEFAULT_TELEMETRY_ENDPOINT = "https://stats.spinnaker.io/log";

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryEventListener.java
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryEventListener.java
@@ -55,7 +55,7 @@ import retrofit.mime.TypedString;
 
 @Slf4j
 @Component
-@ConditionalOnProperty("telemetry.enabled")
+@ConditionalOnProperty("stats.enabled")
 public class TelemetryEventListener implements EventListener {
 
   protected static final String TELEMETRY_REGISTRY_NAME = "telemetry";


### PR DESCRIPTION
This is the core of this request in https://github.com/spinnaker/halyard/pull/1565#discussion_r390586727

The rest of the change involves renaming the whole module and a whole lot of `s/telemetry/stats/g` changes - I'd like to confirm that this minimal, understandable change actually works as expected and then we can rename the module in a separate cleanup PR. 