### PR TITLE
feat(config): add worker and scheduler profiles

### DIFF
--- a/echo-web/config/echo.yml
+++ b/echo-web/config/echo.yml
@@ -32,8 +32,6 @@ webhooks:
 
 scheduler:
   enabled: ${services.echo.cron.enabled:true}
-  cron:
-    timezone: ${global.spinnaker.timezone:America/Los_Angeles}
 
 redis:
   connection: ${services.redis.baseUrl:redis://localhost:6379}

--- a/echo-web/config/echo.yml
+++ b/echo-web/config/echo.yml
@@ -32,6 +32,8 @@ webhooks:
 
 scheduler:
   enabled: ${services.echo.cron.enabled:true}
+  cron:
+    timezone: ${global.spinnaker.timezone:America/Los_Angeles}
 
 redis:
   connection: ${services.redis.baseUrl:redis://localhost:6379}

--- a/echo-web/config/echo.yml
+++ b/echo-web/config/echo.yml
@@ -50,3 +50,21 @@ resilience4j.circuitbreaker:
       waitDurationInOpenState: 12h
       # Try to get back to a working state...
       permittedNumberOfCallsInHalfOpenState: 1
+
+---
+# This profile is used in sharded deployments for an Echo that handles only
+# scheduled tasks.
+spring:
+  profiles: scheduler
+
+scheduler:
+  enabled: true
+
+---
+# This profile is used in sharded deployments for an Echo that handles all
+# operations other than scheduled tasks.
+spring:
+  profiles: worker
+
+scheduler:
+  enabled: false

--- a/halconfig/echo-scheduler.yml
+++ b/halconfig/echo-scheduler.yml
@@ -6,9 +6,6 @@ server:
 
 scheduler:
   enabled: true
-  threadPoolSize: 20
-  cron:
-    timezone: ${global.spinnaker.timezone:America/Los_Angeles}
 
 redis:
   connection: ${services.redis.baseUrl:redis://localhost:6379}


### PR DESCRIPTION
* fix(config): remove unnecessary config properties 

  Timezone is already defaulted in the base config, and thread pool size is never read.

* feat(config): add worker and scheduler profiles 

  Add profiles for sharded Echo, which will be referenced in the base Kustomization available as part of the Kleat deployment workflow.
