### PR TITLE
fix(templates/googlechat): custom template

### DIFF
--- a/echo-notifications/src/main/resources/templates/manualJudgment/body-googlechat.ftl
+++ b/echo-notifications/src/main/resources/templates/manualJudgment/body-googlechat.ftl
@@ -1,0 +1,25 @@
+<#if (notification.additionalContext.execution.name)??>
+  <#if (notification.additionalContext.execution.trigger.buildInfo.number)??>
+Stage <i>${notification.additionalContext.stageName}</i> for ${notification.source.application}'s ${notification.additionalContext.execution.name} pipeline build ${notification.additionalContext.execution.trigger.buildInfo.number?c} is <b>awaiting manual judgment</b>.
+  <#else>
+Stage <i>${notification.additionalContext.stageName}</i> for ${notification.source.application}'s ${notification.additionalContext.execution.name} pipeline is <b>awaiting manual judgment</b>.
+  </#if>
+<#else>
+Stage <i>${notification.additionalContext.stageName}</i> for ${notification.source.application} is <b>awaiting manual judgment</b>.
+</#if>
+
+<#if (notification.additionalContext.instructions)??>
+<u>Instructions:</u>
+${markdownToHtml.convert(notification.additionalContext.instructions)}
+</#if>
+
+For more details, please visit:
+<#if (notification.additionalContext.stageId)??>
+  <#if (notification.additionalContext.restrictExecutionDuringTimeWindow)??>
+<a href="${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}?refId=${notification.additionalContext.stageId}&step=1">${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}?refId=${notification.additionalContext.stageId}&step=1</a>
+  <#else>
+<a href="${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}?refId=${notification.additionalContext.stageId}">${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}?refId=${notification.additionalContext.stageId}</a>
+  </#if>
+<#else>
+<a href="${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}">${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}</a>
+</#if>

--- a/echo-notifications/src/main/resources/templates/manualJudgmentContinue/body-googlechat.ftl
+++ b/echo-notifications/src/main/resources/templates/manualJudgmentContinue/body-googlechat.ftl
@@ -1,0 +1,28 @@
+<#if (notification.additionalContext.execution.name)??>
+  <#if (notification.additionalContext.execution.trigger.buildInfo.number)??>
+Stage <i>${notification.additionalContext.stageName}</i> for ${notification.source.application}'s ${notification.additionalContext.execution.name} pipeline build ${notification.additionalContext.execution.trigger.buildInfo.number} was <b>judged to continue by ${notification.additionalContext.judgedBy}</b>.
+  <#else>
+Stage <i>${notification.additionalContext.stageName}</i> for ${notification.source.application}'s ${notification.additionalContext.execution.name} pipeline was <b>judged to continue by ${notification.additionalContext.judgedBy}</b>.
+  </#if>
+<#else>
+Stage <i>${notification.additionalContext.stageName}</i> for ${notification.source.application} was <b>judged to continue by ${notification.additionalContext.judgedBy}</b>.
+</#if>
+
+<#if (notification.additionalContext.message)??>
+<u>Instructions:</u>
+${markdownToHtml.convert(notification.additionalContext.message)}
+</#if>
+<#if (notification.additionalContext.judgmentInput)??>
+Judgment '${htmlToText.convert(notification.additionalContext.judgmentInput)}' was selected.
+</#if>
+
+For more details, please visit:
+<#if (notification.additionalContext.stageId)??>
+  <#if (notification.additionalContext.restrictExecutionDuringTimeWindow)??>
+<a href="${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}?refId=${notification.additionalContext.stageId}&step=1">${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}?refId=${notification.additionalContext.stageId}&step=1</a>
+  <#else>
+<a href="${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}?refId=${notification.additionalContext.stageId}">${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}?refId=${notification.additionalContext.stageId}</a>
+  </#if>
+<#else>
+<a href="${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}">${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}</a>
+</#if>

--- a/echo-notifications/src/main/resources/templates/manualJudgmentStop/body-googlechat.ftl
+++ b/echo-notifications/src/main/resources/templates/manualJudgmentStop/body-googlechat.ftl
@@ -1,0 +1,25 @@
+<#if (notification.additionalContext.execution.name)??>
+  <#if (notification.additionalContext.execution.trigger.buildInfo.number)??>
+Stage <i>${notification.additionalContext.stageName}</i> for ${notification.source.application}'s ${notification.additionalContext.execution.name} pipeline build ${notification.additionalContext.execution.trigger.buildInfo.number} was <b>judged to stop</b>.
+  <#else>
+Stage <i>${notification.additionalContext.stageName}</i> for ${notification.source.application}'s ${notification.additionalContext.execution.name} pipeline was <b>judged to stop</b>.
+  </#if>
+<#else>
+Stage <i>${notification.additionalContext.stageName}</i> for ${notification.source.application} was <b>judged to stop</b>.
+</#if>
+
+<#if (notification.additionalContext.message)??>
+<u>Instructions:</u>
+${markdownToHtml.convert(notification.additionalContext.message)}
+</#if>
+
+For more details, please visit:
+<#if (notification.additionalContext.stageId)??>
+  <#if (notification.additionalContext.restrictExecutionDuringTimeWindow)??>
+<a href="${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}?refId=${notification.additionalContext.stageId}&step=1">${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}?refId=${notification.additionalContext.stageId}&step=1</a>
+  <#else>
+<a href="${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}?refId=${notification.additionalContext.stageId}">${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}?refId=${notification.additionalContext.stageId}</a>
+  </#if>
+<#else>
+<a href="${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}">${baseUrl}/#/applications/${notification.source.application}/executions/details/${notification.source.executionId}</a>
+</#if>


### PR DESCRIPTION
Copied the default template, but added some HTML tag to make the message more readable and also converted the additional instructions/messages with `markdownToHtml.convert(...)` since Google Chat support a [subset of HTML tags](https://developers.google.com/chat/reference/message-formats/cards#card_text_formatting).

fix https://github.com/spinnaker/spinnaker/issues/6236

<img width="341" alt="Screenshot 2021-06-04 at 20 00 46" src="https://user-images.githubusercontent.com/1011520/120850702-af6b0400-c56f-11eb-8022-b882e9305902.png">
