### PR TITLE
fix(notifications): Support new Microsoft Teams webhook URLs

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/MicrosoftTeamsConfig.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/MicrosoftTeamsConfig.java
@@ -16,19 +16,13 @@
 
 package com.netflix.spinnaker.echo.config;
 
-import static retrofit.Endpoints.newFixedEndpoint;
-
-import com.netflix.spinnaker.echo.microsoftteams.MicrosoftTeamsClient;
 import com.netflix.spinnaker.echo.microsoftteams.MicrosoftTeamsService;
-import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import retrofit.Endpoint;
 import retrofit.RestAdapter;
 import retrofit.client.Client;
-import retrofit.converter.JacksonConverter;
 
 @Configuration
 @ConditionalOnProperty("microsoftteams.enabled")
@@ -36,26 +30,10 @@ import retrofit.converter.JacksonConverter;
 public class MicrosoftTeamsConfig {
 
   @Bean
-  public Endpoint teamsEndpoint() {
-    return newFixedEndpoint("https://outlook.office.com/webhook");
-  }
-
-  @Bean
   public MicrosoftTeamsService microsoftTeamsService(
-      Endpoint teamsEndpoint, Client retrofitClient, RestAdapter.LogLevel retrofitLogLevel) {
-
+      Client retrofitClient, RestAdapter.LogLevel retrofitLogLevel) {
     log.info("Microsoft Teams service loaded");
 
-    MicrosoftTeamsClient microsoftTeamsClient =
-        new RestAdapter.Builder()
-            .setConverter(new JacksonConverter())
-            .setClient(retrofitClient)
-            .setEndpoint(teamsEndpoint)
-            .setLogLevel(retrofitLogLevel)
-            .setLog(new Slf4jRetrofitLogger(MicrosoftTeamsClient.class))
-            .build()
-            .create(MicrosoftTeamsClient.class);
-
-    return new MicrosoftTeamsService(microsoftTeamsClient);
+    return new MicrosoftTeamsService(retrofitClient, retrofitLogLevel);
   }
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsNotificationService.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsNotificationService.java
@@ -91,12 +91,9 @@ class MicrosoftTeamsNotificationService implements NotificationService {
 
     for (String webhookUrl : notification.getTo()) {
       log.info("Sending Microsoft Teams event notification");
-      log.debug("Teams Webhook Url: " + webhookUrl);
+      log.debug("Teams Webhook URL: " + webhookUrl);
 
-      String baseUrl = "https://outlook.office.com/webhook/";
-      String completeLink = webhookUrl;
-      String partialWebhookURL = completeLink.substring(baseUrl.length());
-      teamsService.sendMessage(partialWebhookURL, teamsMessage);
+      teamsService.sendMessage(webhookUrl, teamsMessage);
     }
 
     return new EchoResponse.Void();

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsNotificationService.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsNotificationService.java
@@ -91,7 +91,7 @@ class MicrosoftTeamsNotificationService implements NotificationService {
 
     for (String webhookUrl : notification.getTo()) {
       log.info("Sending Microsoft Teams event notification");
-      log.debug("Teams Webhook URL: " + webhookUrl);
+      log.debug("Teams Webhook URL: {}", webhookUrl);
 
       teamsService.sendMessage(webhookUrl, teamsMessage);
     }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsService.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsService.java
@@ -38,14 +38,6 @@ public class MicrosoftTeamsService {
   }
 
   public Response sendMessage(String webhookUrl, MicrosoftTeamsMessage message) {
-    // As of Jan 2021, Microsoft has migrated to a new webhook URL where the hostname can be
-    // dynamic.
-    //
-    // In order to support both old and new URLs, and since retrofit 1.x does not support dynamic
-    // URLs,
-    // the endpoint and relative path must be derived from the full webhook URL.
-    // The RestAdapter does not provide any methods to change the endpoint URL once it's created,
-    // so this object must be instantiated with a new endpoint URL for each message.
     MicrosoftTeamsClient microsoftTeamsClient =
         new RestAdapter.Builder()
             .setConverter(new JacksonConverter())

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsService.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsService.java
@@ -38,6 +38,8 @@ public class MicrosoftTeamsService {
   }
 
   public Response sendMessage(String webhookUrl, MicrosoftTeamsMessage message) {
+    // The RestAdapter instantiation needs to occur for each message to be sent as
+    // the incoming webhook base URL and path may be different for each Teams channel
     MicrosoftTeamsClient microsoftTeamsClient =
         new RestAdapter.Builder()
             .setConverter(new JacksonConverter())
@@ -52,17 +54,13 @@ public class MicrosoftTeamsService {
   }
 
   private String getEndpointUrl(String webhookUrl) {
-    String baseUrl = "";
-
     try {
       URL url = new URL(webhookUrl);
-      baseUrl = url.getProtocol() + "://" + url.getHost();
+      return url.getProtocol() + "://" + url.getHost();
     } catch (MalformedURLException e) {
       throw new InvalidRequestException(
           "Unable to determine base URL from Microsoft Teams webhook URL.", e);
     }
-
-    return baseUrl;
   }
 
   private String getRelativePath(String webhookUrl) {
@@ -82,7 +80,7 @@ public class MicrosoftTeamsService {
 
     // Remove slash from beginning of path as the client will prefix the string with a slash
     if (relativePath.charAt(0) == '/') {
-      relativePath = relativePath.substring(1, relativePath.length());
+      relativePath = relativePath.substring(1);
     }
 
     return relativePath;

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsService.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsService.java
@@ -57,8 +57,9 @@ public class MicrosoftTeamsService {
     try {
       URL url = new URL(webhookUrl);
       baseUrl = url.getProtocol() + "://" + url.getHost();
-    } catch(MalformedURLException e) {
-      throw new InvalidRequestException("Unable to determine base URL from Microsoft Teams webhook URL.", e);
+    } catch (MalformedURLException e) {
+      throw new InvalidRequestException(
+          "Unable to determine base URL from Microsoft Teams webhook URL.", e);
     }
 
     return baseUrl;
@@ -74,8 +75,9 @@ public class MicrosoftTeamsService {
       if (StringUtils.isEmpty(relativePath)) {
         throw new MalformedURLException();
       }
-    } catch(MalformedURLException e) {
-      throw new InvalidRequestException("Unable to determine relative path from Microsoft Teams webhook URL.", e);
+    } catch (MalformedURLException e) {
+      throw new InvalidRequestException(
+          "Unable to determine relative path from Microsoft Teams webhook URL.", e);
     }
 
     // Remove slash from beginning of path as the client will prefix the string with a slash

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/MicrosoftTeamsNotificationAgent.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/MicrosoftTeamsNotificationAgent.java
@@ -138,12 +138,10 @@ public class MicrosoftTeamsNotificationAgent extends AbstractEventNotificationAg
     teamsMessage.addSection(section);
 
     log.info("Sending Microsoft Teams notification");
-    String baseUrl = "https://outlook.office.com/webhook/";
-    String completeLink =
+    String webhookUrl =
         Optional.ofNullable(preference).map(p -> (String) p.get("address")).orElse(null);
 
-    String partialWebhookURL = completeLink.substring(baseUrl.length());
-    Response response = teamsService.sendMessage(partialWebhookURL, teamsMessage);
+    Response response = teamsService.sendMessage(webhookUrl, teamsMessage);
 
     log.info(
         "Received response from Microsoft Teams Webhook  : {} {} for execution id {}. {}",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 fiatVersion=1.26.0
-korkVersion=7.97.2
+korkVersion=7.98.0
 kotlinVersion=1.4.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.10.1


### PR DESCRIPTION
This PR adds support for new webhook URLs for Microsoft Teams notifications.

See issue https://github.com/spinnaker/spinnaker/issues/6324 for more details.