### PR TITLE
fix(misc): newer version of fiat api client requires url to wire up c…

### DIFF
--- a/echo-plugins-test/src/test/resources/echo-plugins-test.yml
+++ b/echo-plugins-test/src/test/resources/echo-plugins-test.yml
@@ -4,6 +4,10 @@ front50:
 orca:
   baseUrl: 'http://localhost:8083'
 
+services:
+  fiat:
+    baseUrl: http://fiat.net
+
 resilience4j.circuitbreaker:
   instances:
     telemetry:


### PR DESCRIPTION
- Newer version of fiat api client requires url and performs non null check and this change is to satisfy that constraint by supplying the necessary config while building the application contexts in unit tests. There is a failing build of [autobump PR ](https://github.com/spinnaker/echo/pull/899)due to this.