### PR TITLE
feat(jira): Add Jira issue transition to JiraNotificationService

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/JiraConfig.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/JiraConfig.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.config;
 
 import static retrofit.Endpoints.newFixedEndpoint;
 
+import com.netflix.spinnaker.echo.jackson.EchoObjectMapper;
 import com.netflix.spinnaker.echo.jira.JiraProperties;
 import com.netflix.spinnaker.echo.jira.JiraService;
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger;
@@ -54,7 +55,7 @@ public class JiraConfig {
     RestAdapter.Builder builder =
         new RestAdapter.Builder()
             .setEndpoint(newFixedEndpoint(jiraProperties.getBaseUrl()))
-            .setConverter(new JacksonConverter())
+            .setConverter(new JacksonConverter(EchoObjectMapper.getInstance()))
             .setClient(retrofitClient)
             .setLogLevel(retrofitLogLevel)
             .setLog(new Slf4jRetrofitLogger(JiraService.class));

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/jira/JiraNotificationService.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/jira/JiraNotificationService.java
@@ -22,13 +22,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.echo.api.Notification;
 import com.netflix.spinnaker.echo.controller.EchoResponse;
-import com.netflix.spinnaker.echo.jira.JiraService.CreateJiraIssueRequest;
-import com.netflix.spinnaker.echo.jira.JiraService.CreateJiraIssueResponse;
+import com.netflix.spinnaker.echo.jira.JiraService.CreateIssueRequest;
+import com.netflix.spinnaker.echo.jira.JiraService.CreateIssueResponse;
+import com.netflix.spinnaker.echo.jira.JiraService.IssueTransitions;
+import com.netflix.spinnaker.echo.jira.JiraService.TransitionIssueRequest;
 import com.netflix.spinnaker.echo.notification.NotificationService;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,36 +40,85 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import retrofit.RetrofitError;
+import retrofit.client.Response;
 
 @Component
 @ConditionalOnProperty("jira.enabled")
 public class JiraNotificationService implements NotificationService {
   private static final Logger LOGGER = LoggerFactory.getLogger(JiraNotificationService.class);
   private static final int MAX_RETRY = 3;
-  private static final long RETRY_BACKOFF = 3;
+  private static final long RETRY_BACKOFF = 100;
 
   private final JiraService jiraService;
   private final RetrySupport retrySupport;
   private final ObjectMapper mapper;
 
   @Autowired
-  public JiraNotificationService(JiraService jiraService, ObjectMapper objectMapper) {
+  public JiraNotificationService(
+      JiraService jiraService, RetrySupport retrySupport, ObjectMapper objectMapper) {
     this.jiraService = jiraService;
-    this.retrySupport = new RetrySupport();
+    this.retrySupport = retrySupport;
     this.mapper = objectMapper;
   }
 
   @Override
   public boolean supportsType(String type) {
-    return "JIRA".equals(type.toUpperCase());
+    return "JIRA".equalsIgnoreCase(type);
   }
 
   @Override
-  public EchoResponse<CreateJiraIssueResponse> handle(Notification notification) {
+  public EchoResponse handle(Notification notification) {
+    return isTransition(notification) ? transitionIssue(notification) : create(notification);
+  }
+
+  private boolean isTransition(Notification notification) {
+    return notification.getAdditionalContext().get("transitionContext") != null;
+  }
+
+  private EchoResponse.Void transitionIssue(Notification notification) {
+    Map<String, Object> transitionContext =
+        (Map<String, Object>) notification.getAdditionalContext().get("transitionContext");
+    String jiraIssue = (String) notification.getAdditionalContext().get("jiraIssue");
+
+    try {
+      // transitionContext is the full Jira transition API payload - except the transition ID is
+      // probably unknown.  So, we get the transition ID from the transition name.
+      Map<String, String> transition = (Map<String, String>) transitionContext.get("transition");
+      String transitionName = transition.get("name");
+      IssueTransitions issueTransitions =
+          retrySupport.retry(getIssueTransitions(jiraIssue), MAX_RETRY, RETRY_BACKOFF, false);
+
+      issueTransitions.getTransitions().stream()
+          .filter(it -> it.getName().equals(transitionName))
+          .findFirst()
+          .ifPresentOrElse(
+              t -> transition.put("id", t.getId()),
+              () -> {
+                throw new IllegalArgumentException(
+                    ImmutableMap.of(
+                            "issue", jiraIssue,
+                            "transitionName", transitionName,
+                            "validTransitionNames",
+                                issueTransitions.getTransitions().stream()
+                                    .map(IssueTransitions.Transition::getName)
+                                    .collect(Collectors.toList()))
+                        .toString());
+              });
+
+      retrySupport.retry(
+          transitionIssue(jiraIssue, transitionContext), MAX_RETRY, RETRY_BACKOFF, false);
+      return new EchoResponse.Void();
+    } catch (Exception e) {
+      throw new TransitionJiraIssueException(
+          String.format("Failed to transition Jira issue %s: %s", jiraIssue, errors(e)), e);
+    }
+  }
+
+  private EchoResponse<CreateIssueResponse> create(Notification notification) {
     Map<String, Object> issueRequestBody = issueRequestBody(notification);
     try {
-      CreateJiraIssueResponse response =
-          retrySupport.retry(createJiraIssue(issueRequestBody), MAX_RETRY, RETRY_BACKOFF, false);
+      CreateIssueResponse response =
+          retrySupport.retry(createIssue(issueRequestBody), MAX_RETRY, RETRY_BACKOFF, false);
 
       return new EchoResponse<>(response);
     } catch (Exception e) {
@@ -78,8 +130,18 @@ public class JiraNotificationService implements NotificationService {
     }
   }
 
-  private Supplier<CreateJiraIssueResponse> createJiraIssue(Map<String, Object> issueRequestBody) {
-    return () -> jiraService.createJiraIssue(new CreateJiraIssueRequest(issueRequestBody));
+  private Supplier<IssueTransitions> getIssueTransitions(String issueIdOrKey) {
+    return () -> jiraService.getIssueTransitions(issueIdOrKey);
+  }
+
+  private Supplier<Response> transitionIssue(
+      String issueIdOrKey, Map<String, Object> issueRequestBody) {
+    return () ->
+        jiraService.transitionIssue(issueIdOrKey, new TransitionIssueRequest(issueRequestBody));
+  }
+
+  private Supplier<CreateIssueResponse> createIssue(Map<String, Object> issueRequestBody) {
+    return () -> jiraService.createIssue(new CreateIssueRequest(issueRequestBody));
   }
 
   private Map<String, Object> issueRequestBody(Notification notification) {
@@ -110,6 +172,13 @@ public class JiraNotificationService implements NotificationService {
   @ResponseStatus(value = HttpStatus.BAD_REQUEST)
   static class CreateJiraIssueException extends RuntimeException {
     public CreateJiraIssueException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+  static class TransitionJiraIssueException extends RuntimeException {
+    public TransitionJiraIssueException(String message, Throwable cause) {
       super(message, cause);
     }
   }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/jira/JiraService.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/jira/JiraService.java
@@ -18,21 +18,72 @@ package com.netflix.spinnaker.echo.jira;
 
 import com.netflix.spinnaker.echo.controller.EchoResponse;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import retrofit.client.Response;
 import retrofit.http.Body;
+import retrofit.http.GET;
 import retrofit.http.POST;
+import retrofit.http.Path;
 
 public interface JiraService {
   @POST("/rest/api/2/issue/")
-  CreateJiraIssueResponse createJiraIssue(@Body CreateJiraIssueRequest createJiraIssueRequest);
+  CreateIssueResponse createIssue(@Body CreateIssueRequest createIssueRequest);
 
-  class CreateJiraIssueRequest extends HashMap<String, Object> {
-    CreateJiraIssueRequest(Map<String, Object> body) {
+  @GET("/rest/api/2/issue/{issueIdOrKey}/transitions")
+  IssueTransitions getIssueTransitions(@Path("issueIdOrKey") String issueIdOrKey);
+
+  @POST("/rest/api/2/issue/{issueIdOrKey}/transitions")
+  Response transitionIssue(
+      @Path("issueIdOrKey") String issueIdOrKey,
+      @Body TransitionIssueRequest transitionIssueRequest);
+
+  class CreateIssueRequest extends HashMap<String, Object> {
+    CreateIssueRequest(Map<String, Object> body) {
       super(body);
     }
   }
 
-  class CreateJiraIssueResponse implements EchoResponse.EchoResult {
+  class TransitionIssueRequest extends HashMap<String, Object> {
+    TransitionIssueRequest(Map<String, Object> body) {
+      super(body);
+    }
+  }
+
+  class IssueTransitions {
+    private List<Transition> transitions;
+
+    public List<Transition> getTransitions() {
+      return transitions;
+    }
+
+    public void setTransitions(List<Transition> transitions) {
+      this.transitions = transitions;
+    }
+
+    public static class Transition {
+      private String id;
+      private String name;
+
+      public String getId() {
+        return id;
+      }
+
+      public void setId(String id) {
+        this.id = id;
+      }
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(String name) {
+        this.name = name;
+      }
+    }
+  }
+
+  class CreateIssueResponse implements EchoResponse.EchoResult {
     private String id;
     private String key;
     private String self;

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/jira/JiraService.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/jira/JiraService.java
@@ -38,6 +38,10 @@ public interface JiraService {
       @Path("issueIdOrKey") String issueIdOrKey,
       @Body TransitionIssueRequest transitionIssueRequest);
 
+  @POST("/rest/api/2/issue/{issueIdOrKey}/comment")
+  Response addComment(
+      @Path("issueIdOrKey") String issueIdOrKey, @Body CommentIssueRequest commentIssueRequest);
+
   class CreateIssueRequest extends HashMap<String, Object> {
     CreateIssueRequest(Map<String, Object> body) {
       super(body);
@@ -47,6 +51,22 @@ public interface JiraService {
   class TransitionIssueRequest extends HashMap<String, Object> {
     TransitionIssueRequest(Map<String, Object> body) {
       super(body);
+    }
+  }
+
+  class CommentIssueRequest {
+    private String body;
+
+    CommentIssueRequest(String body) {
+      this.body = body;
+    }
+
+    public String getBody() {
+      return body;
+    }
+
+    public void setBody(String body) {
+      this.body = body;
     }
   }
 

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/jira/JiraNotificationServiceSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/jira/JiraNotificationServiceSpec.groovy
@@ -1,0 +1,38 @@
+package com.netflix.spinnaker.echo.jira
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.echo.api.Notification
+import com.netflix.spinnaker.kork.core.RetrySupport
+import spock.lang.Specification
+
+
+class JiraNotificationServiceSpec extends Specification {
+
+  def jiraService = Mock(JiraService)
+  def retrySupport = new RetrySupport()
+  def objectMapper = Mock(ObjectMapper)
+  JiraNotificationService service = new JiraNotificationService(jiraService, retrySupport, objectMapper)
+
+  void 'Handles Jira transition'() {
+    given:
+    def notification = new Notification(
+      notificationType: "JIRA",
+      source: new Notification.Source(user: "foo@example.com"),
+      additionalContext: [
+        jiraIssue: "EXMPL-0000",
+        transitionContext: [
+          transition: [
+            name: "Done"
+          ]
+        ]
+      ]
+    )
+
+    when:
+    service.handle(notification)
+
+    then:
+    1 * jiraService.getIssueTransitions(_) >> new JiraService.IssueTransitions(transitions: [new JiraService.IssueTransitions.Transition(name: "Done", id: "4")])
+    1 * jiraService.transitionIssue(_, _)
+  }
+}

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/jira/JiraNotificationServiceSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/jira/JiraNotificationServiceSpec.groovy
@@ -2,24 +2,28 @@ package com.netflix.spinnaker.echo.jira
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.echo.api.Notification
+import com.netflix.spinnaker.echo.jackson.EchoObjectMapper
 import com.netflix.spinnaker.kork.core.RetrySupport
 import spock.lang.Specification
+import spock.lang.Unroll
 
 
 class JiraNotificationServiceSpec extends Specification {
 
   def jiraService = Mock(JiraService)
   def retrySupport = new RetrySupport()
-  def objectMapper = Mock(ObjectMapper)
+  def objectMapper = EchoObjectMapper.getInstance()
   JiraNotificationService service = new JiraNotificationService(jiraService, retrySupport, objectMapper)
 
-  void 'Handles Jira transition'() {
+  @Unroll
+  void 'Handles Jira transition, calls comment if comment is set'() {
     given:
     def notification = new Notification(
       notificationType: "JIRA",
       source: new Notification.Source(user: "foo@example.com"),
       additionalContext: [
         jiraIssue: "EXMPL-0000",
+        comment: comment,
         transitionContext: [
           transition: [
             name: "Done"
@@ -34,5 +38,11 @@ class JiraNotificationServiceSpec extends Specification {
     then:
     1 * jiraService.getIssueTransitions(_) >> new JiraService.IssueTransitions(transitions: [new JiraService.IssueTransitions.Transition(name: "Done", id: "4")])
     1 * jiraService.transitionIssue(_, _)
+    addCommentCall * jiraService.addComment(_, _)
+
+    where:
+    comment         || addCommentCall
+    null            || 0
+    "testing 1234"  || 1
   }
 }


### PR DESCRIPTION
`transitionContext` payload can be the full Jira transition REST API payload, however the transition ID will be looked up based on the transition name
