### PR TITLE
fix(test): Fix over-specified test

### DIFF
--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandlerSpec.groovy
@@ -114,7 +114,7 @@ class ManualEventHandlerSpec extends Specification implements RetrofitStubs {
     }
     List<Artifact> resolvedArtifacts = eventHandler.resolveArtifacts(triggerArtifacts)
     Map<String, Object> firstArtifact = objectMapper.convertValue(resolvedArtifacts.first(), Map.class)
-    firstArtifact = firstArtifact.findAll { key, value -> value != null && key != "customKind"}
+    firstArtifact = firstArtifact.findAll { key, value -> value && key != "customKind"}
 
     then:
     resolvedArtifacts.size() == 1


### PR DESCRIPTION
The kork bump changes some non-specified fields in Artifact from null to empty string, which breaks this test. Fix it to not care.