### PR TITLE
fix(core): Add closing '}' on `@Value`

### DIFF
--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgent.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgent.java
@@ -50,7 +50,7 @@ public abstract class AbstractEventNotificationAgent implements EventListener {
 
   protected ObjectMapper mapper = EchoObjectMapper.getInstance();
 
-  @Value("${spinnaker.base-url")
+  @Value("${spinnaker.base-url}")
   protected String spinnakerUrl;
 
   public abstract String getNotificationType();


### PR DESCRIPTION
Was missed on the original Groovy -> Java refactor.