### PR TITLE
feat(webhooks/github): Add more metadata to PR events

### DIFF
--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/trigger/GitEvent.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/trigger/GitEvent.java
@@ -38,7 +38,13 @@ public class GitEvent extends TriggerEvent {
   @NoArgsConstructor
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Content {
-    public Content(String repoProject, String slug, String hash, String branch, String action, List<Artifact> artifacts) {
+    public Content(
+        String repoProject,
+        String slug,
+        String hash,
+        String branch,
+        String action,
+        List<Artifact> artifacts) {
       this.repoProject = repoProject;
       this.slug = slug;
       this.hash = hash;
@@ -58,8 +64,6 @@ public class GitEvent extends TriggerEvent {
     private String title;
     private List<Artifact> artifacts;
   }
-
-
 
   @JsonIgnore
   public String getHash() {

--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/trigger/GitEvent.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/trigger/GitEvent.java
@@ -38,13 +38,28 @@ public class GitEvent extends TriggerEvent {
   @NoArgsConstructor
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Content {
+    public Content(String repoProject, String slug, String hash, String branch, String action, List<Artifact> artifacts) {
+      this.repoProject = repoProject;
+      this.slug = slug;
+      this.hash = hash;
+      this.branch = branch;
+      this.action = action;
+      this.artifacts = artifacts;
+    }
+
     private String repoProject;
     private String slug;
     private String hash;
     private String branch;
     private String action;
+    private Integer number;
+    private Boolean draft;
+    private String state;
+    private String title;
     private List<Artifact> artifacts;
   }
+
+
 
   @JsonIgnore
   public String getHash() {

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GithubWebhookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GithubWebhookEventHandler.java
@@ -94,7 +94,7 @@ public class GithubWebhookEventHandler implements GitWebhookHandler {
         results.put("title", pullRequest.getTitle());
       }
     }
-    
+
     event.content.putAll(results);
 
     log.info(

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GithubWebhookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/GithubWebhookEventHandler.java
@@ -83,15 +83,18 @@ public class GithubWebhookEventHandler implements GitWebhookHandler {
     results.put("hash", webhookEvent.getHash());
     results.put("branch", webhookEvent.getBranch());
     results.put("action", githubEvent.concat(":").concat(webhookEvent.getAction()));
+
     if (webhookEvent instanceof GithubPullRequestEvent) {
       GithubPullRequestEvent pullRequestEvent = (GithubPullRequestEvent) webhookEvent;
-      if (((GithubPullRequestEvent) webhookEvent).getPullRequest() != null) {
-        results.put("number", String.valueOf(pullRequestEvent.getPullRequest().getNumber()));
-        results.put("draft", String.valueOf(pullRequestEvent.getPullRequest().getDraft()));
-        results.put("state", pullRequestEvent.getPullRequest().getState());
-        results.put("title", pullRequestEvent.getPullRequest().getTitle());
+      if (pullRequestEvent.getPullRequest() != null) {
+        GithubPullRequestEvent.PullRequest pullRequest = pullRequestEvent.getPullRequest();
+        results.put("number", String.valueOf(pullRequest.getNumber()));
+        results.put("draft", String.valueOf(pullRequest.getDraft()));
+        results.put("state", pullRequest.getState());
+        results.put("title", pullRequest.getTitle());
       }
     }
+    
     event.content.putAll(results);
 
     log.info(

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/github/GithubPullRequestEvent.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/github/GithubPullRequestEvent.java
@@ -17,23 +17,21 @@
 package com.netflix.spinnaker.echo.scm.github;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.netflix.spinnaker.echo.api.events.Event;
-import java.util.Map;
 import java.util.Optional;
 import lombok.Data;
 
 @Data
 public class GithubPullRequestEvent implements GithubWebhookEvent {
-  Repository repository;
+  private Repository repository;
 
   @JsonProperty("pull_request")
-  PullRequest pullRequest;
+  private PullRequest pullRequest;
 
-  String action;
+  private String action;
 
   // `.repository.full_name`
   @Override
-  public String getFullRepoName(Event event, Map postedEvent) {
+  public String getFullRepoName() {
     return Optional.of(this)
         .map(GithubPullRequestEvent::getRepository)
         .map(Repository::getFullName)
@@ -42,7 +40,7 @@ public class GithubPullRequestEvent implements GithubWebhookEvent {
 
   // `.repository.owner.login`
   @Override
-  public String getRepoProject(Event event, Map postedEvent) {
+  public String getRepoProject() {
     return Optional.of(this)
         .map(GithubPullRequestEvent::getRepository)
         .map(Repository::getOwner)
@@ -52,7 +50,7 @@ public class GithubPullRequestEvent implements GithubWebhookEvent {
 
   // `.repository.name`
   @Override
-  public String getSlug(Event event, Map postedEvent) {
+  public String getSlug() {
     return Optional.of(this)
         .map(GithubPullRequestEvent::getRepository)
         .map(Repository::getName)
@@ -62,7 +60,7 @@ public class GithubPullRequestEvent implements GithubWebhookEvent {
   // `.pull_request.head.sha`
   // TODO
   @Override
-  public String getHash(Event event, Map postedEvent) {
+  public String getHash() {
     return Optional.of(this)
         .map(GithubPullRequestEvent::getPullRequest)
         .map(PullRequest::getHead)
@@ -73,7 +71,7 @@ public class GithubPullRequestEvent implements GithubWebhookEvent {
   // `.pull_request.head.ref`
   // TODO
   @Override
-  public String getBranch(Event event, Map postedEvent) {
+  public String getBranch() {
     // Replace on "" still returns "", which is fine
     return Optional.of(this)
         .map(GithubPullRequestEvent::getPullRequest)
@@ -82,34 +80,32 @@ public class GithubPullRequestEvent implements GithubWebhookEvent {
         .orElse("");
   }
 
-  // `.action`
-  @Override
-  public String getAction(Event event, Map postedEvent) {
-    return Optional.of(this).map(GithubPullRequestEvent::getAction).orElse("");
-  }
-
   @Data
   private static class Repository {
-    RepositoryOwner owner;
-    String name;
+    private RepositoryOwner owner;
+    private String name;
 
     @JsonProperty("full_name")
-    String fullName;
+    private String fullName;
   }
 
   @Data
   private static class RepositoryOwner {
-    String login;
+    private String login;
   }
 
   @Data
-  private static class PullRequest {
-    PullRequestHead head;
+  public static class PullRequest {
+    private PullRequestHead head;
+    private Boolean draft;
+    private int number;
+    private String state;
+    private String title;
   }
 
   @Data
   private static class PullRequestHead {
-    String ref;
-    String sha;
+    private String ref;
+    private String sha;
   }
 }

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/github/GithubPushEvent.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/github/GithubPushEvent.java
@@ -17,8 +17,6 @@
 package com.netflix.spinnaker.echo.scm.github;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.netflix.spinnaker.echo.api.events.Event;
-import java.util.Map;
 import java.util.Optional;
 import lombok.Data;
 
@@ -32,7 +30,7 @@ public class GithubPushEvent implements GithubWebhookEvent {
 
   // `.repository.full_name`
   @Override
-  public String getFullRepoName(Event event, Map postedEvent) {
+  public String getFullRepoName() {
     return Optional.of(this)
         .map(GithubPushEvent::getRepository)
         .map(Repository::getFullName)
@@ -41,7 +39,7 @@ public class GithubPushEvent implements GithubWebhookEvent {
 
   // `.repository.owner.name`
   @Override
-  public String getRepoProject(Event event, Map postedEvent) {
+  public String getRepoProject() {
     return Optional.of(this)
         .map(GithubPushEvent::getRepository)
         .map(Repository::getOwner)
@@ -51,7 +49,7 @@ public class GithubPushEvent implements GithubWebhookEvent {
 
   // `.repository.name`
   @Override
-  public String getSlug(Event event, Map postedEvent) {
+  public String getSlug() {
     return Optional.of(this)
         .map(GithubPushEvent::getRepository)
         .map(Repository::getName)
@@ -60,19 +58,19 @@ public class GithubPushEvent implements GithubWebhookEvent {
 
   // `.after`
   @Override
-  public String getHash(Event event, Map postedEvent) {
+  public String getHash() {
     return Optional.of(this).map(GithubPushEvent::getAfter).orElse("");
   }
 
   // `.ref`, remove `refs/heads/`
   @Override
-  public String getBranch(Event event, Map postedEvent) {
+  public String getBranch() {
     // Replace on "" still returns "", which is fine
     return Optional.of(this).map(GithubPushEvent::getRef).orElse("").replace("refs/heads/", "");
   }
 
   @Override
-  public String getAction(Event event, Map postedEvent) {
+  public String getAction() {
     return ACTION;
   }
 

--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/github/GithubWebhookEvent.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/github/GithubWebhookEvent.java
@@ -16,19 +16,16 @@
 
 package com.netflix.spinnaker.echo.scm.github;
 
-import com.netflix.spinnaker.echo.api.events.Event;
-import java.util.Map;
-
 public interface GithubWebhookEvent {
-  String getFullRepoName(Event event, Map postedEvent);
+  String getFullRepoName();
 
-  String getRepoProject(Event event, Map postedEvent);
+  String getRepoProject();
 
-  String getSlug(Event event, Map postedEvent);
+  String getSlug();
 
-  String getHash(Event event, Map postedEvent);
+  String getHash();
 
-  String getBranch(Event event, Map postedEvent);
+  String getBranch();
 
-  String getAction(Event event, Map postedEvent);
+  String getAction();
 }

--- a/echo-webhooks/src/test/groovy/com/netflix/spinnaker/echo/controllers/WebhooksControllerSpec.groovy
+++ b/echo-webhooks/src/test/groovy/com/netflix/spinnaker/echo/controllers/WebhooksControllerSpec.groovy
@@ -427,10 +427,14 @@ class WebhooksControllerSpec extends Specification {
       """{
           "action": "opened",
           "pull_request": {
+            "number": 42,
             "head": {
               "ref": "simple-tag",
               "sha": "0000000000000000000000000000000000000000"
-            }
+            },
+            "title": "Very nice Pull Request",
+            "draft": false,
+            "state": "open"
           },
           "repository": {
             "name": "Hello-World",
@@ -451,6 +455,10 @@ class WebhooksControllerSpec extends Specification {
     event.content.slug == "Hello-World"
     event.content.branch == "simple-tag"
     event.content.action == "pull_request:opened"
+    event.content.number == "42"
+    event.content.title == "Very nice Pull Request"
+    event.content.state == "open"
+    event.content.draft == "false"
   }
 
   void 'handles non-push Github Webhook Event gracefully'() {


### PR DESCRIPTION
Add PR number, draft status, state and title to the pull request event.
Also did some cleanup of the `GithubWebhookEvent` interface and removed unused parameters.