### PR TITLE
fix(headers): Lowercase X-Hub-Signature for a successful lookup

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/GitEventHandler.java
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class GitEventHandler extends BaseTriggerEventHandler<GitEvent> {
   private static final String GIT_TRIGGER_TYPE = "git";
-  private static final String GITHUB_SECURE_SIGNATURE_HEADER = "X-Hub-Signature";
+  private static final String GITHUB_SECURE_SIGNATURE_HEADER = "x-hub-signature";
   private static final List<String> supportedTriggerTypes =
       Collections.singletonList(GIT_TRIGGER_TYPE);
 


### PR DESCRIPTION
As discussed in https://github.com/spinnaker/echo/pull/865 

Lower casing the github webhook secret header key for the lookup solves this specific issue.

For the record, metadata requestHeaders lookup is still case sensitive, and I am not solving that in this PR.
