### PR TITLE
fix(discovery): Respect discovery status

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@
 plugins {
   id 'io.spinnaker.project' version "$spinnakerGradleVersion" apply false
   id "org.jetbrains.kotlin.jvm" version "$kotlinVersion" apply false
+  id 'com.adarshr.test-logger' version '2.1.0'
 }
 
 subprojects {
@@ -34,6 +35,7 @@ subprojects {
     apply plugin: "java-library"
     apply plugin: "groovy"
     apply plugin: 'jacoco'
+    apply plugin: 'com.adarshr.test-logger'
 
     test {
       testLogging {

--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgent.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgent.java
@@ -164,7 +164,7 @@ public abstract class AbstractEventNotificationAgent implements EventListener {
     }
 
     List<Map<String, Object>> notifications =
-        (List<Map<String, Object>>) context.get("notifications");
+        (List<Map<String, Object>>) context.getOrDefault("notifications", Collections.emptyList());
 
     return notifications.stream()
         .filter(it -> shouldSendRequestForNotification(it, configType, status))

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/config/SchedulerConfiguration.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/config/SchedulerConfiguration.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.config
 
 import com.netflix.spinnaker.echo.scheduler.actions.pipeline.PipelineConfigsPollingJob
 import com.netflix.spinnaker.echo.scheduler.actions.pipeline.PipelineTriggerJob
+import com.netflix.spinnaker.echo.scheduler.actions.pipeline.QuartzDiscoveryActivator
 import com.netflix.spinnaker.echo.scheduler.actions.pipeline.TriggerConverter
 import com.netflix.spinnaker.echo.scheduler.actions.pipeline.TriggerListener
 import com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration
@@ -121,5 +122,10 @@ class SchedulerConfiguration {
         schedulerFactoryBean.setGlobalTriggerListeners(triggerListener)
       }
     }
+  }
+
+  @Bean
+  QuartzDiscoveryActivator quartzDiscoveryActivator(SchedulerFactoryBean schedulerFactory) {
+    return new QuartzDiscoveryActivator(schedulerFactory.getScheduler())
   }
 }

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/QuartzDiscoveryActivator.java
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/scheduler/actions/pipeline/QuartzDiscoveryActivator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.echo.scheduler.actions.pipeline;
+
+import com.netflix.spinnaker.kork.discovery.InstanceStatus;
+import com.netflix.spinnaker.kork.discovery.RemoteStatusChangedEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.springframework.context.ApplicationListener;
+
+@Slf4j
+public class QuartzDiscoveryActivator implements ApplicationListener<RemoteStatusChangedEvent> {
+  private final Scheduler scheduler;
+
+  public QuartzDiscoveryActivator(Scheduler scheduler) {
+    this.scheduler = scheduler;
+  }
+
+  @Override
+  public void onApplicationEvent(RemoteStatusChangedEvent event) {
+    if (event.getSource().getStatus() == InstanceStatus.UP) {
+      log.info("Instance is ${e.status}... resuming quartz scheduler");
+      try {
+        scheduler.start();
+      } catch (SchedulerException e) {
+        log.warn("Failed to resume quartz scheduler", e);
+      }
+    } else if (event.getSource().getPreviousStatus() == InstanceStatus.UP) {
+      log.info("Instance is ${e.status}... placing quartz into standby");
+      try {
+        scheduler.standby();
+      } catch (SchedulerException e) {
+        log.warn("Failed to place quartz scheduler into standby", e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add discovery status check for triggering, polling pipelines configs, and pausing/resuming quartz based on discovery status
