### PR TITLE
feat(notifications): Allow notifications on synthetic stage

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgent.groovy
@@ -110,8 +110,7 @@ abstract class AbstractEventNotificationAgent implements EventListener {
 
     // stage level configurations
     if (config.type == 'stage') {
-      boolean isSynthetic = event.content?.isSynthetic?: event.content?.context?.stageDetails?.isSynthetic
-      if (event.content?.context?.sendNotifications && ( !isSynthetic ) ) {
+      if (event.content?.context?.sendNotifications) {
         event.content?.context?.notifications?.each { notification ->
           String key = getNotificationType()
           if (notification.type == key && notification?.when?.contains("${config.type}.$status".toString())) {

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgentSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgentSpec.groovy
@@ -89,7 +89,7 @@ class AbstractEventNotificationAgentSpec extends Specification {
     // notifications ON, stage cancelled
     fakeStageEvent("orca:stage:failed", "stage.failed", true)                                 || 0
     // notifications ON, stage is synthetic
-    fakeStageEvent("orca:stage:complete", "stage.complete", false, true)                      || 0
+    fakeStageEvent("orca:stage:complete", "stage.complete", false, true)                      || 1
   }
 
   private def fakePipelineEvent(String type, String status, String notifyWhen, Map extraExecutionProps = [:]) {


### PR DESCRIPTION
Currently notification is not supported on synthetic stages and it makes synthetic stage less flexible.

Ideally synthetic stage should be treated equally as a normal stage and be able to send notifications if needed.

This PR is to support notifications on synthetic stages.