### PR TITLE
fix(triggers): Changing format for suppression properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,12 @@ See [Sample deployment topology](#sample-deployment-topology) for additional inf
 There are several ways to suppress triggers in `echo` (note, all of the below are backed by `DynamicConfigService` and therefore can be modified at runtime)
 * `orca.enabled` (default: `true`)  
     top level knob that disables communication with `orca` and thus ALL triggers
-* `scheduler.suppressTriggers` (default: `false`)  
+* `scheduler.triggers.enabled` (default: `true`)  
     allows suppressing triggering of events from the CRON scheduler only
-* `scheduler.compensationJob.suppressTriggers` (default: `false`)  
+* `scheduler.compensationJob.triggers.enabled` (default: `true`)  
     allows suppressing triggering of events from the compensation job (aka missed CRON scheduler) only
 
-There are two settings for each trigger, e.g. `scheduler.enabled` and `scheduler.suppressTriggers`. 
+There are two settings for each trigger, e.g. `scheduler.enabled` and `scheduler.triggers.enabled`. 
 The reason for this complexity is to allow scenarios where there are two `echo` clusters that are running the scheduler for redundancy reasons (e.g. in two regions).  
 In order to correctly switch which cluster (region) is generating triggers they both need to be "up-to-speed" hence you'd run the scheduler in both clusters but only one would trigger.
 That way, when you switch which cluster does the triggering it will trigger the correct events without duplicates.

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.java
@@ -394,12 +394,9 @@ public class PipelineInitiator {
     boolean triggerEnabled = true;
 
     if (triggerSource == TriggerSource.COMPENSATION_SCHEDULER) {
-      triggerEnabled =
-          !dynamicConfigService.getConfig(
-              Boolean.class, "scheduler.compensation-job.suppress-triggers", false);
+      triggerEnabled = dynamicConfigService.isEnabled("scheduler.compensation-job.triggers", true);
     } else if (triggerSource == TriggerSource.CRON_SCHEDULER) {
-      triggerEnabled =
-          !dynamicConfigService.getConfig(Boolean.class, "scheduler.suppress-triggers", false);
+      triggerEnabled = dynamicConfigService.isEnabled("scheduler.triggers", true);
     }
 
     return triggerEnabled && dynamicConfigService.isEnabled("orca", true);

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiatorSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiatorSpec.groovy
@@ -78,7 +78,7 @@ class PipelineInitiatorSpec extends Specification {
     pipelineInitiator.startPipeline(pipeline, PipelineInitiator.TriggerSource.CRON_SCHEDULER)
 
     then:
-    1 * dynamicConfigService.getConfig(Boolean.class, 'scheduler.suppress-triggers', false) >> { return suppress }
+    1 * dynamicConfigService.isEnabled('scheduler.triggers', true) >> { return !suppress }
     _ * dynamicConfigService.isEnabled("orca", true) >> { return enabled }
     _ * fiatStatus.isEnabled() >> { return enabled }
     _ * fiatStatus.isLegacyFallbackEnabled() >> { return legacyFallbackEnabled }


### PR DESCRIPTION
Changing to "positive" by default instead of "negative" property to align with similar properties in `igor`, and, e.g. `orca.enabled`
