### PR TITLE
fix(builds): Add JDK_18 env var for failing Docker nightly builds

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -5,6 +5,7 @@ RUN apk add --update \
     && rm -rf /var/cache/apk
 MAINTAINER sig-platform@spinnaker.io
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
+ENV JDK_18 /usr/lib/jvm/java-1.8-openjdk
 ENV GRADLE_USER_HOME /workspace/.gradle
 ENV GRADLE_OPTS -Xmx4g
 CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true echo-web:installDist -x test


### PR DESCRIPTION
This failed last night and failed for me locally: https://console.cloud.google.com/cloud-build/builds/0edd57a0-c6cb-4227-8754-fff7bcab134d;tab=detail?organizationId=433637338589&project=spinnaker-community

Copied this from https://github.com/spinnaker/clouddriver/blob/master/Dockerfile.compile#L8 (but path is changed for alpine)