### PR TITLE
feat(stats): Enable stats by default in echo

### DIFF
--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/config/TelemetryConfig.kt
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/config/TelemetryConfig.kt
@@ -33,7 +33,7 @@ import retrofit.client.OkClient
 import retrofit.converter.JacksonConverter
 
 @Configuration
-@ConditionalOnProperty("stats.enabled")
+@ConditionalOnProperty(value = ["stats.enabled"], matchIfMissing = true)
 @EnableConfigurationProperties(TelemetryConfigProps::class)
 open class TelemetryConfig {
 

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/ExecutionDataProvider.kt
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/ExecutionDataProvider.kt
@@ -29,7 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Component
-@ConditionalOnProperty("stats.enabled")
+@ConditionalOnProperty(value = ["stats.enabled"], matchIfMissing = true)
 class ExecutionDataProvider : TelemetryEventDataProvider {
 
   private val objectMapper = EchoObjectMapper.getInstance()

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/InstanceIdSupplier.kt
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/InstanceIdSupplier.kt
@@ -28,7 +28,7 @@ import redis.clients.jedis.commands.JedisCommands
 val UNIQUE_ID_KEY = "spinnaker:stats:instanceId"
 
 @Component
-@ConditionalOnProperty("stats.enabled")
+@ConditionalOnProperty(value = ["stats.enabled"], matchIfMissing = true)
 class InstanceIdSupplier(
   private val config: TelemetryConfig.TelemetryConfigProps,
   redisSelector: RedisClientSelector?

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/PipelineCountsDataProvider.kt
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/PipelineCountsDataProvider.kt
@@ -26,7 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Component
-@ConditionalOnProperty("stats.enabled")
+@ConditionalOnProperty(value = ["stats.enabled"], matchIfMissing = true)
 class PipelineCountsDataProvider(private val front50: Front50Service) : TelemetryEventDataProvider {
 
   private val appPipelinesSupplier =

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/SpinnakerEnvironmentDataProvider.kt
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/SpinnakerEnvironmentDataProvider.kt
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Component
  * This is mostly in its own [TelemetryEventDataProvider] because it's not really testable.
  */
 @Component
-@ConditionalOnProperty("stats.enabled")
+@ConditionalOnProperty(value = ["stats.enabled"], matchIfMissing = true)
 class SpinnakerEnvironmentDataProvider : TelemetryEventDataProvider {
 
   private val environment by lazy { computeDeploymentEnvironment() }

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/SpinnakerInstanceDataProvider.kt
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/SpinnakerInstanceDataProvider.kt
@@ -27,7 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Component
-@ConditionalOnProperty("stats.enabled")
+@ConditionalOnProperty(value = ["stats.enabled"], matchIfMissing = true)
 class SpinnakerInstanceDataProvider(private val config: TelemetryConfigProps, private val instanceIdSupplier: InstanceIdSupplier) : TelemetryEventDataProvider {
   override fun populateData(echoEvent: EchoEvent, statsEvent: StatsEvent): StatsEvent {
 

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryEventListener.java
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryEventListener.java
@@ -33,7 +33,7 @@ import retrofit.mime.TypedString;
 
 @Slf4j
 @Component
-@ConditionalOnProperty("stats.enabled")
+@ConditionalOnProperty(value = "stats.enabled", matchIfMissing = true)
 public class TelemetryEventListener implements EventListener {
 
   protected static final String TELEMETRY_REGISTRY_NAME = "telemetry";


### PR DESCRIPTION
The rollout plan for stats involved having the stats become opt-out (ie enabled by default) as of Spinnaker 1.19. While this was implemented, it was only done at the Halyard level; Halyard now explicitly sends 'stats.enabled = true' by default (and sends 'stats.enabled = false' for users who have disabled stats collection).

This is confusing, as stats collection is now opt-out for Halyard users but still opt-in for anyone writing their own config. As part of the effort to have services own and default their own config, update echo to be consistent with Halyard (and with the intent of the rollout plan).

With this change, echo will send usage statistics for anyone who does not have a 'stats.enabled' field in their config. Halyard users should all have this field already set to either true/false, so this would primarily affect users either writing their own config or upcoming users of kleat.