### PR TITLE
fix(headers): Metadata requestHeaders lookup should be case insensitive

### DIFF
--- a/echo-api/echo-api.gradle
+++ b/echo-api/echo-api.gradle
@@ -5,9 +5,19 @@
  * avoid dependency conflicts we should bring the bare minimum of transitive
  * dependencies along for the ride -- ideally nothing besides kork-plugins-api.
  */
+apply from: "${project.rootDir}/gradle/kotlin.gradle"
+
 dependencies {
   api "com.netflix.spinnaker.kork:kork-plugins-api"
 
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")
+
+  testImplementation("io.strikt:strikt-core")
+  testImplementation("dev.minutest:minutest")
+  testImplementation("io.mockk:mockk")
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/echo-api/src/main/java/com/netflix/spinnaker/echo/api/events/Metadata.java
+++ b/echo-api/src/main/java/com/netflix/spinnaker/echo/api/events/Metadata.java
@@ -17,9 +17,9 @@
 package com.netflix.spinnaker.echo.api.events;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -37,5 +37,6 @@ public class Metadata {
   private String application;
   private String _content_id;
   private Map<String, String> attributes;
-  private Map<String, List<String>> requestHeaders = new HashMap<>();
+  private TreeMap<String, List<String>> requestHeaders =
+      new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 }

--- a/echo-api/src/test/kotlin/com/netflix/spinnaker/echo/api/events/MetadataTest.kt
+++ b/echo-api/src/test/kotlin/com/netflix/spinnaker/echo/api/events/MetadataTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.api.events
+
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expect
+import strikt.assertions.isEqualTo
+
+class MetadataTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    context("Metadata") {
+      fixture {
+        Fixture()
+      }
+
+      test("Request header case insensitive") {
+        val upperCaseHeader = "UPPERCASE-HEADER"
+        val lowerCaseHeader = "lowercase-header"
+        metadata.requestHeaders[upperCaseHeader] = mutableListOf("foo")
+        metadata.requestHeaders[lowerCaseHeader] = mutableListOf("bar")
+
+        expect {
+          that(metadata.requestHeaders[upperCaseHeader.toLowerCase()]?.get(0)).isEqualTo("foo")
+          that(metadata.requestHeaders[lowerCaseHeader.toUpperCase()]?.get(0)).isEqualTo("bar")
+        }
+      }
+    }
+  }
+
+  private class Fixture {
+    var metadata = Metadata()
+  }
+}


### PR DESCRIPTION
In https://github.com/spinnaker/echo/pull/790 I removed `HttpHeaders` so that `echo-api` could be dependency free (basically, just Java) -- this is important for the ongoing extensibility / plugin work we are doing.

However, I overlooked that `HttpHeaders` builds a case insensitive map.  This resolves that issue.

Resolves: https://github.com/spinnaker/spinnaker/issues/5645
Relates to: https://github.com/spinnaker/echo/pull/840