### PR TITLE
feat(pubsub): add support for links in pubsub triggers

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandler.java
@@ -78,13 +78,26 @@ public class PubsubEventHandler extends BaseTriggerEventHandler<PubsubEvent> {
     Map parameters =
         payload.containsKey("parameters") ? (Map) payload.get("parameters") : new HashMap();
     MessageDescription description = pubsubEvent.getContent().getMessageDescription();
-    return trigger ->
-        trigger
-            .atMessageDescription(
-                description.getSubscriptionName(), description.getPubsubSystem().toString())
-            .atParameters(parameters)
-            .atPayload(payload)
-            .atEventId(pubsubEvent.getEventId());
+    return inputTrigger -> {
+      Trigger trigger =
+          inputTrigger
+              .atMessageDescription(
+                  description.getSubscriptionName(), description.getPubsubSystem().toString())
+              .atParameters(parameters)
+              .atPayload(payload)
+              .atEventId(pubsubEvent.getEventId());
+
+      Object linkTextObject = payload.get("linkText");
+      Object linkObject = payload.get("link");
+      if (linkTextObject instanceof String && linkObject instanceof String) {
+        String linkText = (String) linkTextObject;
+        String link = (String) linkObject;
+        if (StringUtils.isNotBlank(linkText) && StringUtils.isNotBlank(link)) {
+          trigger = trigger.withLink(link).withLinkText(linkText);
+        }
+      }
+      return trigger;
+    };
   }
 
   @Override

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandlerSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandlerSpec.groovy
@@ -257,4 +257,33 @@ class PubsubEventHandlerSpec extends Specification implements RetrofitStubs {
     enabledGooglePubsubTrigger.withAttributeConstraints([key: 'value'])      | 1
     enabledGooglePubsubTrigger.withAttributeConstraints([key: 'wrongValue']) | 0
   }
+
+  @Unroll
+  def "sets link details if defined"() {
+    given:
+    def trigger = enabledGooglePubsubTrigger
+
+    def event = new PubsubEvent()
+    def description = MessageDescription.builder()
+      .pubsubSystem(PubsubSystem.GOOGLE)
+      .ackDeadlineSeconds(1)
+      .subscriptionName("projects/project/subscriptions/subscription")
+      .messagePayload(JsonOutput.toJson([key: 'value']))
+      .messageAttributes([key: 'value'])
+      .build()
+
+    when:
+    def content = new PubsubEvent.Content()
+    content.setMessageDescription(description)
+    event.content = content
+    def link = 'https://sample.com'
+    def linkText = 'someLinkText'
+    event.payload = [link: link, linkText: linkText]
+
+    def outputTrigger = eventHandler.buildTrigger(event).apply(trigger)
+
+    then:
+    outputTrigger.link.equals(link)
+    outputTrigger.linkText.equals(linkText)
+  }
 }


### PR DESCRIPTION
It is nice how how Jenkins triggers display a link back to the build that triggered the pipeline. This keys off the link and linkText properties in the Trigger object. I would like to see this same behavior supported for pubsub triggers. This change allows senders of pubsub events to add link and linkText in the trigger message payload, and thus set a link that will be displayed in the pipeline execution UI.

I tested this out on our spinnaker installation and it renders the link like a champ:

<img width="261" alt="image" src="https://user-images.githubusercontent.com/4722632/207469458-e199617a-ae9b-446e-9db6-1a2f755c0ba3.png">
