### PR TITLE
chore(vulnerabilities): bump jsoup version resolve CVE-2015-6748

### DIFF
--- a/echo-notifications/echo-notifications.gradle
+++ b/echo-notifications/echo-notifications.gradle
@@ -32,7 +32,7 @@ dependencies {
   implementation "javax.mail:mail:1.4.1"
   implementation "org.springframework.boot:spring-boot-starter-mail"
   implementation "org.springframework.boot:spring-boot-starter-freemarker"
-  implementation "org.jsoup:jsoup:1.8.2"
+  implementation "org.jsoup:jsoup:1.8.3"
   implementation "com.atlassian.commonmark:commonmark:0.9.0"
   testImplementation "com.icegreen:greenmail:1.4.0"
   testImplementation "org.apache.httpcomponents:httpclient"


### PR DESCRIPTION
Upgrade org.jsoup version.
Fix [CVE-2015-6748](https://nvd.nist.gov/vuln/detail/CVE-2015-6748) caused by org.jsoup.