### PR TITLE
fix(tests): Introduce junit5 vintage engine for running junit4 test cases over junit5 and cleanup of useJUnitPlatform() from sub-modules in echo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ subprojects {
       testLogging {
         exceptionFormat = 'full'
       }
+     useJUnitPlatform {
+       includeEngines "junit-vintage", "junit-jupiter"
+     }
     }
 
     tasks.withType(JavaExec) {
@@ -81,6 +84,7 @@ subprojects {
       testImplementation "org.springframework:spring-test"
       testImplementation "org.hamcrest:hamcrest-core"
       testRuntimeOnly "cglib:cglib-nodep"
+      testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
       testRuntimeOnly "org.objenesis:objenesis"
     }
   }

--- a/echo-api-tck/echo-api-tck.gradle
+++ b/echo-api-tck/echo-api-tck.gradle
@@ -9,9 +9,3 @@ dependencies {
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
-
-test {
-  useJUnitPlatform {
-    includeEngines("junit-jupiter", "junit-vintage")
-  }
-}

--- a/echo-api/echo-api.gradle
+++ b/echo-api/echo-api.gradle
@@ -21,7 +21,3 @@ dependencies {
   testImplementation("io.mockk:mockk")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/echo-pipelinetriggers/echo-pipelinetriggers.gradle
+++ b/echo-pipelinetriggers/echo-pipelinetriggers.gradle
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-test {
-  useJUnitPlatform {
-    includeEngines "junit-vintage", "junit-jupiter"
-  }
-}
-
 dependencies {
   implementation project(':echo-model')
   implementation "io.spinnaker.kork:kork-artifacts"

--- a/echo-plugins-test/echo-plugins-test.gradle
+++ b/echo-plugins-test/echo-plugins-test.gradle
@@ -13,9 +13,3 @@ dependencies {
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
-
-test {
-  useJUnitPlatform {
-    includeEngines("junit-jupiter", "junit-vintage")
-  }
-}

--- a/echo-telemetry/echo-telemetry.gradle
+++ b/echo-telemetry/echo-telemetry.gradle
@@ -33,9 +33,3 @@ dependencies {
   testImplementation 'io.strikt:strikt-core'
   testImplementation "io.spinnaker.kork:kork-jedis-test"
 }
-
-test {
-  useJUnitPlatform {
-    includeEngines("junit-vintage", "junit-jupiter")
-  }
-}

--- a/echo-web/src/test/java/com/netflix/spinnaker/echo/ApplicationSpec.java
+++ b/echo-web/src/test/java/com/netflix/spinnaker/echo/ApplicationSpec.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo;
 
 import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService;
 import com.netflix.spinnaker.echo.services.Front50Service;
+import com.netflix.spinnaker.fiat.shared.FiatService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,6 +33,8 @@ public class ApplicationSpec {
   @MockBean Front50Service front50Service;
 
   @MockBean OrcaService orcaService;
+
+  @MockBean FiatService fiatService;
 
   @Test
   public void startupTest() {}

--- a/echo-web/src/test/java/com/netflix/spinnaker/echo/telemetry/TelemetrySpec.java
+++ b/echo-web/src/test/java/com/netflix/spinnaker/echo/telemetry/TelemetrySpec.java
@@ -22,6 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.netflix.spinnaker.echo.Application;
 import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService;
 import com.netflix.spinnaker.echo.services.Front50Service;
+import com.netflix.spinnaker.fiat.shared.FiatService;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +44,8 @@ public class TelemetrySpec {
   @MockBean Front50Service front50Service;
 
   @MockBean OrcaService orcaService;
+
+  @MockBean FiatService fiatService;
 
   @Autowired WebApplicationContext wac;
 

--- a/echo-web/src/test/resources/echo-test.yml
+++ b/echo-web/src/test/resources/echo-test.yml
@@ -4,9 +4,6 @@ spinnaker:
 front50:
   baseUrl: 'http://localhost:8080'
 
-orca:
-  baseUrl: 'http://localhost:8083'
-
 resilience4j.circuitbreaker:
   instances:
     telemetry:

--- a/echo-webhooks/echo-webhooks.gradle
+++ b/echo-webhooks/echo-webhooks.gradle
@@ -28,9 +28,3 @@ dependencies {
   testRuntimeOnly "org.junit.platform:junit-platform-launcher"
   testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
 }
-
-test {
-  useJUnitPlatform {
-    includeEngines "junit-vintage", "junit-jupiter"
-  }
-}


### PR DESCRIPTION
Spring boot 2.4.x removed JUnit5 vintage engine from spring-boot-starter-test. 
[https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#junit-5s-vintage-engine-removed-from-spring-boot-starter-test] It is required for executing junit4 based test cases in echo. So, introducing junit-vintage-engine dependency in build.gradle, using testRuntimeOnly() as suggested in section 3.1 of https://junit.org/junit5/docs/5.6.2/user-guide/index.pdf

After applying this fix, coverage increased from 533 to 535 test case executions.

Clean up the call for test engines using `useJUnitPlatform()` from sub-modules, and placing it in build.gradle. As per the gradle docs, all test engines on the test runtime classpath will be used by sub modules. https://docs.gradle.org/6.8.1/userguide/java_testing.html#filtering_test_engine

Encountered below error with `gradle :echo-web:test --tests "com.netflix.spinnaker.echo.ApplicationSpec.startupTest"` test execution:
```
Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
2023-03-13 22:26:53.554 ERROR 60447 --- [    Test worker] o.s.boot.SpringApplication               : Application run failed

org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'pipelineTriggerJob' defined in URL [jar:file:/echo/echo-scheduler/build/libs/echo-scheduler.jar!/com/netflix/spinnaker/echo/scheduler/actions/pipeline/PipelineTriggerJob.class]: Unsatisfied dependency expressed through constructor parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'pipelineInitiator' defined in URL [jar:file:/echo/echo-pipelinetriggers/build/libs/echo-pipelinetriggers.jar!/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.class]: Unsatisfied dependency expressed through constructor parameter 2; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'fiatPermissionEvaluator' defined in URL [jar:file:/.gradle/caches/modules-2/files-2.1/io.spinnaker.fiat/fiat-api/1.36.0/f491739bbb725f377af0e49136c948964ff25827/fiat-api-1.36.0.jar!/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.class]: Unsatisfied dependency expressed through constructor parameter 1; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'fiatService' defined in class path resource [com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.netflix.spinnaker.fiat.shared.FiatService]: Factory method 'fiatService' threw exception; nested exception is java.lang.NullPointerException
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:800) ~[spring-beans-5.3.13.jar:5.3.13]
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:229) ~[spring-beans-5.3.13.jar:5.3.13]

Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'pipelineInitiator' defined in URL [jar:file:/echo/echo-pipelinetriggers/build/libs/echo-pipelinetriggers.jar!/com/netflix/spinnaker/echo/pipelinetriggers/orca/PipelineInitiator.class]: Unsatisfied dependency expressed through constructor parameter 2; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'fiatPermissionEvaluator' defined in URL [jar:file:/.gradle/caches/modules-2/files-2.1/io.spinnaker.fiat/fiat-api/1.36.0/f491739bbb725f377af0e49136c948964ff25827/fiat-api-1.36.0.jar!/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.class]: Unsatisfied dependency expressed through constructor parameter 1; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'fiatService' defined in class path resource [com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.netflix.spinnaker.fiat.shared.FiatService]: Factory method 'fiatService' threw exception; nested exception is java.lang.NullPointerException
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:800) ~[spring-beans-5.3.13.jar:5.3.13]
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:229) ~[spring-beans-5.3.13.jar:5.3.13]

Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'fiatPermissionEvaluator' defined in URL [jar:file:/.gradle/caches/modules-2/files-2.1/io.spinnaker.fiat/fiat-api/1.36.0/f491739bbb725f377af0e49136c948964ff25827/fiat-api-1.36.0.jar!/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.class]: Unsatisfied dependency expressed through constructor parameter 1; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'fiatService' defined in class path resource [com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.netflix.spinnaker.fiat.shared.FiatService]: Factory method 'fiatService' threw exception; nested exception is java.lang.NullPointerException
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:800) ~[spring-beans-5.3.13.jar:5.3.13]
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:229) ~[spring-beans-5.3.13.jar:5.3.13]

Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'fiatService' defined in class path resource [com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.netflix.spinnaker.fiat.shared.FiatService]: Factory method 'fiatService' threw exception; nested exception is java.lang.NullPointerException
	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:658) ~[spring-beans-5.3.13.jar:5.3.13]
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:638) ~[spring-beans-5.3.13.jar:5.3.13]

Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.netflix.spinnaker.fiat.shared.FiatService]: Factory method 'fiatService' threw exception; nested exception is java.lang.NullPointerException
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:185) ~[spring-beans-5.3.13.jar:5.3.13]
	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:653) ~[spring-beans-5.3.13.jar:5.3.13]
	... 153 common frames omitted
Caused by: java.lang.NullPointerException: null
	at java.base/java.util.Objects.requireNonNull(Objects.java:221) ~[na:na]
	at com.netflix.spinnaker.config.DefaultServiceEndpoint.<init>(DefaultServiceEndpoint.java:82) ~[kork-web-7.167.0.jar:7.167.0]
	at com.netflix.spinnaker.config.DefaultServiceEndpoint.<init>(DefaultServiceEndpoint.java:59) ~[kork-web-7.167.0.jar:7.167.0]
	at com.netflix.spinnaker.config.DefaultServiceEndpoint.<init>(DefaultServiceEndpoint.java:55) ~[kork-web-7.167.0.jar:7.167.0]
	at com.netflix.spinnaker.fiat.shared.FiatAuthenticationConfig.fiatService(FiatAuthenticationConfig.java:77) ~[fiat-api-1.36.0.jar:1.36.0]
 ```
 Fix the issue by adding `services.fiat.baseUrl` property in echo-test.yml