### PR TITLE
fix(trigger): handle quartz errors better

### DIFF
--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/InvalidCronExpressionException.java
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/InvalidCronExpressionException.java
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.echo.scheduler.actions.pipeline;
 
-public class InvalidCronExpressionException extends IllegalArgumentException {
+import com.netflix.spinnaker.kork.exceptions.UserException;
+
+public class InvalidCronExpressionException extends UserException {
   public InvalidCronExpressionException(String cronExpression, String explanation) {
     super("Invalid CRON expression: '" + cronExpression + "' explanation: " + explanation);
   }

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineConfigPollingMetrics.java
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineConfigPollingMetrics.java
@@ -1,0 +1,60 @@
+package com.netflix.spinnaker.echo.scheduler.actions.pipeline;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PipelineConfigPollingMetrics {
+  private final Registry registry;
+
+  private final Id triggerCountId;
+  private final Id removeCountId;
+  private final Id removeFailCountId;
+  private final Id failedUpdateCountId;
+  private final Id addCountId;
+  private final Id syncErrorId;
+  private final Id syncTimeId;
+
+  @Autowired
+  public PipelineConfigPollingMetrics(Registry registry) {
+    this.registry = registry;
+    triggerCountId = registry.createId("echo.triggers.count");
+    removeCountId = registry.createId("echo.triggers.sync.removeCount");
+    removeFailCountId = registry.createId("echo.triggers.sync.removeFailCount");
+    failedUpdateCountId = registry.createId("echo.triggers.sync.failedUpdateCount");
+    addCountId = registry.createId("echo.triggers.sync.addCount");
+    syncErrorId = registry.createId("echo.triggers.sync.error");
+    syncTimeId = registry.createId("echo.triggers.sync.executionTimeMillis");
+  }
+
+  public void triggerCount(int count) {
+    registry.gauge(triggerCountId).set(count);
+  }
+
+  public void incrementTriggerSyncError() {
+    registry.counter(syncErrorId).increment();
+  }
+
+  public void removeCount(int count) {
+    registry.gauge(removeCountId).set(count);
+  }
+
+  public void failedRemoveCount(int count) {
+    registry.gauge(removeFailCountId).set(count);
+  }
+
+  public void failedUpdateCount(int count) {
+    registry.gauge(failedUpdateCountId).set(count);
+  }
+
+  public void addCount(int count) {
+    registry.gauge(addCountId).set(count);
+  }
+
+  public void recordSyncTime(long elapsedMillis) {
+    registry.timer(syncTimeId).record(elapsedMillis, TimeUnit.MILLISECONDS);
+  }
+}

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineConfigsPollingJob.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineConfigsPollingJob.groovy
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.echo.scheduler.actions.pipeline
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.echo.model.Trigger
 import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCache
-import com.netflix.spinnaker.kork.exceptions.ConfigurationException
 import groovy.util.logging.Slf4j
 import org.quartz.CronTrigger
 import org.quartz.DisallowConcurrentExecution
@@ -203,7 +202,7 @@ class PipelineConfigsPollingJob implements Job {
       boolean willTriggerFire = willTriggerFire(trigger)
 
       if (!willTriggerFire) {
-        throw new ConfigurationException("Trigger is in the past")
+        throw new SchedulerException("Trigger is in the past")
       }
     } catch (SchedulerException e) {
       log.warn("Failed to create a new trigger: id: ${pipelineTrigger.id} for pipeline: ${pipelineTrigger.parent.application}:${pipelineTrigger.parent.name} (${pipelineTrigger.parent.id}). " +


### PR DESCRIPTION
We want to know when `echo` fails to register a trigger with quartz but only if it's not a user error (e.g. bad cron express, cron expression in the past, etc).
Quartz, unfortunately, often throws a non-descript `SchedulerException` which doesn't provide machine identifiable way to decipher if this is a user error or a system error.

This change replicates some logic that's in [quartz](https://github.com/quartz-scheduler/quartz/blob/939a9a25fbf3b374608de59e413405aebe10c089/quartz-core/src/main/java/org/quartz/core/QuartzScheduler.java#L882-L896)
to decide if the trigger is valid, if not we will log a warning, but won't increment any failure metrics.
If the are exceptions/errors outside of the trigger validation path, those will still log errors and increment failure metrics

