### PR TITLE
feat(rest): add retries to sending rest events

### DIFF
--- a/echo-rest/src/main/java/com/netflix/spinnaker/echo/config/RestProperties.java
+++ b/echo-rest/src/main/java/com/netflix/spinnaker/echo/config/RestProperties.java
@@ -46,5 +46,6 @@ public class RestProperties {
     Map<String, String> headers;
     String headersFile;
     Boolean flatten = false;
+    int retryCount = 1;
   }
 }

--- a/echo-rest/src/main/java/com/netflix/spinnaker/echo/events/RestEventListener.java
+++ b/echo-rest/src/main/java/com/netflix/spinnaker/echo/events/RestEventListener.java
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.echo.api.events.Event;
 import com.netflix.spinnaker.echo.api.events.EventListener;
 import com.netflix.spinnaker.echo.config.RestUrls;
 import com.netflix.spinnaker.echo.jackson.EchoObjectMapper;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -43,6 +45,7 @@ class RestEventListener implements EventListener {
   private RestUrls restUrls;
   private RestEventTemplateEngine restEventTemplateEngine;
   private Registry registry;
+  private RetrySupport retrySupport;
 
   @Value("${rest.default-event-name:spinnaker_events}")
   private String eventName;
@@ -52,10 +55,14 @@ class RestEventListener implements EventListener {
 
   @Autowired
   RestEventListener(
-      RestUrls restUrls, RestEventTemplateEngine restEventTemplateEngine, Registry registry) {
+      RestUrls restUrls,
+      RestEventTemplateEngine restEventTemplateEngine,
+      Registry registry,
+      RetrySupport retrySupport) {
     this.restUrls = restUrls;
     this.restEventTemplateEngine = restEventTemplateEngine;
     this.registry = registry;
+    this.retrySupport = retrySupport;
   }
 
   @Override
@@ -94,7 +101,13 @@ class RestEventListener implements EventListener {
                     eventMap = m;
                   }
                 }
-                service.getClient().recordEvent(eventMap);
+
+                Map<String, Object> finalEventMap = eventMap;
+                retrySupport.retry(
+                    () -> service.getClient().recordEvent(finalEventMap),
+                    service.getConfig().getRetryCount(),
+                    Duration.ofMillis(200),
+                    false);
               } catch (Exception e) {
                 if (event != null
                     && event.getDetails() != null


### PR DESCRIPTION
Add configurable retries (default to non-behavior changing 1) to sending events to a REST listener
