### PR TITLE
refactor(core): Support plugins v2 framework

### DIFF
--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/notification/ExtensionNotificationAgent.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/notification/ExtensionNotificationAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Armory, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package com.netflix.spinnaker.echo.notification;
@@ -35,7 +36,11 @@ public class ExtensionNotificationAgent extends AbstractEventNotificationAgent {
 
   @Override
   public void sendNotifications(
-      Map notification, String application, Event event, Map config, String status) {
+      Map<String, Object> notification,
+      String application,
+      Event event,
+      Map<String, String> config,
+      String status) {
     agent.sendNotifications(notification, application, event, status);
   }
 }

--- a/echo-core/src/test/groovy/com/netflix/spinnaker/echo/events/EventPropagationSpec.groovy
+++ b/echo-core/src/test/groovy/com/netflix/spinnaker/echo/events/EventPropagationSpec.groovy
@@ -17,6 +17,8 @@ package com.netflix.spinnaker.echo.events
 
 import com.netflix.spinnaker.echo.api.events.EventListener
 import com.netflix.spinnaker.echo.api.events.Event
+import org.springframework.beans.BeansException
+import org.springframework.beans.factory.ObjectProvider
 import rx.schedulers.Schedulers
 import spock.lang.Specification
 
@@ -28,16 +30,11 @@ class EventPropagationSpec extends Specification {
     void 'events are sent to every listener'() {
 
         given:
-        EventPropagator propagator = new EventPropagator()
-        propagator.scheduler = Schedulers.immediate()
         EventListener l1 = Mock(EventListener)
         EventListener l2 = Mock(EventListener)
+        EventPropagator propagator = new EventPropagator(new StaticObjectProvider([l1, l2]), null, Schedulers.immediate())
 
         when:
-        propagator.addListener(l1)
-        propagator.addListener(l2)
-
-        and:
         propagator.processEvent(new Event())
 
         then:
@@ -46,4 +43,32 @@ class EventPropagationSpec extends Specification {
 
     }
 
+
+  private static class StaticObjectProvider implements ObjectProvider<List<EventListener>> {
+
+    StaticObjectProvider(List<EventListener> eventListeners) {
+      this.eventListeners = eventListeners
+    }
+    List<EventListener> eventListeners = []
+
+    @Override
+    List<EventListener> getObject(Object... args) throws BeansException {
+      return eventListeners
+    }
+
+    @Override
+    List<EventListener> getIfAvailable() throws BeansException {
+      return eventListeners
+    }
+
+    @Override
+    List<EventListener> getIfUnique() throws BeansException {
+      return eventListeners
+    }
+
+    @Override
+    List<EventListener> getObject() throws BeansException {
+      return eventListeners
+    }
+  }
 }

--- a/echo-plugins-test/src/test/kotlin/com/netflix/spinnaker/echo/plugins/test/EchoPluginsFixture.kt
+++ b/echo-plugins-test/src/test/kotlin/com/netflix/spinnaker/echo/plugins/test/EchoPluginsFixture.kt
@@ -34,11 +34,11 @@ import org.springframework.test.context.TestPropertySource
 
 class EchoPluginsFixture : PluginsTckFixture, EchoTestService() {
 
-  final override val plugins = File("build/plugins")
+  override val plugins = File("build/plugins")
 
-  final override val enabledPlugin: PluginJar
-  final override val disabledPlugin: PluginJar
-  final override val versionNotSupportedPlugin: PluginJar
+  override val enabledPlugin: PluginJar
+  override val disabledPlugin: PluginJar
+  override val versionNotSupportedPlugin: PluginJar
 
   override val extensionClassNames: MutableList<String> = mutableListOf(
     EventListenerExtension::class.java.name,

--- a/echo-plugins-test/src/test/kotlin/com/netflix/spinnaker/echo/plugins/test/EchoPluginsTest.kt
+++ b/echo-plugins-test/src/test/kotlin/com/netflix/spinnaker/echo/plugins/test/EchoPluginsTest.kt
@@ -35,8 +35,8 @@ class EchoPluginsTest : PluginsTck<EchoPluginsFixture>() {
       defaultPluginTests()
 
       test("Event listener extension is loaded into context") {
-        val eventListeners = applicationContext.getBeansOfType<EventListener>(EventListener::class.java)
-        val extensionBeanName = "com.netflix.echo.enabled.plugin.EventListenerExtension".replace(".", "")
+        val eventListeners = applicationContext.getBeansOfType(EventListener::class.java)
+        val extensionBeanName = "com.netflix.echo.enabled.plugin_eventListenerExtension"
         val extension = eventListeners[extensionBeanName]
         expect {
           that(extension).isNotNull()
@@ -45,7 +45,7 @@ class EchoPluginsTest : PluginsTck<EchoPluginsFixture>() {
 
       test("Notification agent extension is loaded into context") {
         val eventListeners = applicationContext.getBeansOfType(NotificationAgent::class.java)
-        val extensionBeanName = "com.netflix.echo.enabled.plugin.NotificationAgentExtension".replace(".", "")
+        val extensionBeanName = "com.netflix.echo.enabled.plugin_notificationAgentExtension"
         val extension = eventListeners[extensionBeanName]
         expect {
           that(extension).isNotNull()

--- a/echo-web/src/main/java/com/netflix/spinnaker/echo/config/EchoCoreConfig.java
+++ b/echo-web/src/main/java/com/netflix/spinnaker/echo/config/EchoCoreConfig.java
@@ -20,19 +20,14 @@ import com.netflix.spinnaker.config.PluginsAutoConfiguration;
 import com.netflix.spinnaker.echo.api.events.EventListener;
 import com.netflix.spinnaker.echo.api.events.NotificationAgent;
 import com.netflix.spinnaker.echo.events.EventPropagator;
-import com.netflix.spinnaker.echo.notification.ExtensionNotificationAgent;
 import com.netflix.spinnaker.kork.artifacts.parsing.DefaultJinjavaFactory;
 import com.netflix.spinnaker.kork.artifacts.parsing.JinjaArtifactExtractor;
 import com.netflix.spinnaker.kork.artifacts.parsing.JinjavaFactory;
 import com.netflix.spinnaker.kork.core.RetrySupport;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import lombok.val;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -46,28 +41,11 @@ import org.springframework.context.annotation.Import;
 })
 @Import({PluginsAutoConfiguration.class})
 public class EchoCoreConfig {
-  private ApplicationContext context;
-
-  @Autowired
-  public EchoCoreConfig(ApplicationContext context) {
-    this.context = context;
-  }
-
   @Bean
-  public EventPropagator propagator(Optional<List<NotificationAgent>> notificationAgents) {
-
-    EventPropagator instance = new EventPropagator();
-    for (EventListener e : context.getBeansOfType(EventListener.class).values()) {
-      instance.addListener(e);
-    }
-    val extensionNotificationAgents =
-        notificationAgents.orElseGet(ArrayList::new).stream()
-            .map(ExtensionNotificationAgent::new)
-            .collect(Collectors.toList());
-    for (ExtensionNotificationAgent e : extensionNotificationAgents) {
-      instance.addListener(e);
-    }
-    return instance;
+  public EventPropagator propagator(
+      Optional<List<NotificationAgent>> notificationAgents,
+      ObjectProvider<List<EventListener>> eventListenerProvider) {
+    return new EventPropagator(eventListenerProvider, notificationAgents.orElse(null));
   }
 
   @Bean

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 fiatVersion=1.24.0
-korkVersion=7.73.0
+korkVersion=7.74.0
 kotlinVersion=1.4.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.7.0


### PR DESCRIPTION
- Moved `ExtensionNotificationAgent` to `echo-core`
- Refactored `EventPropagator` to use `ObjectProvider` for `EventListener` beans
- Fixed test for V2 plugin support

