### PR TITLE
refactor(triggers): make BaseTriggerEventHandler's constructor public

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BaseTriggerEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BaseTriggerEventHandler.java
@@ -52,7 +52,7 @@ public abstract class BaseTriggerEventHandler<T extends TriggerEvent>
   private final FiatPermissionEvaluator fiatPermissionEvaluator;
   protected final ObjectMapper objectMapper;
 
-  BaseTriggerEventHandler(
+  public BaseTriggerEventHandler(
       Registry registry,
       ObjectMapper objectMapper,
       FiatPermissionEvaluator fiatPermissionEvaluator) {


### PR DESCRIPTION
Make BaseTriggerEventHandler's constructor public so we can extend the
class outside of the package. This makes it easier for the community to
add in customized trigger event handle.

<!-- Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days. -->

@ezimanyi 
