### PR TITLE
feat(test): add echo integration test fixture

### DIFF
--- a/echo-api-tck/README.md
+++ b/echo-api-tck/README.md
@@ -1,0 +1,3 @@
+# echo-api-tck
+
+Test harnesses and utilities for echo-api consumers (plugin developers).

--- a/echo-api-tck/echo-api-tck.gradle
+++ b/echo-api-tck/echo-api-tck.gradle
@@ -1,0 +1,17 @@
+apply from: "${project.rootDir}/gradle/kotlin.gradle"
+
+dependencies {
+  implementation(project(":echo-web"))
+
+  api("org.springframework.boot:spring-boot-starter-test")
+  api("dev.minutest:minutest")
+
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+}
+
+test {
+  useJUnitPlatform {
+    includeEngines("junit-jupiter", "junit-vintage")
+  }
+}

--- a/echo-api-tck/src/main/kotlin/com/netflix/spinnaker/echo/api/test/EchoFixture.kt
+++ b/echo-api-tck/src/main/kotlin/com/netflix/spinnaker/echo/api/test/EchoFixture.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.echo.api.test
+
+import com.netflix.spinnaker.echo.Application
+import dev.minutest.TestContextBuilder
+import dev.minutest.TestDescriptor
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestContextManager
+import org.springframework.test.context.TestPropertySource
+
+/**
+ * EchoFixture is the base configuration for an Echo integration test.
+ */
+@SpringBootTest(classes = [Application::class])
+@TestPropertySource(properties = ["spring.config.location=classpath:echo-test-app.yml"])
+abstract class EchoFixture
+
+/**
+ * DSL for constructing an EchoFixture within a Minutest suite.
+ */
+inline fun <PF, reified F> TestContextBuilder<PF, F>.echoFixture(
+  crossinline factory: (Unit).(testDescriptor: TestDescriptor) -> F
+) {
+  fixture { testDescriptor ->
+    factory(testDescriptor).also {
+      TestContextManager(F::class.java).prepareTestInstance(it)
+    }
+  }
+}

--- a/echo-api-tck/src/main/resources/echo-test-app.yml
+++ b/echo-api-tck/src/main/resources/echo-test-app.yml
@@ -1,0 +1,16 @@
+front50:
+  baseUrl: http://localhost:8080
+
+orca:
+  baseUrl: http://localhost:8083
+
+services:
+  fiat:
+    baseUrl: http://localhost:7003
+
+spring:
+  application:
+    name: echo
+
+spinnaker:
+  baseUrl: http://localhost:9000

--- a/echo-api-tck/src/test/kotlin/com/netflix/spinnaker/echo/api/test/EchoFixtureTest.kt
+++ b/echo-api-tck/src/test/kotlin/com/netflix/spinnaker/echo/api/test/EchoFixtureTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.echo.api.test
+
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+
+class EchoFixtureTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    context("an echo integration test environment") {
+      echoFixture {
+        Fixture()
+      }
+
+      test("service starts") { /* no-op */ }
+    }
+  }
+
+  inner class Fixture : EchoFixture()
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,6 +25,7 @@
 enableFeaturePreview("VERSION_ORDERING_V2")
 
 include 'echo-api',
+        'echo-api-tck',
         'echo-artifacts',
         'echo-bom',
         'echo-core',


### PR DESCRIPTION
This is modeled after https://github.com/spinnaker/orca/tree/master/orca-api-tck and has the same purpose (letting plugin developers write integration tests). Planning on doing this for quite a few other services. There isn't much here, but it can be tough for plugin developers to know exactly what config values they need to get Echo to run in a test environment.