### PR TITLE
fix(front50): Add SpinnakerRequestInterceptor to Front50 OkHttpClient

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/IgorConfig.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/IgorConfig.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.config;
 
 import com.jakewharton.retrofit.Ok3Client;
 import com.netflix.spinnaker.echo.services.IgorService;
+import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,7 +27,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import retrofit.Endpoint;
 import retrofit.Endpoints;
-import retrofit.RequestInterceptor;
 import retrofit.RestAdapter.Builder;
 import retrofit.RestAdapter.LogLevel;
 import retrofit.converter.JacksonConverter;
@@ -45,7 +45,7 @@ public class IgorConfig {
       Endpoint igorEndpoint,
       Ok3Client ok3Client,
       LogLevel retrofitLogLevel,
-      RequestInterceptor spinnakerRequestInterceptor) {
+      SpinnakerRequestInterceptor spinnakerRequestInterceptor) {
     log.info("igor service loaded");
     return new Builder()
         .setEndpoint(igorEndpoint)

--- a/echo-web/src/main/java/com/netflix/spinnaker/echo/config/Front50Config.java
+++ b/echo-web/src/main/java/com/netflix/spinnaker/echo/config/Front50Config.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.config;
 
 import com.netflix.spinnaker.config.OkHttpClientConfiguration;
 import com.netflix.spinnaker.echo.services.Front50Service;
+import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import com.squareup.okhttp.ConnectionPool;
 import com.squareup.okhttp.OkHttpClient;
@@ -64,13 +65,17 @@ public class Front50Config {
 
   @Bean
   public Front50Service front50Service(
-      Endpoint front50Endpoint, OkHttpClient okHttpClient, LogLevel retrofitLogLevel) {
+      Endpoint front50Endpoint,
+      OkHttpClient okHttpClient,
+      LogLevel retrofitLogLevel,
+      SpinnakerRequestInterceptor spinnakerRequestInterceptor) {
     log.info("front50 service loaded");
 
     return new Builder()
         .setEndpoint(front50Endpoint)
         .setConverter(new JacksonConverter())
         .setClient(new OkClient(okHttpClient))
+        .setRequestInterceptor(spinnakerRequestInterceptor)
         .setLogLevel(retrofitLogLevel)
         .setLog(new Slf4jRetrofitLogger(Front50Service.class))
         .build()


### PR DESCRIPTION
This fixes [spinnaker/issues/5035](https://github.com/spinnaker/spinnaker/issues/5035) and [spinnaker/issues/4941](https://github.com/spinnaker/spinnaker/issues/4941)

This fix adds SpinnakerRequestInterceptor to Front50 OkHttpClient in Echo. 

Currently, Front50 OkHttpClient in Echo does not propagate the AuthenticationRequest [Headers](https://github.com/spinnaker/kork/blob/v7.5.1/kork-security/src/main/java/com/netflix/spinnaker/security/AuthenticatedRequest.java#L39) to Front50 on Http calls. Reason for this behaviour is due to Front50 Client created without SpinnakerRequestInterceptor. This interceptor ensures Headers are propagated as part of request headers on Http calls.

This has caused Echo not able to get the latest pipeline configuration from Front50 and rely on Pipeline configuration cache.
- Before spinnaker version 1.18, Echo used to call Front50 '[GetHistory](https://github.com/spinnaker/front50/blob/version-0.21.0/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy#L98)' endpoint to get pipeline configuration and was returned empty object due to @PostFilter annotation. This forces Echo to pick up configuration from Pipeline cache. 
- With version 1.18, Echo calls Front50 '[GetPipeline](https://github.com/spinnaker/front50/blob/version-0.21.0/front50-web/src/main/groovy/com/netflix/spinnaker/front50/controllers/PipelineController.groovy#L105)' endpoint will return 403 due to @PostAuthorize which results in again picking up configuration from Pipeline cache.

Note: SpinnakerRequestInterceptor is already set in Igor [OkHttpClient](https://github.com/spinnaker/echo/blob/version-2.10.1/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/IgorConfig.java#L54) configuration in Echo, so Auth headers are propagated on http calls to Igor.

Edit: As per @plumpy feedback, changing the Igor OkHttpClient configuration to use `SpinnakerRequestInterceptor`