### PR TITLE
Revert "fix: enable use of pipeline parameter in the email address field (#5697)"

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgent.groovy
@@ -81,20 +81,9 @@ class EmailNotificationAgent extends AbstractEventNotificationAgent {
 
     String link = "${spinnakerUrl}/#/applications/${application}/${config.type == 'stage' ? 'executions/details' : config.link }/${event.content?.execution?.id}"
 
-    def engine = new groovy.text.SimpleTemplateEngine()
-    event.content.parameters = event.content?.execution?.trigger?.parameters
-
-    def expandEmail = { address ->
-       if (address != null && address != "") {
-          return [ engine.createTemplate(address as String).make(event.content) ] as String[]
-       }
-
-       return null
-    }
-
     sendMessage(
-      expandEmail(preference.address),
-      expandEmail(preference.cc),
+      preference.address ? [preference.address] as String[] : null,
+      preference.cc ? [preference.cc] as String[] : null,
       event,
       subject,
       config.type,

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgentSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgentSpec.groovy
@@ -163,49 +163,4 @@ class EmailNotificationAgentSpec extends Specification {
                                 name: "foo-stage",
                                 execution: [id: "abc", name: "foo-pipeline"]])
   }
-
-  def "expand email address/cc from parameters"() {
-    given:
-    def email = new BlockingVariables()
-    mailService.send(*_) >> { to, cc, subject, text ->
-      email.to = to
-      email.cc = cc
-      email.subject = subject
-      email.text = text
-    }
-
-    when:
-    agent.sendNotifications(
-      [address: address, cc: cc],
-      application,
-      event,
-      [type: "stage"],
-      status
-    )
-
-    then:
-    email.to == ["fake@email.com"]
-    email.cc == ["fakecc@email.com"]
-
-    and:
-    0 * _
-
-    where:
-    customSubject = "A custom subject"
-    customBody = "A **custom** body"
-    application = "whatever"
-    address = '''${parameters.EmailTo}'''
-    cc = '''${parameters.EmailCc}'''
-    status = "complete"
-    pipelineName = "foo-pipeline"
-    stageName = "foo-stage"
-    trigger = [ parameters: [EmailTo: "fake@email.com",
-						EmailCc: "fakecc@email.com",
-						]]
-
-    event = new Event(content: [context: [customSubject: customSubject,
-                                          customBody: customBody],
-                                name: "foo-stage",
-                                execution: [id: "abc", name: "foo-pipeline", trigger: trigger]])
-  }
 }


### PR DESCRIPTION
Reverts spinnaker/echo#869

This change did not properly address the underlying issue which was in `orca` (https://github.com/spinnaker/orca/pull/3712). Furthermore, this change in `echo` introduced a regression in the `RestListener` which prevented it from actually sending any events if there was an email notification also present on the stage/pipeline