### PR TITLE
fix(quartz): set org.quartz.jobStore.dontSetAutoCommitFalse

### DIFF
--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/config/SchedulerConfiguration.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/config/SchedulerConfiguration.groovy
@@ -115,6 +115,7 @@ class SchedulerConfiguration {
           props.put("org.quartz.jobStore.isClustered", "true")
           props.put("org.quartz.jobStore.acquireTriggersWithinLock", "true")
           props.put("org.quartz.scheduler.instanceId", "AUTO")
+          props.put("org.quartz.jobStore.dontSetAutoCommitFalse", "false")
           schedulerFactoryBean.setQuartzProperties(props)
         }
         schedulerFactoryBean.setGlobalTriggerListeners(triggerListener)


### PR DESCRIPTION
Noticed that some triggers got wedged in the `ACQUIRED` state. Following the suggestion from http://www.quartz-scheduler.org/documentation/2.3.1-SNAPSHOT/faq.html
Setting `org.quartz.jobStore.dontSetAutoCommitFalse=false`
