### PR TITLE
fix(hooks): Fix github webhooks with secrets

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandler.java
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class GitEventHandler extends BaseTriggerEventHandler<GitEvent> {
   private static final String GIT_TRIGGER_TYPE = "git";
-  private static final String GITHUB_SECURE_SIGNATURE_HEADER = "X-Hub-Signature";
+  private static final String GITHUB_SECURE_SIGNATURE_HEADER = "x-hub-signature";
   private static final List<String> supportedTriggerTypes =
       Collections.singletonList(GIT_TRIGGER_TYPE);
 

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandlerSpec.groovy
@@ -286,7 +286,7 @@ class GitEventHandlerSpec extends Specification implements RetrofitStubs {
     gitEvent.rawContent = "toBeHashed"
     gitEvent.details.source = "github"
     if (signature) {
-      gitEvent.details.requestHeaders.put("X-Hub-Signature", ["sha1=" + signature])
+      gitEvent.details.requestHeaders.put("x-hub-signature", ["sha1=" + signature])
     }
 
     def trigger = enabledGithubTrigger.atSecret(secret).atBranch("master")


### PR DESCRIPTION
**Issue:**
The pipelines are no longer being triggered by Github webhooks if there is a secret required. Removing the secret allows them to function normally.

This issue was reported [here](https://github.com/spinnaker/spinnaker/issues/5645).

**Problem:**
The headings are all lowercase, so they are now not found.
This previously worked because the **org.springframework.http.HttpHeaders** class was used but was replaced by **java.util.Map**, which is case sensitive. That change was made [here](https://github.com/spinnaker/echo/commit/784909eaffd14dcf9bdd358e3792cc3160328d4d#diff-1558ece8b8cf054fbba6806681248cc1R39).

![image](https://user-images.githubusercontent.com/53754439/78661779-a3ce6f80-78cf-11ea-8954-de093eab22f0.png)
