### PR TITLE
fix(trigger): Fixup property names for trigger suppression

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
@@ -395,9 +395,11 @@ public class PipelineInitiator {
 
     if (triggerSource == TriggerSource.COMPENSATION_SCHEDULER) {
       triggerEnabled =
-          !dynamicConfigService.isEnabled("scheduler.compensation-job.suppress-triggers", false);
+          !dynamicConfigService.getConfig(
+              Boolean.class, "scheduler.compensation-job.suppress-triggers", false);
     } else if (triggerSource == TriggerSource.CRON_SCHEDULER) {
-      triggerEnabled = !dynamicConfigService.isEnabled("scheduler.suppress-triggers", false);
+      triggerEnabled =
+          !dynamicConfigService.getConfig(Boolean.class, "scheduler.suppress-triggers", false);
     }
 
     return triggerEnabled && dynamicConfigService.isEnabled("orca", true);

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiatorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiatorSpec.groovy
@@ -78,7 +78,7 @@ class PipelineInitiatorSpec extends Specification {
     pipelineInitiator.startPipeline(pipeline, PipelineInitiator.TriggerSource.CRON_SCHEDULER)
 
     then:
-    1 * dynamicConfigService.isEnabled('scheduler.suppress-triggers', false) >> { return suppress }
+    1 * dynamicConfigService.getConfig(Boolean.class, 'scheduler.suppress-triggers', false) >> { return suppress }
     _ * dynamicConfigService.isEnabled("orca", true) >> { return enabled }
     _ * fiatStatus.isEnabled() >> { return enabled }
     _ * fiatStatus.isLegacyFallbackEnabled() >> { return legacyFallbackEnabled }


### PR DESCRIPTION
Fixup for my prior PR, #927.
I don't want the props to need the `enabled` suffix, hence changing `isEnabled` -> `getConfig` for the dynamicConfig query
