### PR TITLE
fix(discovery): Undo respecting discovery for config poller

### DIFF
--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheSpec.groovy
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.echo.model.Trigger
 import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService
 import com.netflix.spinnaker.echo.services.Front50Service
 import com.netflix.spinnaker.echo.test.RetrofitStubs
-import com.netflix.spinnaker.kork.discovery.DiscoveryStatusListener
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
@@ -38,7 +37,6 @@ class PipelineCacheSpec extends Specification implements RetrofitStubs {
   def orca = Mock(OrcaService)
   def registry = new NoopRegistry()
   def objectMapper = EchoObjectMapper.getInstance()
-  def activator = Mock(DiscoveryStatusListener)
 
   @Shared
   def interval = 30
@@ -47,7 +45,7 @@ class PipelineCacheSpec extends Specification implements RetrofitStubs {
   def sleepMs = 100
 
   @Subject
-  def pipelineCache = new PipelineCache(Mock(ScheduledExecutorService), interval, sleepMs, objectMapper, activator, front50, orca, registry)
+  def pipelineCache = new PipelineCache(Mock(ScheduledExecutorService), interval, sleepMs, objectMapper, front50, orca, registry)
 
   def "keeps polling if Front50 returns an error"() {
     given:
@@ -57,8 +55,6 @@ class PipelineCacheSpec extends Specification implements RetrofitStubs {
       id         : 'P1'
     ]
     def pipeline = Pipeline.builder().application('application').name('Pipeline').id('P1').build()
-
-    activator.isEnabled() >> true
 
     def initialLoad = []
     front50.getPipelines() >> initialLoad >> { throw unavailable() } >> [pipelineMap]


### PR DESCRIPTION
Follow up to https://github.com/spinnaker/echo/pull/1050
Apparently, being `UP` is predicated on the config poller having successfully run. But now that I made configpoller predicated on being `UP` echo doesn't come up...
There is no harm (just wasted RPS) for disabled instances getting config, so I am undoing this part of the change.
Just leaving the discovery activated part for scheduler

I didn't catch this because I tested with discovery being OFF and then turning it OFF and not the other way around.
