### PR TITLE
chore(logs): allow anonymous call to front50 to get pipelines

### DIFF
--- a/echo-telemetry/echo-telemetry.gradle
+++ b/echo-telemetry/echo-telemetry.gradle
@@ -22,8 +22,8 @@ dependencies {
   implementation project(':echo-core')
   implementation "com.netflix.spinnaker.kork:kork-jedis"
   implementation 'com.google.protobuf:protobuf-java-util'
-  implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.spinnaker.kork:kork-proto"
+  implementation "com.netflix.spinnaker.kork:kork-security"
   implementation 'com.netflix.spinnaker.kork:kork-web'
   implementation 'com.squareup.retrofit:retrofit'
   implementation 'com.squareup.retrofit:converter-jackson'

--- a/echo-telemetry/echo-telemetry.gradle
+++ b/echo-telemetry/echo-telemetry.gradle
@@ -22,6 +22,7 @@ dependencies {
   implementation project(':echo-core')
   implementation "com.netflix.spinnaker.kork:kork-jedis"
   implementation 'com.google.protobuf:protobuf-java-util'
+  implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.spinnaker.kork:kork-proto"
   implementation 'com.netflix.spinnaker.kork:kork-web'
   implementation 'com.squareup.retrofit:retrofit'

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/PipelineCountsDataProvider.kt
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/PipelineCountsDataProvider.kt
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.echo.telemetry
 import com.google.common.base.Suppliers
 import com.netflix.spinnaker.echo.api.events.Event as EchoEvent
 import com.netflix.spinnaker.echo.services.Front50Service
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.kork.proto.stats.Event as StatsEvent
 import java.util.concurrent.TimeUnit
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -45,7 +46,7 @@ class PipelineCountsDataProvider(private val front50: Front50Service) : Telemetr
   }
 
   private fun retrievePipelines(): Map<String, Int> {
-    return front50.pipelines
+    return AuthenticatedRequest.allowAnonymous { front50.pipelines }
       .filter { it.containsKey("application") }
       .groupBy { it["application"] as String }
       .mapValues { it.value.size }


### PR DESCRIPTION
to clean up warnings like:
```
2021-03-17 22:51:04.801  WARN 1 --- [oScheduler-1063] c.n.s.okhttp.OkHttp3MetricsInterceptor   : Request GET:http://spin-front50.spinnaker-stage:8080/pipelines?restricted=false is missing [X-SPINNAKER-USER, X-SPINNAKER-ACCOUNTS] authentication headers and will be treated as anonymous.
Request from: com.netflix.spinnaker.okhttp.MetricsInterceptor.doIntercept(MetricsInterceptor.java:98)
	at com.netflix.spinnaker.okhttp.OkHttp3MetricsInterceptor.intercept(OkHttp3MetricsInterceptor.java:36)
	at com.netflix.spinnaker.echo.telemetry.PipelineCountsDataProvider.retrievePipelines(PipelineCountsDataProvider.kt:48)
	at com.netflix.spinnaker.echo.telemetry.PipelineCountsDataProvider.access$retrievePipelines(PipelineCountsDataProvider.kt:30)
	at com.netflix.spinnaker.echo.telemetry.PipelineCountsDataProvider$appPipelinesSupplier$1.get(PipelineCountsDataProvider.kt:33)
	at com.netflix.spinnaker.echo.telemetry.PipelineCountsDataProvider$appPipelinesSupplier$1.get(PipelineCountsDataProvider.kt:30)
	at com.netflix.spinnaker.echo.telemetry.PipelineCountsDataProvider.populateData(PipelineCountsDataProvider.kt:38)
	at com.netflix.spinnaker.echo.telemetry.TelemetryEventListener.processEvent(TelemetryEventListener.java:94)
	at com.netflix.spinnaker.echo.events.EventPropagator.lambda$processEvent$0(EventPropagator.java:71)
	at com.netflix.spinnaker.security.AuthenticatedRequest.lambda$wrapCallableForPrincipal$0(AuthenticatedRequest.java:272)
	at com.netflix.spinnaker.echo.events.EventPropagator.lambda$processEvent$2(EventPropagator.java:78)
```
