### PR TITLE
feat(event): Add circuit breaker for events sending.

### DIFF
--- a/echo-rest/src/main/java/com/netflix/spinnaker/echo/events/RestEventService.java
+++ b/echo-rest/src/main/java/com/netflix/spinnaker/echo/events/RestEventService.java
@@ -33,6 +33,10 @@ public class RestEventService {
   private final RetrySupport retrySupport;
 
   @CircuitBreaker(name = "sendEvent")
+  public void sendEventWithCircuitBreaker(Map<String, Object> event, RestUrls.Service service) {
+    sendEvent(event, service);
+  }
+
   public void sendEvent(Map<String, Object> event, RestUrls.Service service) {
     retrySupport.retry(
         () -> service.getClient().recordEvent(event),

--- a/echo-rest/src/main/java/com/netflix/spinnaker/echo/events/RestEventService.java
+++ b/echo-rest/src/main/java/com/netflix/spinnaker/echo/events/RestEventService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.events;
+
+import com.netflix.spinnaker.echo.config.RestUrls;
+import com.netflix.spinnaker.kork.core.RetrySupport;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import java.time.Duration;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty("rest.enabled")
+public class RestEventService {
+
+  private final RetrySupport retrySupport;
+
+  @CircuitBreaker(name = "sendEvent")
+  public void sendEvent(Map<String, Object> event, RestUrls.Service service) {
+    retrySupport.retry(
+        () -> service.getClient().recordEvent(event),
+        service.getConfig().getRetryCount(),
+        Duration.ofMillis(200),
+        false);
+  }
+}

--- a/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/RestEventListenerSpec.groovy
+++ b/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/RestEventListenerSpec.groovy
@@ -30,7 +30,7 @@ class RestEventListenerSpec extends Specification {
 
   @Subject
   RestEventService restEventService = new RestEventService(new RetrySupport())
-  RestEventListener listener = new RestEventListener(null, null, restEventService, new NoopRegistry(), new RetrySupport())
+  RestEventListener listener = new RestEventListener(null, null, restEventService, new NoopRegistry())
   Event event = new Event(content: ['uno': 'dos'])
   RestService restService
 

--- a/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/RestEventListenerSpec.groovy
+++ b/echo-rest/src/test/groovy/com/netflix/spinnaker/echo/events/RestEventListenerSpec.groovy
@@ -29,7 +29,8 @@ import spock.lang.Subject
 class RestEventListenerSpec extends Specification {
 
   @Subject
-  RestEventListener listener = new RestEventListener(null, null, new NoopRegistry(), new RetrySupport())
+  RestEventService restEventService = new RestEventService(new RetrySupport())
+  RestEventListener listener = new RestEventListener(null, null, restEventService, new NoopRegistry(), new RetrySupport())
   Event event = new Event(content: ['uno': 'dos'])
   RestService restService
 
@@ -190,5 +191,24 @@ class RestEventListenerSpec extends Specification {
     1 * restService2.recordEvent({
       it == listener.mapper.convertValue(event, Map)
     })
+  }
+
+  void 'should send event when circuit breaker is enabled'() {
+    given:
+    RestProperties.RestEndpointConfiguration config = new RestProperties.RestEndpointConfiguration()
+
+    RestUrls.Service service = RestUrls.Service.builder()
+      .client(restService)
+      .config(config)
+      .build()
+
+    listener.circuitBreakerEnabled = true
+    listener.restUrls.services = [service]
+
+    when:
+    listener.processEvent(event)
+
+    then:
+    1 * restService.recordEvent({ it == listener.mapper.convertValue(event, Map) })
   }
 }


### PR DESCRIPTION
**Description**

The event may have payload size up to 10 MB and even more, there are no strict limits. The number of events to be sent can be large. It depends on how frequently Spinnaker runs pipelines, and other internal jobs. As a result, if consumer API is unavailable or has high latency then Echo service is constantly restarting due to Out of Memory error.

**How to use?**

Add to `echo-local.yml`:

```
rest:
  enabled: true
  circuitBreakerEnabled: true

resilience4j:
  circuitbreaker:
    instances:
      sendEvent:
        failure-rate-threshold: 50
        minimum-number-of-calls: 5
        automatic-transition-from-open-to-half-open-enabled: true
        wait-duration-in-open-state: 5s
        permitted-number-of-calls-in-half-open-state: 3
        sliding-window-size: 10
        sliding-window-type: count_based
```