### PR TITLE
fix: The circuit breaker feature for sending events to telemetry endpoint is hidden under a required feature flag property

### DIFF
--- a/echo-rest/src/main/java/com/netflix/spinnaker/echo/events/RestEventListener.java
+++ b/echo-rest/src/main/java/com/netflix/spinnaker/echo/events/RestEventListener.java
@@ -51,7 +51,7 @@ class RestEventListener implements EventListener {
   @Value("${rest.default-field-name:payload}")
   private String fieldName;
 
-  @Value("${rest.circuit-breaker-enabled}")
+  @Value("${rest.circuit-breaker-enabled:false}")
   private boolean circuitBreakerEnabled;
 
   @Autowired


### PR DESCRIPTION
It should be optional - if no config is defined in the YAML file, it should disable the circuit breaker feature by default