### PR TITLE
chore(pubsub): don't allow overriding of bean

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/PipelineTriggerConfiguration.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/PipelineTriggerConfiguration.java
@@ -18,7 +18,6 @@ import java.util.concurrent.Executors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -70,7 +69,6 @@ public class PipelineTriggerConfiguration {
   }
 
   @Bean
-  @ConditionalOnMissingBean(PubsubEventHandler.class)
   PubsubEventHandler pubsubEventHandler(
       Registry registry,
       ObjectMapper objectMapper,

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandler.java
@@ -97,7 +97,7 @@ public class PubsubEventHandler extends BaseTriggerEventHandler<PubsubEvent> {
     MessageDescription description = pubsubEvent.getContent().getMessageDescription();
 
     return trigger ->
-        trigger.getType().equalsIgnoreCase(PUBSUB_TRIGGER_TYPE)
+        supportedTriggerTypes().contains(trigger.getType())
             && trigger.getPubsubSystem().equalsIgnoreCase(description.getPubsubSystem().toString())
             && trigger.getSubscriptionName().equalsIgnoreCase(description.getSubscriptionName())
             && (trigger.getPayloadConstraints() == null


### PR DESCRIPTION
A while ago I added the ability to override the pubsub event handler because I was doing custom stuff. I'm removing this capability because the way we ended up implementing things means its fine for the handlers to run side by side.

Also making a small change to the pubsub handler to read the list of supported trigger types from the already defined function.