### PR TITLE
feat(build): adds project properties for composite builds.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,18 @@ korkVersion=7.41.1
 kotlinVersion=1.3.71
 org.gradle.parallel=true
 spinnakerGradleVersion=8.0.6
+
+# To enable a composite reference to a project, set the
+#  project property `'<projectName>Composite=true'`.
+#
+# This can be done either as
+#  * a command line flag, e.g. `-PkorkComposite=true`
+#  * a project property via gradle.properties
+#  * a global project property via ~/.gradle/gradle.properties
+#
+# The composite project must checked out in a sibling directory
+# to this project, matching the name of the project
+# e.g. '../kork'
+#
+#fiatComposite=true
+#korkComposite=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+['fiat', 'kork'].each { prj ->
+  String propName = "${prj}Composite"
+  String projectPath = "../$prj"
+  if (settings.ext.has(propName) && Boolean.parseBoolean(settings.ext.get(propName) as String)) {
+    includeBuild projectPath
+  }
+}
+
 include 'echo-api',
         'echo-artifacts',
         'echo-bom',


### PR DESCRIPTION
This adds flags for the related projects that we bring in
as dependencies, to enable referencing the related project
as a composite build via gradle.

This method of enabling composite builds seems to work
significantly better with IntelliJ. (As opposed to
importing multiple projects into the IDE and configuring
the composite relationship after the fact)

This holds the opinion that all the projects are checked
out in the same parent directory, and can be found at
`'../<projectName>'` relative to this project.

To enable a composite reference to a project, set the
project property `'<projectName>Composite=true'`.

This can be done either as
* a command line flag, e.g. `-PkorkComposite=true`
* a project property via gradle.properties
* a global project property via ~/.gradle/gradle.properties