### PR TITLE
feat(notifications): add switch for supplying custom notification UI

### DIFF
--- a/echo-api/src/main/java/com/netflix/spinnaker/echo/api/events/NotificationAgent.java
+++ b/echo-api/src/main/java/com/netflix/spinnaker/echo/api/events/NotificationAgent.java
@@ -48,4 +48,18 @@ public interface NotificationAgent extends SpinnakerExtensionPoint {
    */
   @Nonnull
   List<NotificationParameter> getParameters();
+
+  /**
+   * Return BASIC here to auto-generate a UI from the parameters defined in {@link
+   * Notification#getParameters}. Return CUSTOM to use a custom UI instead.
+   */
+  @Nonnull
+  default NotificationUIType getUiType() {
+    return NotificationUIType.BASIC;
+  }
+
+  public enum NotificationUIType {
+    BASIC,
+    CUSTOM;
+  }
 }


### PR DESCRIPTION
Allows a notification agent plugin to define a custom UI rather than using the autogenerated UI (e.g., if there's some custom validation logic that's needed for inputs).

See: https://github.com/spinnaker/deck/pull/8432