### PR TITLE
fix(pubsub): Add ability to control pubsub message processing

### DIFF
--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
@@ -161,6 +161,9 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
 
       receiveMessageResult.getMessages().forEach(this::handleMessage);
     }
+
+    // If isEnabled is false, let's not busy spin
+    Thread.sleep(500);
   }
 
   private void handleMessage(Message message) {

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriber.java
@@ -128,11 +128,7 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
         initializeQueue();
       } catch (Exception e) {
         log.error("Unexpected error running " + getWorkerName() + ", restarting worker", e);
-        try {
-          Thread.sleep(500);
-        } catch (InterruptedException e1) {
-          log.error("Thread {} interrupted while sleeping", getWorkerName(), e1);
-        }
+        sleepALittle();
       }
     }
   }
@@ -163,7 +159,7 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
     }
 
     // If isEnabled is false, let's not busy spin
-    Thread.sleep(500);
+    sleepALittle();
   }
 
   private void handleMessage(Message message) {
@@ -260,5 +256,13 @@ public class SQSSubscriber implements Runnable, PubsubSubscriber {
     return registry
         .createId("echo.pubsub.amazon.failedMessages")
         .withTag("exceptionClass", e.getClass().getSimpleName());
+  }
+
+  private void sleepALittle() {
+    try {
+      Thread.sleep(500);
+    } catch (InterruptedException e1) {
+      log.error("Thread {} interrupted while sleeping", getWorkerName(), e1);
+    }
   }
 }

--- a/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriberProvider.java
+++ b/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/pubsub/aws/SQSSubscriberProvider.java
@@ -150,6 +150,6 @@ public class SQSSubscriberProvider {
   private Supplier<Boolean> isEnabledSupplier() {
     return () ->
         discoveryStatusListener.isEnabled()
-            && dynamicConfigService.isEnabled("pubsub.amazon", true);
+            && dynamicConfigService.isEnabled("pubsub.amazon.processing", true);
   }
 }


### PR DESCRIPTION
Follow up to https://github.com/spinnaker/echo/pull/903
The "problem" with that PR was that the flag used for `isEnabled` (`pubsub.amazon.enabled`) was also the same flag that gated bean creation
for the pubsub components, e.g. [here](https://github.com/spinnaker/echo/blob/master/echo-pubsub-aws/src/main/java/com/netflix/spinnaker/echo/config/AmazonPubsubConfig.java#L28)
This meant that if a server group comes up with `pubsub.amazon` OFF it can never be turned ON on the fly without restarting those instances.
This change, divorces the two concepts into "pubsub enabled" and "pubsub processing enabled" with a new flag `pubsub.amazon.processing.enabled`

Additionally, if processing is turned off we will busy spin, adding a `sleep` to alleviate that
