### PR TITLE
feat(pipeline executions/echo): Add support for max concurrent pipeline executions

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Pipeline.java
@@ -57,6 +57,8 @@ public class Pipeline {
 
   @JsonProperty boolean limitConcurrent;
 
+  @JsonProperty int maxConcurrentExecutions;
+
   @JsonProperty boolean keepWaitingPipelines;
 
   @JsonProperty boolean plan;

--- a/echo-model/src/test/groovy/com/netflix/spinnaker/echo/model/PipelineSpec.groovy
+++ b/echo-model/src/test/groovy/com/netflix/spinnaker/echo/model/PipelineSpec.groovy
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.echo.jackson.EchoObjectMapper
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class PipelineSpec extends Specification {
 
@@ -310,5 +311,69 @@ class PipelineSpec extends Specification {
     then:
     noExceptionThrown()
     pipeline == pipelineRoundTrip
+  }
+
+  @Unroll
+  void 'pipeline config deserialization for pipelines with limitConcurrent = #limitConcurrent'() {
+    given:
+    def testId = "68a14710-1ade-11e5-89a8-65c9c75401223f"
+    def testAppName = "Testing limitConcurrent"
+    def testPipelineName = "a_pipeline"
+    def pipelineJson = """{
+            "name": "${testPipelineName}",
+            "limitConcurrent": ${limitConcurrent},
+            "application": "${testAppName}",
+            "id": "${testId}"
+        }
+        """
+
+    when:
+    Pipeline pipeline = objectMapper.readValue(pipelineJson, Pipeline)
+
+    then:
+    noExceptionThrown()
+    pipeline != null
+    pipeline.id == testId
+    pipeline.name == testPipelineName
+    pipeline.application == testAppName
+    pipeline.limitConcurrent == limitConcurrent
+
+    where:
+    limitConcurrent | _
+    true | _
+    false | _
+  }
+
+  @Unroll
+  void 'pipeline config deserialization for pipelines with maxConcurrentExecutions = #maxConcurrentExecutions'() {
+    given:
+    def testId = "68a14710-1ade-11e5-89a8-65c9c754999923f"
+    def testAppName = "Testing limitConcurrent"
+    def testPipelineName = "a_pipeline"
+    def pipelineJson = """{
+            "name": "${testPipelineName}",
+            "limitConcurrent": true,
+            "maxConcurrentExecutions": ${maxConcurrentExecutions},
+            "application": "${testAppName}",
+            "id": "${testId}"
+        }
+        """
+
+    when:
+    Pipeline pipeline = objectMapper.readValue(pipelineJson, Pipeline)
+
+    then:
+    noExceptionThrown()
+    pipeline != null
+    pipeline.id == testId
+    pipeline.name == testPipelineName
+    pipeline.application == testAppName
+    pipeline.maxConcurrentExecutions == maxConcurrentExecutions
+    pipeline.limitConcurrent == true
+
+    where:
+    maxConcurrentExecutions || _
+    2 | _
+    0 | _
   }
 }


### PR DESCRIPTION
It adds support for max concurrent pipeline executions. If concurrent pipeline execution is enabled, pipelines will queue when the max concurrent pipeline executions is reached. Any queued pipelines will be allowed to run once the number of running pipeline executions drops below the max. If the max is set to 0, then pipelines will not queue.

This is the proposed change for spinnaker/spinnaker#6558.

Changes to orca, front50 and deck are also needed in order to expose max concurrent pipeline executions as a pipeline configuration to Spinnaker users.

(Orca pull request: spinnaker/orca#4193)
(Front50 pull request: https://github.com/spinnaker/front50/pull/1080)
(Deck pull request: https://github.com/spinnaker/deck/pull/9777)