### PR TITLE
fix(notification): Support channel ID as Slack notification address

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgent.groovy
@@ -99,7 +99,7 @@ class SlackNotificationAgent extends AbstractEventNotificationAgent {
         .replace("{{link}}", link ?: "")
     }
 
-    String address = preference.address.startsWith('#') ? preference.address : "#${preference.address}"
+    String address = preference.address
 
     Response response
     if (sendCompactMessages) {

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
@@ -53,7 +53,7 @@ class SlackNotificationService implements NotificationService {
     def text = notificationTemplateEngine.build(notification, NotificationTemplateEngine.Type.BODY)
     notification.to.each {
       def response
-      String address = it.startsWith('#') ? it : "#${it}"
+      String address = it
       if (slack.config.sendCompactMessages) {
         response = slack.sendCompactMessage(new CompactSlackMessage(text), address, true)
       } else {

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationServiceSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationServiceSpec.groovy
@@ -42,7 +42,7 @@ class SlackNotificationServiceSpec extends Specification {
     given:
     Notification notification = new Notification()
     notification.notificationType = "SLACK"
-    notification.to = [ "channel1", "channel2" ]
+    notification.to = [ "channel1", "#channel2", "C12345678" ]
     notification.severity = Notification.Severity.NORMAL
     notification.additionalContext["body"] = "text"
 
@@ -54,6 +54,8 @@ class SlackNotificationServiceSpec extends Specification {
     service.handle(notification)
 
     then:
-    notification.to.size() * slack.sendMessage(*_)
+    1 * slack.sendMessage(_, "channel1", _)
+    1 * slack.sendMessage(_, "#channel2", _)
+    1 * slack.sendMessage(_, "C12345678", _)
   }
 }


### PR DESCRIPTION
This PR is to fix spinnaker/spinnaker#5841.

Slack API for sending notification supports channel name, channel name with `#` prefix and channel ID as its address. These 3 options can be used interchangeably.
Echo's Slack notification service doesn't support putting channel ID in the address field.

Before this PR, SlackNotificationService prefix the channel address with `#` if it's missing. If the channel ID is input by the user, it won't work properly with the `#` prefix.

After this PR, Slack notification service keep channel address as is. Users are allowed to specify channel ID.