### PR TITLE
fix(webhooks/stash): Adding jsonalias for refChanges field of StashWe…

### DIFF
--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/StashWebhookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/StashWebhookEventHandler.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.echo.scm;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.echo.api.events.Event;
 import com.netflix.spinnaker.echo.jackson.EchoObjectMapper;
@@ -54,7 +55,9 @@ public class StashWebhookEventHandler implements GitWebhookHandler {
 
   @Data
   private static class StashWebhookEvent {
+    @JsonAlias("changes")
     List<StashRefChanges> refChanges;
+
     StashRepository repository;
   }
 

--- a/echo-webhooks/src/test/java/com/netflix/spinnaker/echo/scm/StashWebhookEventHandlerTest.java
+++ b/echo-webhooks/src/test/java/com/netflix/spinnaker/echo/scm/StashWebhookEventHandlerTest.java
@@ -1,0 +1,39 @@
+package com.netflix.spinnaker.echo.scm;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.echo.api.events.Event;
+import com.netflix.spinnaker.echo.api.events.Metadata;
+import com.netflix.spinnaker.echo.jackson.EchoObjectMapper;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class StashWebhookEventHandlerTest {
+
+  @Test
+  void canHandleLegacyPayload() throws IOException {
+    File file = new File(getClass().getResource("/legacy_stash_payload.json").getFile());
+    String rawPayload = new String(Files.readAllBytes(file.toPath()));
+
+    ObjectMapper mapper = EchoObjectMapper.getInstance();
+    Map<String, Object> payload = mapper.readValue(rawPayload, new TypeReference<>() {});
+
+    Event event = new Event();
+    Metadata metadata = new Metadata();
+    metadata.setType("git");
+    metadata.setSource("stash");
+    event.details = metadata;
+    event.rawContent = rawPayload;
+    event.payload = payload;
+    event.content = payload;
+    event.content.put("event_type", "repo:push");
+
+    StashWebhookEventHandler handler = new StashWebhookEventHandler();
+    assertThatCode(() -> handler.handle(event, payload)).doesNotThrowAnyException();
+  }
+}

--- a/echo-webhooks/src/test/resources/legacy_stash_payload.json
+++ b/echo-webhooks/src/test/resources/legacy_stash_payload.json
@@ -1,0 +1,76 @@
+{
+    "eventKey": "repo:refs_changed",
+    "date": "2021-07-09T11:59:12-0400",
+    "actor": {
+      "name": "blah",
+      "emailAddress": "blah@company.com",
+      "id": 54183,
+      "displayName": "Blah, Blah",
+      "active": true,
+      "slug": "blah",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://some.endpoint.com/stash/users/blah"
+          }
+        ]
+      }
+    },
+    "repository": {
+      "slug": "sample-manifests",
+      "id": 32163,
+      "name": "sample-manifests",
+      "hierarchyId": "7663bf10753d48192d5b",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "project": {
+        "key": "E-BLAH",
+        "id": 4611,
+        "name": "Blah-Platform",
+        "description": "This is a fake description",
+        "public": false,
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "https://some.endpoint.com/stash/projects/E-BLAH"
+            }
+          ]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [
+          {
+            "href": "ssh://git@some.endpoint.com/e-blah/sample-manifests.git",
+            "name": "ssh"
+          },
+          {
+            "href": "https://some.endpoint.com/stash/scm/e-blah/sample-manifests.git",
+            "name": "http"
+          }
+        ],
+        "self": [
+          {
+            "href": "https://some.endpoint.com/stash/projects/E-BLAH/repos/sample-manifests/browse"
+          }
+        ]
+      }
+    },
+    "changes": [
+      {
+        "ref": {
+          "id": "refs/heads/master",
+          "displayId": "master",
+          "type": "BRANCH"
+        },
+        "refId": "refs/heads/master",
+        "fromHash": "7e3701f9bdf88997254610726be874cb315725f7",
+        "toHash": "6701da6ba49197208319f3ecad71ec9c449172fa",
+        "type": "UPDATE"
+      }
+    ]
+  }


### PR DESCRIPTION
…bhookEvent to account for Stash webhook payloads that follow this format.

This patch adds a simple json alias for the refChanges field of StashWebhookEvent to account for payloads that have a slightly different format of changes for the field name. Several issues have been reported for Stash triggers not functioning but have been unable to tie a reported issue to this field in particular. Currently, I was struggling with Stash triggers and built a custom image with this proposed fix to validate. This fix corrected Stash triggers in my case and has no impact to existing payloads that follow the refChanges format.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://www.spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
