### PR TITLE
chore(dependencies): remove dependency on groovy-all

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ subprojects {
       annotationProcessor "org.projectlombok:lombok"
       testAnnotationProcessor "org.projectlombok:lombok"
 
-      implementation "org.codehaus.groovy:groovy-all"
+      implementation "org.codehaus.groovy:groovy"
       implementation "com.github.ben-manes.caffeine:guava"
       implementation "com.netflix.spectator:spectator-api"
       implementation "org.slf4j:slf4j-api"

--- a/echo-notifications/echo-notifications.gradle
+++ b/echo-notifications/echo-notifications.gradle
@@ -33,6 +33,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-freemarker"
   implementation "org.jsoup:jsoup:1.8.3"
   implementation "com.atlassian.commonmark:commonmark:0.9.0"
+  implementation "org.codehaus.groovy:groovy-json"
   testImplementation("com.icegreen:greenmail:1.5.14") {
     exclude group: "com.sun.mail", module: "javax.mail"
   }


### PR DESCRIPTION
with a specific goal to get `org.testng:testng:7.4.0` out of shipping code, since it's vulnerable to CVE-2022-4065.
