### PR TITLE
feat(constraint): support jsonpath expression in payload constraint key

### DIFF
--- a/echo-pipelinetriggers/echo-pipelinetriggers.gradle
+++ b/echo-pipelinetriggers/echo-pipelinetriggers.gradle
@@ -47,6 +47,7 @@ dependencies {
   implementation "commons-codec:commons-codec"
 
   implementation 'com.vdurmont:semver4j'
+  implementation "com.jayway.jsonpath:json-path"
 
   testImplementation project(':echo-test')
   testImplementation "org.springframework.boot:spring-boot-starter-test"

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
@@ -112,7 +112,7 @@ public class ArtifactMatcher {
 
     for (Object key : constraints.keySet()) {
       if (!payload.containsKey(key) || payload.get(key) == null) {
-        log.info("key not present in payload, needs to check with jsonpath");
+        log.debug("key not present in payload, needs to check with jsonpath");
         List<String> values = getValueUsingJsonPath(documentContext, key.toString());
         if (values != null && anyMatch(constraints.get(key).toString(), values)) {
           continue;

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/WebhookEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/WebhookEventHandler.java
@@ -14,7 +14,7 @@
 
 package com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers;
 
-import static com.netflix.spinnaker.echo.pipelinetriggers.artifacts.ArtifactMatcher.isConstraintInPayload;
+import static com.netflix.spinnaker.echo.pipelinetriggers.artifacts.ArtifactMatcher.isJsonPathConstraintInPayload;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spectator.api.Registry;
@@ -104,7 +104,7 @@ public class WebhookEventHandler extends BaseTriggerEventHandler<WebhookEvent> {
                 // If the Constraints are present, check that there are equivalents in the webhook
                 // payload.
                 (trigger.getPayloadConstraints() != null
-                    && isConstraintInPayload(
+                    && isJsonPathConstraintInPayload(
                         trigger.getPayloadConstraints(), webhookEvent.getPayload())));
   }
 

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcherSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcherSpec.groovy
@@ -91,6 +91,11 @@ class ArtifactMatcherSpec extends Specification {
     "\$.one.test2.changes[a].value": "bar"
   ]
 
+  def multipleJsonPathConstraints = [
+    "\$.one.test1.title": "st",
+    "\$.one.test2.title": "no match"
+  ]
+
   def complexPayload = [
     "one": [
       "test1": [
@@ -285,6 +290,14 @@ class ArtifactMatcherSpec extends Specification {
   def "no match when bad expression using JSONPath constraint with multi-level json"() {
     when:
     boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(jsonPathConstraintsBadJsonPath, complexPayload)
+
+    then:
+    !result
+  }
+
+  def "no match when multiple JSONPath constraints with multi-level json"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(multipleJsonPathConstraints, complexPayload)
 
     then:
     !result

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcherSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcherSpec.groovy
@@ -138,81 +138,130 @@ class ArtifactMatcherSpec extends Specification {
 
   def "matches when constraint is partial word"() {
     when:
-    boolean resultOld = ArtifactMatcher.isConstraintInPayload(shortConstraint, matchPayload)
-    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(shortConstraint, matchPayload)
+    boolean result = ArtifactMatcher.isConstraintInPayload(shortConstraint, matchPayload)
 
     then:
-    resultOld && resultNew
+    result
   }
 
   def "matches exact string"() {
     when:
-    boolean resultOld = ArtifactMatcher.isConstraintInPayload(contstraints, matchPayload)
-    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(contstraints, matchPayload)
-
+    boolean result = ArtifactMatcher.isConstraintInPayload(contstraints, matchPayload)
 
     then:
-    resultOld && resultNew
+    result
   }
 
   def "no match when constraint word not present"() {
     when:
-    boolean resultOld = ArtifactMatcher.isConstraintInPayload(contstraints, noMatchPayload)
-    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(contstraints, noMatchPayload)
-
+    boolean result = ArtifactMatcher.isConstraintInPayload(contstraints, noMatchPayload)
 
     then:
-    !resultOld && !resultNew
+    !result
   }
 
   def "matches when payload value is in a list of constraint strings"() {
     when:
-    boolean resultOld = ArtifactMatcher.isConstraintInPayload(constraintsOR, matchPayload)
-    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(constraintsOR, matchPayload)
-
+    boolean result = ArtifactMatcher.isConstraintInPayload(constraintsOR, matchPayload)
 
     then:
-    resultOld && resultNew
+    result
   }
 
   def "no match when val not present in list of constraint strings"() {
     when:
-    boolean resultOld = ArtifactMatcher.isConstraintInPayload(constraintsOR, noMatchPayload)
-    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(constraintsOR, noMatchPayload)
-
+    boolean result = ArtifactMatcher.isConstraintInPayload(constraintsOR, noMatchPayload)
 
     then:
-    !resultOld && !resultNew
+    !result
   }
 
   def "matches when val is in stringified list of constraints"() {
     when:
-    boolean resultOld = ArtifactMatcher.isConstraintInPayload(stringifiedListConstraints, matchPayload)
-    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(stringifiedListConstraints, matchPayload)
-
+    boolean result = ArtifactMatcher.isConstraintInPayload(stringifiedListConstraints, matchPayload)
 
     then:
-    resultOld && resultNew
+    result
   }
 
   def "matches when payload contains list and constraint is a stringified list"() {
     when:
-    boolean resultOld = ArtifactMatcher.isConstraintInPayload(stringifiedListConstraints, payloadWithList)
-    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(stringifiedListConstraints, payloadWithList)
-
+    boolean result = ArtifactMatcher.isConstraintInPayload(stringifiedListConstraints, payloadWithList)
 
     then:
-    resultOld && resultNew
+    result
   }
 
   def "matches when payload is a list list and constraints are a list"() {
     when:
-    boolean resultOld = ArtifactMatcher.isConstraintInPayload(constraintsOR, payloadWithList)
-    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(constraintsOR, payloadWithList)
-
+    boolean result = ArtifactMatcher.isConstraintInPayload(constraintsOR, payloadWithList)
 
     then:
-    resultOld && resultNew
+    result
+  }
+
+  def "matches when constraint is partial word using Jsonpath"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(shortConstraint, matchPayload)
+
+    then:
+    result
+  }
+
+  def "matches exact string using Jsonpath"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(contstraints, matchPayload)
+
+    then:
+    result
+  }
+
+  def "no match when constraint word not present using Jsonpath"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(contstraints, noMatchPayload)
+
+    then:
+    !result
+  }
+
+  def "matches when payload value is in a list of constraint strings using Jsonpath"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(constraintsOR, matchPayload)
+
+    then:
+    result
+  }
+
+  def "no match when val not present in list of constraint strings using Jsonpath"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(constraintsOR, noMatchPayload)
+
+    then:
+    !result
+  }
+
+  def "matches when val is in stringified list of constraints using Jsonpath"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(stringifiedListConstraints, matchPayload)
+
+    then:
+    result
+  }
+
+  def "matches when payload contains list and constraint is a stringified list using Jsonpath"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(stringifiedListConstraints, payloadWithList)
+
+    then:
+    result
+  }
+
+  def "matches when payload is a list list and constraints are a list using Jsonpath"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(constraintsOR, payloadWithList)
+
+    then:
+    result
   }
 
   def "matches when val is a string using JSONPath constraint with multi-level json"() {

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcherSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcherSpec.groovy
@@ -27,8 +27,8 @@ class ArtifactMatcherSpec extends Specification {
   ]
 
   def noMatchPayload = [
-      "four": "four",
-      "five": "five"
+    "four": "four",
+    "five": "five"
   ]
 
   def contstraints = [
@@ -40,78 +40,255 @@ class ArtifactMatcherSpec extends Specification {
   ]
 
   def constraintsOR = [
-      "one": ["uno", "one"]
+    "one": ["uno", "one"]
   ]
 
   def payloadWithList = [
-      "one": ["one"]
+    "one": ["one"]
   ]
 
   def stringifiedListConstraints = [
     "one": "['uno', 'one']"
   ]
 
+  def jsonPathConstraintsToString = [
+    "\$.one.test1.title": "st"
+  ]
+
+  def jsonPathConstraintsToStringNOT = [
+    "\$.one.test2.title": "no match"
+  ]
+
+  def jsonPathConstraintsToBool = [
+    "\$.one.test1.isValid": "true"
+  ]
+
+  def jsonPathConstraintsToList = [
+    "\$.one.test1.modified": ".yml"
+  ]
+
+  def jsonPathConstraintsToListNOT = [
+    "\$.one.test1.modified": ".xml"
+  ]
+
+  def jsonPathConstraintsToObject = [
+    "\$.one.test1.author": "edgar"
+  ]
+
+  def jsonPathConstraintsToNumber = [
+    "\$.two.test3.count": "3"
+  ]
+
+  def jsonPathConstraintsToListOfObjects = [
+    "\$.two.test2.changes": "bar"
+  ]
+
+  def jsonPathConstraintsToUnknownField = [
+    "\$.two.test4.changes": "bar"
+  ]
+
+  def jsonPathConstraintsBadJsonPath = [
+    "\$.one.test2.changes[a].value": "bar"
+  ]
+
+  def complexPayload = [
+    "one": [
+      "test1": [
+        "title": "test",
+        "modified": ["folder1/file1.txt", "folder1/file2.txt", "folder2/file1.yml"],
+        "isValid": true,
+        "author": [
+          "name": "edgar",
+          "username": "edgarulg"
+        ]
+      ],
+      "test2": [
+        "title": "another test",
+        "created": ["folder3/new.txt"],
+        "isValid": false,
+        "author": [
+          "name": "jorge",
+          "username": "jorge123"
+        ],
+        "changes": [
+          [
+            "id": 1,
+            "value": "foo"
+          ],
+          [
+            "id": 2,
+            "value": "bar"
+          ]
+        ]
+      ]
+    ],
+    "two": [
+      "test3": [
+        "count": 3,
+        "ref": null,
+        "isActive": false
+      ]
+    ]
+  ]
+
   def "matches when constraint is partial word"() {
     when:
-    boolean result = ArtifactMatcher.isConstraintInPayload(shortConstraint, matchPayload)
+    boolean resultOld = ArtifactMatcher.isConstraintInPayload(shortConstraint, matchPayload)
+    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(shortConstraint, matchPayload)
 
     then:
-    result
+    resultOld && resultNew
   }
 
   def "matches exact string"() {
     when:
-    boolean result = ArtifactMatcher.isConstraintInPayload(contstraints, matchPayload)
+    boolean resultOld = ArtifactMatcher.isConstraintInPayload(contstraints, matchPayload)
+    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(contstraints, matchPayload)
+
 
     then:
-    result
+    resultOld && resultNew
   }
 
   def "no match when constraint word not present"() {
     when:
-    boolean result = ArtifactMatcher.isConstraintInPayload(contstraints, noMatchPayload)
+    boolean resultOld = ArtifactMatcher.isConstraintInPayload(contstraints, noMatchPayload)
+    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(contstraints, noMatchPayload)
+
 
     then:
-    !result
+    !resultOld && !resultNew
   }
 
   def "matches when payload value is in a list of constraint strings"() {
     when:
-    boolean result = ArtifactMatcher.isConstraintInPayload(constraintsOR, matchPayload)
+    boolean resultOld = ArtifactMatcher.isConstraintInPayload(constraintsOR, matchPayload)
+    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(constraintsOR, matchPayload)
+
+
+    then:
+    resultOld && resultNew
+  }
+
+  def "no match when val not present in list of constraint strings"() {
+    when:
+    boolean resultOld = ArtifactMatcher.isConstraintInPayload(constraintsOR, noMatchPayload)
+    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(constraintsOR, noMatchPayload)
+
+
+    then:
+    !resultOld && !resultNew
+  }
+
+  def "matches when val is in stringified list of constraints"() {
+    when:
+    boolean resultOld = ArtifactMatcher.isConstraintInPayload(stringifiedListConstraints, matchPayload)
+    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(stringifiedListConstraints, matchPayload)
+
+
+    then:
+    resultOld && resultNew
+  }
+
+  def "matches when payload contains list and constraint is a stringified list"() {
+    when:
+    boolean resultOld = ArtifactMatcher.isConstraintInPayload(stringifiedListConstraints, payloadWithList)
+    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(stringifiedListConstraints, payloadWithList)
+
+
+    then:
+    resultOld && resultNew
+  }
+
+  def "matches when payload is a list list and constraints are a list"() {
+    when:
+    boolean resultOld = ArtifactMatcher.isConstraintInPayload(constraintsOR, payloadWithList)
+    boolean resultNew = ArtifactMatcher.isJsonPathConstraintInPayload(constraintsOR, payloadWithList)
+
+
+    then:
+    resultOld && resultNew
+  }
+
+  def "matches when val is a string using JSONPath constraint with multi-level json"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(jsonPathConstraintsToString, complexPayload)
 
     then:
     result
   }
 
-  def "no match when val not present in list of constraint strings"() {
+  def "no match when val is a string using JSONPath constraint with multi-level json"() {
     when:
-    boolean result = ArtifactMatcher.isConstraintInPayload(constraintsOR, noMatchPayload)
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(jsonPathConstraintsToStringNOT, complexPayload)
 
     then:
     !result
   }
 
-  def "matches when val is in stringified list of constraints"() {
+  def "matches when val is a boolean using JSONPath constraint with multi-level json"() {
     when:
-    boolean result = ArtifactMatcher.isConstraintInPayload(stringifiedListConstraints, matchPayload)
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(jsonPathConstraintsToBool, complexPayload)
 
     then:
     result
   }
 
-  def "matches when payload contains list and constraint is a stringified list"() {
+  def "matches when val is a number using JSONPath constraint with multi-level json"() {
     when:
-    boolean result = ArtifactMatcher.isConstraintInPayload(stringifiedListConstraints, payloadWithList)
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(jsonPathConstraintsToNumber, complexPayload)
 
     then:
     result
   }
 
-  def "matches when payload is a list list and constraints are a list"() {
+  def "matches when val is a List<String> using JSONPath constraint with multi-level json"() {
     when:
-    boolean result = ArtifactMatcher.isConstraintInPayload(constraintsOR, payloadWithList)
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(jsonPathConstraintsToList, complexPayload)
 
     then:
     result
   }
+
+  def "no matches when val is a List<String> using JSONPath constraint with multi-level json"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(jsonPathConstraintsToListNOT, complexPayload)
+
+    then:
+    !result
+  }
+
+  def "no match when val is an Object using JSONPath constraint with multi-level json"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(jsonPathConstraintsToObject, complexPayload)
+
+    then:
+    !result
+  }
+
+  def "no match when val is a List<Map> using JSONPath constraint with multi-level json"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(jsonPathConstraintsToListOfObjects, complexPayload)
+
+    then:
+    !result
+  }
+
+  def "no match when field not found using JSONPath constraint with multi-level json"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(jsonPathConstraintsToUnknownField, complexPayload)
+
+    then:
+    !result
+  }
+
+  def "no match when bad expression using JSONPath constraint with multi-level json"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(jsonPathConstraintsBadJsonPath, complexPayload)
+
+    then:
+    !result
+  }
+
+
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 fiatVersion=1.26.0
-korkVersion=7.97.2
+korkVersion=7.98.0
 kotlinVersion=1.4.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.10.1


### PR DESCRIPTION
This changes is about support [JsonPath](https://github.com/json-path/JsonPath) expressions in the payload constraints for Webhook triggers.

The initial issue opened for request this is here: https://github.com/spinnaker/spinnaker/issues/3643

This feature enable users to include a JsonPath expression in the key of a payload constraint, so it first check if the key is present in first level json key (as it currently works). If the key is not present in the first level json, it will try to search the value in the payload using the key as a jsonpath expression then if exists it try to match with the regex provided.

Payload Constraint examples:
  **Key** | **Value**  
foo   :   bar
foo   :   *ar
$.foo.bar  :  *ar

The json expression must be a valid jsonpath expression and it must point to a value that can be cast to String. (String, Number, Boolean, etc). A List<String> is a valid value, and the regex will be applied to every string on the list.

The constraint will return false when the expression points to an Object, List<Objects> or the field does not exist.

