### PR TITLE
feat(triggers): add execution status as part of orca service pipeline response

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaExecutionStatus.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaExecutionStatus.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-public enum OrcaTaskExecutionStatus {
+public enum OrcaExecutionStatus {
   /** The task has yet to start. */
   NOT_STARTED(false, false),
 
@@ -70,18 +70,18 @@ public enum OrcaTaskExecutionStatus {
     return halt;
   }
 
-  public static final Collection<OrcaTaskExecutionStatus> COMPLETED =
+  public static final Collection<OrcaExecutionStatus> COMPLETED =
       Collections.unmodifiableList(
           Arrays.asList(CANCELED, SUCCEEDED, STOPPED, SKIPPED, TERMINAL, FAILED_CONTINUE));
 
-  private static final Collection<OrcaTaskExecutionStatus> SUCCESSFUL =
+  private static final Collection<OrcaExecutionStatus> SUCCESSFUL =
       Collections.unmodifiableList(Arrays.asList(SUCCEEDED, STOPPED, SKIPPED));
-  private static final Collection<OrcaTaskExecutionStatus> FAILURE =
+  private static final Collection<OrcaExecutionStatus> FAILURE =
       Collections.unmodifiableList(Arrays.asList(TERMINAL, STOPPED, FAILED_CONTINUE));
   private final boolean complete;
   private final boolean halt;
 
-  OrcaTaskExecutionStatus(boolean complete, boolean halt) {
+  OrcaExecutionStatus(boolean complete, boolean halt) {
     this.complete = complete;
     this.halt = halt;
   }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaService.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaService.java
@@ -21,6 +21,8 @@ import com.netflix.spinnaker.echo.model.Pipeline;
 import com.netflix.spinnaker.kork.common.Header;
 import java.util.Collection;
 import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import retrofit.client.Response;
 import retrofit.http.Body;
 import retrofit.http.GET;
@@ -67,26 +69,13 @@ public interface OrcaService {
     }
   }
 
+  @Getter
+  @NoArgsConstructor
   @JsonIgnoreProperties(ignoreUnknown = true)
   class PipelineResponse {
     private String id;
     private String pipelineConfigId;
     private Long startTime;
-
-    public PipelineResponse() {
-      // do nothing
-    }
-
-    public String getId() {
-      return id;
-    }
-
-    public String getPipelineConfigId() {
-      return pipelineConfigId;
-    }
-
-    public Long getStartTime() {
-      return startTime;
-    }
+    private OrcaTaskExecutionStatus status;
   }
 }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaService.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaService.java
@@ -76,6 +76,6 @@ public interface OrcaService {
     private String id;
     private String pipelineConfigId;
     private Long startTime;
-    private OrcaTaskExecutionStatus status;
+    private OrcaExecutionStatus status;
   }
 }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaTaskExecutionStatus.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaTaskExecutionStatus.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pipelinetriggers.orca;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+public enum OrcaTaskExecutionStatus {
+  /** The task has yet to start. */
+  NOT_STARTED(false, false),
+
+  /** The task is still running and the {@code Task} may be re-executed in order to continue. */
+  RUNNING(false, false),
+
+  /** The task is still running and the {@code Task} may be resumed in order to continue. */
+  PAUSED(false, false),
+
+  /** The task is complete but the pipeline should now be stopped pending a trigger of some kind. */
+  SUSPENDED(false, false),
+
+  /** The task executed successfully and the pipeline may now proceed to the next task. */
+  SUCCEEDED(true, false),
+
+  /** The task execution failed, but the pipeline may proceed to the next task. */
+  FAILED_CONTINUE(true, false),
+
+  /** The task failed and the failure was terminal. The pipeline will not progress any further. */
+  TERMINAL(true, true),
+
+  /** The task was canceled. The pipeline will not progress any further. */
+  CANCELED(true, true),
+
+  /**
+   * The step completed but is indicating that a decision path should be followed, not the default
+   * path.
+   */
+  REDIRECT(false, false),
+
+  /** The task was stopped. The pipeline will not progress any further. */
+  STOPPED(true, true),
+
+  /** The task was skipped and the pipeline will proceed to the next task. */
+  SKIPPED(true, false),
+
+  /** The task is not started and must be transitioned to NOT_STARTED. */
+  BUFFERED(false, false);
+
+  /** Indicates that the task/stage/pipeline has finished its work (successfully or not). */
+  public final boolean isComplete() {
+    return complete;
+  }
+
+  /** Indicates an abnormal completion so nothing downstream should run afterward. */
+  public final boolean isHalt() {
+    return halt;
+  }
+
+  public static final Collection<OrcaTaskExecutionStatus> COMPLETED =
+      Collections.unmodifiableList(
+          Arrays.asList(CANCELED, SUCCEEDED, STOPPED, SKIPPED, TERMINAL, FAILED_CONTINUE));
+
+  private static final Collection<OrcaTaskExecutionStatus> SUCCESSFUL =
+      Collections.unmodifiableList(Arrays.asList(SUCCEEDED, STOPPED, SKIPPED));
+  private static final Collection<OrcaTaskExecutionStatus> FAILURE =
+      Collections.unmodifiableList(Arrays.asList(TERMINAL, STOPPED, FAILED_CONTINUE));
+  private final boolean complete;
+  private final boolean halt;
+
+  OrcaTaskExecutionStatus(boolean complete, boolean halt) {
+    this.complete = complete;
+    this.halt = halt;
+  }
+
+  public boolean isSuccessful() {
+    return SUCCESSFUL.contains(this);
+  }
+
+  public boolean isFailure() {
+    return FAILURE.contains(this);
+  }
+}


### PR DESCRIPTION
Add execution status as part of orca service pipeline response. 

Here is the response in Orca: https://github.com/spinnaker/orca/blob/94423342e309ed3c545c9b312fd0d7597f8bbf76/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/PipelineExecution.java#L89

Here is the ExecutionStatus in Orca:
https://github.com/spinnaker/orca/blob/94423342e309ed3c545c9b312fd0d7597f8bbf76/orca-api/src/main/java/com/netflix/spinnaker/orca/api/pipeline/models/ExecutionStatus.java

The execution status of a pipeline can be used by event handlers to determine what to do.

@robzienert 