### PR TITLE
fix(echo): Add default twilio API endpoint

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/pubsub/MessageDescription.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/pubsub/MessageDescription.java
@@ -45,7 +45,7 @@ public class MessageDescription {
 
   private PubsubSystem pubsubSystem;
 
-  private Integer ackDeadlineSeconds;
+  private int ackDeadlineSeconds;
 
   private Integer retentionDeadlineSeconds;
 

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/TwilioConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/TwilioConfig.groovy
@@ -43,7 +43,7 @@ import retrofit.converter.JacksonConverter
 class TwilioConfig {
 
     @Bean
-    Endpoint twilioEndpoint(@Value('${twilio.base-url}') String twilioBaseUrl) {
+    Endpoint twilioEndpoint(@Value('${twilio.base-url:https://api.twilio.com/}') String twilioBaseUrl) {
         newFixedEndpoint(twilioBaseUrl)
     }
 

--- a/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandler.java
+++ b/echo-pubsub-core/src/main/java/com/netflix/spinnaker/echo/pubsub/PubsubMessageHandler.java
@@ -112,7 +112,7 @@ public class PubsubMessageHandler {
 
   private boolean tryAck(
       String messageKey,
-      Integer ackDeadlineSeconds,
+      int ackDeadlineSeconds,
       MessageAcknowledger acknowledger,
       String identifier) {
     if (!acquireMessageLock(messageKey, identifier, ackDeadlineSeconds)) {
@@ -124,8 +124,7 @@ public class PubsubMessageHandler {
     }
   }
 
-  private Boolean acquireMessageLock(
-      String messageKey, String identifier, Integer ackDeadlineSeconds) {
+  private boolean acquireMessageLock(String messageKey, String identifier, int ackDeadlineSeconds) {
     String response =
         redisClientDelegate.withCommandsClient(
             c -> {

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/config/GooglePubsubProperties.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/config/GooglePubsubProperties.java
@@ -25,7 +25,6 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -55,7 +54,7 @@ public class GooglePubsubProperties {
 
     @NotEmpty private String subscriptionName;
 
-    @NotNull @Builder.Default private Integer ackDeadlineSeconds = 10;
+    @Builder.Default private int ackDeadlineSeconds = 10;
 
     // Not required since subscriptions can be public.
     private String jsonPath;

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubSubscriber.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GooglePubsubSubscriber.java
@@ -149,7 +149,7 @@ public class GooglePubsubSubscriber implements PubsubSubscriber {
 
   private static class GooglePubsubMessageReceiver implements MessageReceiver {
 
-    private Integer ackDeadlineSeconds;
+    private int ackDeadlineSeconds;
 
     private PubsubMessageHandler pubsubMessageHandler;
 
@@ -161,7 +161,7 @@ public class GooglePubsubSubscriber implements PubsubSubscriber {
     private NodeIdentity identity = new NodeIdentity();
 
     public GooglePubsubMessageReceiver(
-        Integer ackDeadlineSeconds,
+        int ackDeadlineSeconds,
         String subscriptionName,
         PubsubMessageHandler pubsubMessageHandler) {
       this.ackDeadlineSeconds = ackDeadlineSeconds;
@@ -173,7 +173,7 @@ public class GooglePubsubSubscriber implements PubsubSubscriber {
     public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
       String messagePayload = message.getData().toStringUtf8();
       String messageId = message.getMessageId();
-      Map messageAttributes =
+      Map<String, String> messageAttributes =
           message.getAttributesMap() == null ? new HashMap<>() : message.getAttributesMap();
       log.debug(
           "Received Google pub/sub message with payload: {}\n and attributes: {}",


### PR DESCRIPTION
* fix(echo): Add default twilio API endpoint

  Currently halyard is explicitly setting this default; instead of having kleat need to know about this, just have it defaulted in echo if kleat doesn't pass anything along. (This won't break any existing config as Halyard is always passing this, so we'll never fall to the default, and if anyone is overriding it that will still be respected.)

* refactor(pubsub): Minor pubsub code cleanup

  While reading through this code to document the config for kleat, I made a few changes to improve it:
  * As I traced everywhere we pass ackDeadlineSeconds, I changed it from a NonNull Integer to an int
  * Added an explicit type on a map to fix a compiler warning