### PR TITLE
fix(pipelineTriggers): handle invalid constraint regexes

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
@@ -134,7 +134,12 @@ public class ArtifactMatcher {
     try {
       p = Pattern.compile(us);
     } catch (PatternSyntaxException ex) {
-      log.error("Invalid Regex pattern for constraint, will never match any payload: " + us);
+      log.error(
+          "Invalid regex pattern for constraint, will never match any payload: \""
+              + us
+              + "\": "
+              + ex.getMessage(),
+          ex);
       return false;
     }
     return p.asPredicate().test(other);

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcher.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
@@ -129,7 +130,14 @@ public class ArtifactMatcher {
   }
 
   private static boolean matches(String us, String other) {
-    return Pattern.compile(us).asPredicate().test(other);
+    Pattern p;
+    try {
+      p = Pattern.compile(us);
+    } catch (PatternSyntaxException ex) {
+      log.error("Invalid Regex pattern for constraint, will never match any payload: " + us);
+      return false;
+    }
+    return p.asPredicate().test(other);
   }
 
   private static boolean anyMatch(String us, List<String> values) {

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcherSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/artifacts/ArtifactMatcherSpec.groovy
@@ -39,6 +39,10 @@ class ArtifactMatcherSpec extends Specification {
     "one": "o"
   ]
 
+  def invalidConstraint = [
+    "one": "[one,two"
+  ]
+
   def constraintsOR = [
     "one": ["uno", "one"]
   ]
@@ -160,6 +164,14 @@ class ArtifactMatcherSpec extends Specification {
     !result
   }
 
+  def "no match when constraint invalid"() {
+    when:
+    boolean result = ArtifactMatcher.isConstraintInPayload(invalidConstraint, matchPayload)
+
+    then:
+    !result
+  }
+
   def "matches when payload value is in a list of constraint strings"() {
     when:
     boolean result = ArtifactMatcher.isConstraintInPayload(constraintsOR, matchPayload)
@@ -219,6 +231,14 @@ class ArtifactMatcherSpec extends Specification {
   def "no match when constraint word not present using Jsonpath"() {
     when:
     boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(contstraints, noMatchPayload)
+
+    then:
+    !result
+  }
+
+  def "no match when constraint not valid using Jsonpath"() {
+    when:
+    boolean result = ArtifactMatcher.isJsonPathConstraintInPayload(invalidConstraint, matchPayload)
 
     then:
     !result


### PR DESCRIPTION
Currently, if a user accidentally configures a pipeline trigger with an invalid regex for a constraint value, echo throws a `PatternSyntaxException` any time it receives an event that should be tested against the constraint.  As a result, all pipeline triggers using the same trigger type & source/subscription will be non-functional, not just the pipeline with the bad regex.

This patch catches `PatternSyntaxException`, logs an error about the bad regex for troubleshooting purposes, and returns `false` such that the bad regex will never match, allowing all other pipeline triggers to continue functioning normally.

We haven't raised an issue for this as it's a fairly trivial bug & fix.