### PR TITLE
feat(slack): flag to use interactive bot

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/api/Notification.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/api/Notification.groovy
@@ -29,9 +29,10 @@ class Notification {
   Source source
   Map<String, Object> additionalContext = [:]
   InteractiveActions interactiveActions
+  Boolean useInteractiveBot = false
 
   boolean isInteractive() {
-    interactiveActions != null && !interactiveActions.actions.empty
+    useInteractiveBot || (interactiveActions != null && !interactiveActions.actions.empty)
   }
 
   static class Source {

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationService.groovy
@@ -50,6 +50,7 @@ class SlackNotificationService implements NotificationService {
   @Override
   EchoResponse.Void handle(Notification notification) {
     log.debug("Handling Slack notification to ${notification.to}")
+    def subject = notificationTemplateEngine.build(notification, NotificationTemplateEngine.Type.SUBJECT)
     def text = notificationTemplateEngine.build(notification, NotificationTemplateEngine.Type.BODY)
     notification.to.each {
       def response
@@ -58,7 +59,7 @@ class SlackNotificationService implements NotificationService {
         response = slack.sendCompactMessage(new CompactSlackMessage(text), address, true)
       } else {
         response = slack.sendMessage(
-          new SlackAttachment("Spinnaker Notification", text, (InteractiveActions)notification.interactiveActions),
+          new SlackAttachment(subject, text, (InteractiveActions)notification.interactiveActions),
           address, true)
       }
       log.trace("Received response from Slack: {} {} for message '{}'. {}",

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationServiceSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackNotificationServiceSpec.groovy
@@ -45,6 +45,7 @@ class SlackNotificationServiceSpec extends Specification {
     notification.to = [ "channel1", "#channel2", "C12345678" ]
     notification.severity = Notification.Severity.NORMAL
     notification.additionalContext["body"] = "text"
+    notification.additionalContext["subject"] = "ohai"
 
     slack.config >> new SlackLegacyProperties()
 


### PR DESCRIPTION
A flag (defaulting to false) to use the new slack bot even if you have no interactive actions.

This defaults to the old behavior if you don't specify the flag in your notification payload.


This PR also adds support for the subject line of a slack message. Previously we were using "Spinnaker Notification" which is both redundant (because of the name of the bot) and not useful (because we are sending a subject in the slack notification). 
This shows previous (default subject) and new (a subject that I sent)
![Screen Shot 2020-09-29 at 1 05 16 PM](https://user-images.githubusercontent.com/8454927/94609987-70541880-0254-11eb-96a7-91abb2a44ed9.png)
