### PR TITLE
feat(stats): add support for new stats

### DIFF
--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/PipelineCountsDataProvider.kt
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/PipelineCountsDataProvider.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.echo.telemetry
+
+import com.google.common.base.Suppliers
+import com.netflix.spinnaker.echo.api.events.Event as EchoEvent
+import com.netflix.spinnaker.echo.services.Front50Service
+import com.netflix.spinnaker.kork.proto.stats.Event as StatsEvent
+import java.util.concurrent.TimeUnit
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty("stats.enabled")
+class PipelineCountsDataProvider(private val front50: Front50Service) : TelemetryEventDataProvider {
+
+  private val appPipelinesSupplier =
+    Suppliers.memoizeWithExpiration({ retrievePipelines() }, 30, TimeUnit.MINUTES)
+
+  override fun populateData(echoEvent: EchoEvent, statsEvent: StatsEvent): StatsEvent {
+
+    val newEvent = statsEvent.toBuilder()
+    val appPipelines = appPipelinesSupplier.get()
+    val appPipelineCount = appPipelines[echoEvent.details.application]
+    if (appPipelineCount != null) {
+      newEvent.applicationBuilder.pipelineCount = appPipelineCount
+    }
+    newEvent.spinnakerInstanceBuilder.pipelineCount = appPipelines.values.sum()
+    return newEvent.build()
+  }
+
+  private fun retrievePipelines(): Map<String, Int> {
+    return front50.pipelines
+      .filter { it.containsKey("application") }
+      .groupBy { it["application"] as String }
+      .mapValues { it.value.size }
+  }
+}

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/SpinnakerEnvironmentDataProvider.kt
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/SpinnakerEnvironmentDataProvider.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.echo.telemetry
+
+import com.netflix.spinnaker.echo.api.events.Event as EchoEvent
+import com.netflix.spinnaker.kork.proto.stats.Event as StatsEvent
+import com.netflix.spinnaker.kork.proto.stats.SpinnakerInstance
+import com.netflix.spinnaker.kork.proto.stats.SpinnakerInstance.DeployedArtifacts
+import com.netflix.spinnaker.kork.proto.stats.SpinnakerInstance.Environment
+import java.io.IOException
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+/**
+ * Sets the [SpinnakerInstance.Environment] and [SpinnakerInstance.DeployedArtifacts] fields of the
+ * stats proto.
+ *
+ * This is mostly in its own [TelemetryEventDataProvider] because it's not really testable.
+ */
+@Component
+@ConditionalOnProperty("stats.enabled")
+class SpinnakerEnvironmentDataProvider : TelemetryEventDataProvider {
+
+  private val environment by lazy { computeDeploymentEnvironment() }
+
+  override fun populateData(echoEvent: EchoEvent, statsEvent: StatsEvent): StatsEvent {
+    val newEvent = statsEvent.toBuilder()
+    newEvent.spinnakerInstanceBuilder.mergeFrom(environment)
+    return newEvent.build()
+  }
+
+  private fun computeDeploymentEnvironment(): SpinnakerInstance {
+    val result = SpinnakerInstance.newBuilder()
+    if (System.getenv("KUBERNETES_PORT") != null) {
+      result.apply {
+        environment = Environment.KUBERNETES
+        deployedArtifacts = DeployedArtifacts.DOCKER_CONTAINERS
+      }
+    } else if (debianPackageIsInstalled()) {
+      result.apply {
+        environment = Environment.ENVIRONMENT_UNKNOWN
+        deployedArtifacts = DeployedArtifacts.DEBIAN_PACKAGES
+      }
+    } else {
+      result.apply {
+        environment = Environment.ENVIRONMENT_UNKNOWN
+        deployedArtifacts = DeployedArtifacts.DEPLOYED_ARTIFACTS_UNKNOWN
+      }
+    }
+    return result.build()
+  }
+
+  private fun debianPackageIsInstalled(): Boolean {
+    try {
+      val exitCode = ProcessBuilder()
+        .command("/usr/bin/dpkg-query", "-s", "spinnaker-echo")
+        .start()
+        .waitFor()
+      return exitCode == 0
+    } catch (e: IOException) {
+      return false
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+      return false
+    }
+  }
+}

--- a/echo-telemetry/src/test/kotlin/com/netflix/spinnaker/echo/telemetry/PipelineCountsDataProviderTest.kt
+++ b/echo-telemetry/src/test/kotlin/com/netflix/spinnaker/echo/telemetry/PipelineCountsDataProviderTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.echo.telemetry
+
+import com.netflix.spinnaker.echo.api.events.Event as EchoEvent
+import com.netflix.spinnaker.echo.api.events.Metadata
+import com.netflix.spinnaker.echo.services.Front50Service
+import com.netflix.spinnaker.kork.proto.stats.Event as StatsEvent
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isGreaterThanOrEqualTo
+import strikt.assertions.isLessThanOrEqualTo
+
+@ExtendWith(MockKExtension::class)
+class PipelineCountsDataProviderTest {
+
+  @MockK
+  private lateinit var front50Service: Front50Service
+
+  private lateinit var dataProvider: PipelineCountsDataProvider
+
+  @BeforeEach
+  fun setUp() {
+    dataProvider = PipelineCountsDataProvider(front50Service)
+  }
+
+  @Test
+  fun `basic pipeline counts`() {
+
+    every { front50Service.pipelines } returns listOf(
+      mapOf(
+        "application" to "app1"
+      ),
+      mapOf(
+        "application" to "app2"
+      ),
+      mapOf(
+        "application" to "app2"
+      ),
+      mapOf(
+        "application" to "app2"
+      ),
+      mapOf(
+        "application" to "app3"
+      )
+    )
+
+    val result = dataProvider.populateData(
+      echoEventForApplication("app2"),
+      StatsEvent.getDefaultInstance())
+
+    expectThat(result.spinnakerInstance.pipelineCount).isEqualTo(5)
+    expectThat(result.application.pipelineCount).isEqualTo(3)
+  }
+
+  @Test
+  fun `pipeline without application is ignored`() {
+
+    every { front50Service.pipelines } returns listOf(
+      mapOf(
+        "application" to "app1"
+      ),
+      mapOf(
+        "application" to "app2"
+      ),
+      mapOf(
+        "application" to "app3"
+      ),
+      mapOf(
+        "noApplicationIsDefined" to "thatsCoolMan"
+      )
+    )
+
+    val result = dataProvider.populateData(
+      echoEventForApplication("app2"),
+      StatsEvent.getDefaultInstance())
+
+    // I don't particularly care if it counts the broken pipeline or not.
+    expectThat(result.spinnakerInstance.pipelineCount)
+      .isGreaterThanOrEqualTo(3)
+      .isLessThanOrEqualTo(4)
+    expectThat(result.application.pipelineCount).isEqualTo(1)
+  }
+
+  fun echoEventForApplication(application: String): EchoEvent {
+    return EchoEvent().apply {
+      details = Metadata()
+      details.application = application
+    }
+  }
+}


### PR DESCRIPTION
* whether or not Spinnaker is running under Kubernetes
* which artifacts were used to deploy Spinnaker
* the number of pipelines in this Spinnaker instance
* the number of pipelines in the event's application

See spinnaker/kork#692