### PR TITLE
fix(notifications): Encode url in email notification

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgent.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgent.groovy
@@ -23,10 +23,12 @@ import com.netflix.spinnaker.echo.email.EmailNotificationService
 import com.netflix.spinnaker.echo.api.events.Event
 import freemarker.template.Configuration
 import freemarker.template.Template
+import java.nio.charset.StandardCharsets
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 import org.springframework.ui.freemarker.FreeMarkerTemplateUtils
+import org.springframework.web.util.UriUtils
 
 import static groovy.json.JsonOutput.prettyPrint
 import static groovy.json.JsonOutput.toJson
@@ -79,7 +81,8 @@ class EmailNotificationAgent extends AbstractEventNotificationAgent {
 
     log.info('Sending email {} for {} {} {} {}', kv('address', preference.address), kv('application', application), kv('type', config.type), kv('status', status), kv('executionId', event.content?.execution?.id))
 
-    String link = "${spinnakerUrl}/#/applications/${application}/${config.type == 'stage' ? 'executions/details' : config.link }/${event.content?.execution?.id}"
+    String encodedApplication = UriUtils.encodePathSegment(application, StandardCharsets.UTF_8)
+    String link = "${spinnakerUrl}/#/applications/${encodedApplication}/${config.type == 'stage' ? 'executions/details' : config.link }/${event.content?.execution?.id}"
 
     sendMessage(
       preference.address ? [preference.address] as String[] : null,

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgentSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/EmailNotificationAgentSpec.groovy
@@ -95,6 +95,9 @@ class EmailNotificationAgentSpec extends Specification {
       context.set(ctx)
     }
 
+    and:
+    agent.spinnakerUrl = "https://foo-url"
+
     when:
     agent.sendNotifications(
       [address: address, message: message],
@@ -106,6 +109,7 @@ class EmailNotificationAgentSpec extends Specification {
 
     then:
     context.get().get("message") == message."$type.$status".text
+    context.get().get("link") == "https://foo-url/#/applications/what%20ever/executions/details/foo-id"
 
     where:
     status     | _
@@ -114,11 +118,11 @@ class EmailNotificationAgentSpec extends Specification {
     "failed"   | _
 
     type = "stage"
-    application = "whatever"
+    application = "what ever"
     address = "whoever@netflix.com"
     pipelineName = "foo-pipeline"
     stageName = "foo-stage"
-    event = new Event(content: [name: "foo-stage", execution: [name: "foo-pipeline"]])
+    event = new Event(content: [name: "foo-stage", execution: [name: "foo-pipeline", id: "foo-id"]])
     message = ["complete", "starting", "failed"].collectEntries {
       [("$type.$it".toString()): [text: "custom $it text"]]
     }


### PR DESCRIPTION
Application names can contain spaces. These spaces should be properly encoded in the url in email notifications

Before:
![Screen Shot 2022-10-07 at 10 12 08 AM](https://user-images.githubusercontent.com/7633557/194643899-e6d34489-1f2d-4e16-9c58-e8024722caa9.png)


After:
![Screen Shot 2022-10-07 at 10 15 01 AM](https://user-images.githubusercontent.com/7633557/194643919-82e9e1b7-3da9-4728-9b93-6cbd79a58a69.png)

