### PR TITLE
chore(java11): Compile with Java 11 (but targeting Java 8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # Install Java 8 for cross-compilation support. Setting it up before
+      # Java 11 means it comes later in $PATH (because of how setup-java works)
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - uses: actions/cache@v1
         with:
           path: ~/.gradle
@@ -25,4 +30,4 @@ jobs:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-        run: ./gradlew -PenablePublishing=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" build snapshot --stacktrace
+        run: ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" build snapshot --stacktrace

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,9 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    # Install Java 8 for cross-compilation support. Setting it up before
+    # Java 11 means it comes later in $PATH (because of how setup-java works)
     - uses: actions/setup-java@v1
       with:
         java-version: 8
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
     - uses: actions/cache@v1
       with:
         path: ~/.gradle
@@ -19,4 +24,4 @@ jobs:
     - name: Build
       env:
         GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-      run: ./gradlew build javadoc
+      run: ./gradlew -PenableCrossCompilerPlugin=true build javadoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
+      # Install Java 8 for cross-compilation support. Setting it up before
+      # Java 11 means it comes later in $PATH (because of how setup-java works)
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - uses: actions/cache@v1
         with:
           path: ~/.gradle
@@ -37,7 +42,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
         run: |
-          ./gradlew -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" candidate
+          ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" candidate
       - name: Release build
         if: steps.release_info.outputs.IS_CANDIDATE == 'false'
         env:
@@ -45,7 +50,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
         run: |
-          ./gradlew -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" final
+          ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" final
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,5 +1,10 @@
-FROM openjdk:8
+FROM alpine:3.11
+RUN apk add --update \
+    openjdk11 \
+    openjdk8 \
+    && rm -rf /var/cache/apk
 MAINTAINER sig-platform@spinnaker.io
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
 ENV GRADLE_USER_HOME /workspace/.gradle
-ENV GRADLE_OPTS -Xmx2048m
-CMD ./gradlew --no-daemon echo-web:installDist -x test
+ENV GRADLE_OPTS -Xmx4g
+CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true echo-web:installDist -x test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #Thu Mar 26 04:18:39 UTC 2020
 fiatVersion=1.17.7
 enablePublishing=false
-spinnakerGradleVersion=7.0.1
+spinnakerGradleVersion=7.8.0
 korkVersion=7.29.5
 org.gradle.parallel=true


### PR DESCRIPTION
We don't actually need `-PenableCrossCompilerPlugin=true` in `build.yml` or `release.yml` (it's turned on already by the Nebula plugin since we're making a candidate build) but I thought it was worth adding for clarity.

For the GitHub workflows, I didn't know a great way to test it, so I first read setup-java to determine how the `$PATH` manipulation works, then I tested it with `pr.yml` by:
1. Pushing some code to this PR that uses a Java 11 API (`Optional#stream()`) and seeing the build fail (proving we're compiling against the Java 8 APIs)
2. Changing it to `-PenableCrossCompilerPlugin=false` and watching the build succeed (proving we're using the Java 11 `javac`)