### PR TITLE
fix(bitbucket): Add project key as identifier

### DIFF
--- a/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/BitbucketWebhookEventHandler.java
+++ b/echo-webhooks/src/main/groovy/com/netflix/spinnaker/echo/scm/BitbucketWebhookEventHandler.java
@@ -161,6 +161,9 @@ public class BitbucketWebhookEventHandler implements GitWebhookHandler {
       if (bitbucketCloudEvent.repository.owner != null) {
         repoProject = StringUtils.defaultIfEmpty(bitbucketCloudEvent.repository.owner.username, "");
       }
+      if (StringUtils.isEmpty(repoProject) && bitbucketCloudEvent.repository.project != null) {
+        repoProject = StringUtils.defaultIfEmpty(bitbucketCloudEvent.repository.project.key, "");
+      }
     }
     if (bitbucketCloudEvent.pullRequest != null) {
       BitbucketCloudEvent.PullRequest pullRequest = bitbucketCloudEvent.pullRequest;
@@ -207,11 +210,18 @@ public class BitbucketWebhookEventHandler implements GitWebhookHandler {
       String fullName;
 
       Owner owner;
+
+      Project project;
     }
 
     @Data
     private static class Owner {
       String username;
+    }
+
+    @Data
+    public static class Project {
+      String key;
     }
 
     @Data

--- a/echo-webhooks/src/test/java/com/netflix/spinnaker/echo/scm/BitbucketWebhookEventHandlerTest.java
+++ b/echo-webhooks/src/test/java/com/netflix/spinnaker/echo/scm/BitbucketWebhookEventHandlerTest.java
@@ -57,7 +57,7 @@ class BitbucketWebhookEventHandlerTest {
 
     assertThat(event.content)
         .contains(
-            entry("repoProject", ""),
+            entry("repoProject", "TES"),
             entry("slug", "bitbucketfan/test_webhooks"),
             entry("hash", "9384d1bf6db69ea35cda200648ade30f8ea7b1a4"),
             entry("branch", "master"),


### PR DESCRIPTION
Some Bitbucket Cloud webhooks do not have `repository.owner.username` field. This caused the `repoProject` event field to be empty and echo did not trigger pipelines correctly.