### PR TITLE
refactor(web): Clean up redundant spring property in gradle file

### DIFF
--- a/echo-web/echo-web.gradle
+++ b/echo-web/echo-web.gradle
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-ext {
-  springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/".toString())
-  springProfiles = System.getProperty('spring.profiles.active', "test,local")
-}
-
 apply plugin: 'io.spinnaker.package'
 
 mainClassName = 'com.netflix.spinnaker.echo.Application'
@@ -63,11 +58,6 @@ dependencies {
     testImplementation "org.spockframework:spock-spring"
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
-}
-
-run {
-  systemProperty('spring.config.additional-location', project.springConfigLocation)
-  systemProperty('spring.profiles.active', project.springProfiles)
 }
 
 test {


### PR DESCRIPTION
The properties spring.config.additional-location and spring.profiles.active are redundant in echo-web.gradle file. These properties are set by class com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder in com.netflix.spinnaker.echo.Application. So removing it from gradle file.