### PR TITLE
fix: enable use of pipeline parameter in the email address field (#5697)

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgent.groovy
@@ -81,9 +81,20 @@ class EmailNotificationAgent extends AbstractEventNotificationAgent {
 
     String link = "${spinnakerUrl}/#/applications/${application}/${config.type == 'stage' ? 'executions/details' : config.link }/${event.content?.execution?.id}"
 
+    def engine = new groovy.text.SimpleTemplateEngine()
+    event.content.parameters = event.content?.execution?.trigger?.parameters
+
+    def expandEmail = { address ->
+       if (address != null && address != "") {
+          return [ engine.createTemplate(address as String).make(event.content) ] as String[]
+       }
+
+       return null
+    }
+
     sendMessage(
-      preference.address ? [preference.address] as String[] : null,
-      preference.cc ? [preference.cc] as String[] : null,
+      expandEmail(preference.address),
+      expandEmail(preference.cc),
       event,
       subject,
       config.type,


### PR DESCRIPTION
The change enables use of pipeline parameters in address/cc fields of email notifications - can be either:
 "notifications": [
    {
      "address": "${parameters.Email}",
      "level": "stage",
      "message": {
...

or a longer form:
 "notifications": [
    {
      "address": "${execution.trigger.parameters.Email}",
      "level": "stage",
      "message": {
...