### PR TITLE
feat(triggers): Add ability to suppress triggers at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ See [Sample deployment topology](#sample-deployment-topology) for additional inf
 * `orca.pipelineInitiatorRetryDelayMillis` (default: 5000ms)  
     Number of milliseconds between retries to `orca` (leave at default)
 
+#### Trigger suppression
+There are several ways to suppress triggers in `echo` (note, all of the below are backed by `DynamicConfigService` and therefore can be modified at runtime)
+* `orca.enabled` (default: `true`)  
+    top level knob that disables communication with `orca` and thus ALL triggers
+* `scheduler.suppressTriggers` (default: `false`)  
+    allows suppressing triggering of events from the CRON scheduler only
+* `scheduler.compensationJob.suppressTriggers` (default: `false`)  
+    allows suppressing triggering of events from the compensation job (aka missed CRON scheduler) only
+
+There are two settings for each trigger, e.g. `scheduler.enabled` and `scheduler.suppressTriggers`. 
+The reason for this complexity is to allow scenarios where there are two `echo` clusters that are running the scheduler for redundancy reasons (e.g. in two regions).  
+In order to correctly switch which cluster (region) is generating triggers they both need to be "up-to-speed" hence you'd run the scheduler in both clusters but only one would trigger.
+That way, when you switch which cluster does the triggering it will trigger the correct events without duplicates.
+ 
 ## Missed CRON scheduler
 The missed CRON scheduler is a feature in `echo` that ensures that CRON triggers are firing reliably. It is enabled by setting `scheduler.compensationJob.enabled` configuration option.  
 In an event that a CRON trigger fails to fire or it fires but, for whatever reason, the execution doesn't start the missed CRON scheduler will detect it and attempt to re-trigger the pipeline.  

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/TriggerMonitor.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/monitor/TriggerMonitor.java
@@ -80,7 +80,7 @@ public class TriggerMonitor<T extends TriggerEvent> implements EventListener {
           .forEach(
               p -> {
                 recordMatchingPipeline(p);
-                pipelineInitiator.startPipeline(p, PipelineInitiator.TriggerSource.EVENT);
+                pipelineInitiator.startPipeline(p, PipelineInitiator.TriggerSource.EXTERNAL_EVENT);
               });
 
       matchingPipelines.stream()

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/MissedPipelineTriggerCompensationJob.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/MissedPipelineTriggerCompensationJob.groovy
@@ -207,7 +207,7 @@ class MissedPipelineTriggerCompensationJob implements ApplicationListener<Contex
         expr.timeZone = TimeZone.getTimeZone(dateContext.clock.zone)
 
         if (missedExecution(expr, lastExecution, dateContext.triggerWindowFloor(), dateContext.triggerWindowCeiling(), pipeline)) {
-          pipelineInitiator.startPipeline(pipeline.withTrigger(trigger), PipelineInitiator.TriggerSource.MISSEDSCHEDULER)
+          pipelineInitiator.startPipeline(pipeline.withTrigger(trigger), PipelineInitiator.TriggerSource.COMPENSATION_SCHEDULER)
         }
       } catch (ParseException e) {
         log.error("Error parsing cron expression (${trigger.cronExpression}) for pipeline ${pipeline.id}", e)

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineTriggerJob.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineTriggerJob.groovy
@@ -52,7 +52,7 @@ class PipelineTriggerJob implements Job {
       def eventId = pipeline.trigger.eventId ? pipeline.trigger.eventId : "not set"
 
       LOGGER.info("Executing PipelineTriggerJob for '${pipeline}', eventId='${eventId}', triggerId='${context.trigger.key.name}'")
-      pipelineInitiator.startPipeline(pipeline, PipelineInitiator.TriggerSource.SCHEDULER)
+      pipelineInitiator.startPipeline(pipeline, PipelineInitiator.TriggerSource.CRON_SCHEDULER)
     } catch (Exception e) {
       LOGGER.error("Exception occurred while executing PipelineTriggerJob for ${pipeline}", e)
       throw new JobExecutionException(e)

--- a/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/MissedPipelineTriggerCompensationJobSpec.groovy
+++ b/echo-scheduler/src/test/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/MissedPipelineTriggerCompensationJobSpec.groovy
@@ -84,7 +84,7 @@ class MissedPipelineTriggerCompensationJobSpec extends Specification {
         new OrcaService.PipelineResponse(pipelineConfigId: '4', startTime: getDateOffset(30).time)
       ]
     }
-    1 * pipelineInitiator.startPipeline((Pipeline) pipelines[0].withTrigger(theTriggeringTrigger), PipelineInitiator.TriggerSource.MISSEDSCHEDULER)
+    1 * pipelineInitiator.startPipeline((Pipeline) pipelines[0].withTrigger(theTriggeringTrigger), PipelineInitiator.TriggerSource.COMPENSATION_SCHEDULER)
     0 * orcaService._
     0 * pipelineInitiator._
   }


### PR DESCRIPTION
Adds two dynamic properties:
* `scheduler.suppressTriggers`, and
* `scheduler.compensationJob.suppressTriggers`

(both default to `false`)

This is useful when there are two `echo` clusters (for redundancy) to process events but only one of them should actually trigger.
Processing triggers (e.g. running the schedule) but triggering on only one of the clusters allows both clusters to be "in-sync" and when a switch is needed there will be no (or very few) double triggers.
