### PR TITLE
fix(plugins-test): try harder for the version of versionNotSupportedP…

### DIFF
--- a/echo-plugins-test/src/test/kotlin/com/netflix/spinnaker/echo/plugins/test/EchoPluginsFixture.kt
+++ b/echo-plugins-test/src/test/kotlin/com/netflix/spinnaker/echo/plugins/test/EchoPluginsFixture.kt
@@ -65,7 +65,8 @@ class EchoPluginsFixture : PluginsTckFixture, EchoTestService() {
     plugins.mkdir()
     enabledPlugin = buildPlugin("com.netflix.echo.enabled.plugin", ">=1.0.0")
     disabledPlugin = buildPlugin("com.netflix.echo.disabled.plugin", ">=1.0.0")
-    versionNotSupportedPlugin = buildPlugin("com.netflix.echo.version.not.supported.plugin", ">=2.0.0")
+    // Make it very unlikely that the version of echo satisfies this requirement
+    versionNotSupportedPlugin = buildPlugin("com.netflix.echo.version.not.supported.plugin", "=0.0.9")
   }
 }
 


### PR DESCRIPTION
…lugin to actually not be supported

Before this, an echo version >= 2.0.0 would cause versionNotSupportedPlugin to get used,
causing tests to fail, and making it impossible to e.g. release echo.
