### PR TITLE
feat(pipelinetriggers): only cache enabled pipelines with enabled triggers of specific types

### DIFF
--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/services/Front50Service.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/services/Front50Service.java
@@ -11,12 +11,24 @@ public interface Front50Service {
   List<Map<String, Object>>
       getPipelines(); // Return Map here so we don't throw away MPT attributes.
 
+  @GET("/pipelines?restricted=false")
+  @Headers("Accept: application/json")
+  List<Map<String, Object>> getPipelines(
+      @Query("enabledPipelines") Boolean enabledPipelines,
+      @Query("enabledTriggers") Boolean enabledTriggers,
+      @Query("triggerTypes")
+          String triggerTypes); // Return Map here so we don't throw away MPT attributes.
+
   @GET("/pipelines/{application}?refresh=false")
   @Headers("Accept: application/json")
   List<Pipeline> getPipelines(@Path("application") String application);
 
   @GET("/pipelines/{pipelineId}/get")
   Map<String, Object> getPipeline(@Path("pipelineId") String pipelineId);
+
+  @GET("/pipelines/{application}/name/{name}?refresh=true")
+  Map<String, Object> getPipelineByName(
+      @Path("application") String application, @Path("name") String name);
 
   @POST("/graphql")
   @Headers("Accept: application/json")

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/PipelineTriggerConfiguration.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/PipelineTriggerConfiguration.java
@@ -6,6 +6,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.config.DefaultServiceEndpoint;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.echo.jackson.EchoObjectMapper;
+import com.netflix.spinnaker.echo.pipelinetriggers.PipelineCacheConfigurationProperties;
 import com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.PubsubEventHandler;
 import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService;
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties;
@@ -32,6 +33,7 @@ import retrofit.converter.JacksonConverter;
 @ComponentScan(value = "com.netflix.spinnaker.echo.pipelinetriggers")
 @EnableConfigurationProperties({
   FiatClientConfigurationProperties.class,
+  PipelineCacheConfigurationProperties.class,
   QuietPeriodIndicatorConfigurationProperties.class
 })
 public class PipelineTriggerConfiguration {

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCache.java
@@ -23,6 +23,8 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.patterns.PolledMeter;
 import com.netflix.spinnaker.echo.model.Pipeline;
 import com.netflix.spinnaker.echo.model.Trigger;
+import com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.BaseTriggerEventHandler;
+import com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.TriggerEventHandler;
 import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService;
 import com.netflix.spinnaker.echo.services.Front50Service;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
@@ -37,6 +39,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +58,13 @@ public class PipelineCache implements MonitoredPoller {
   private final ObjectMapper objectMapper;
   private final PipelineCacheConfigurationProperties pipelineCacheConfigurationProperties;
 
+  /**
+   * If enabled by a feature flag, query front50 for (enabled) pipelines with only these (enabled)
+   * trigger types. A comma-separated string since that's what front50 expects. Getter only for
+   * testing.
+   */
+  @Getter private final String supportedTriggerTypes;
+
   private volatile Boolean running;
   private volatile Instant lastPollTimestamp;
 
@@ -70,7 +80,8 @@ public class PipelineCache implements MonitoredPoller {
       ObjectMapper objectMapper,
       @NonNull Front50Service front50,
       @NonNull OrcaService orca,
-      @NonNull Registry registry) {
+      @NonNull Registry registry,
+      @NonNull List<BaseTriggerEventHandler> triggerHandlers) {
     this(
         Executors.newSingleThreadScheduledExecutor(),
         pollingIntervalMs,
@@ -79,7 +90,8 @@ public class PipelineCache implements MonitoredPoller {
         objectMapper,
         front50,
         orca,
-        registry);
+        registry,
+        triggerHandlers);
   }
 
   // VisibleForTesting
@@ -91,7 +103,8 @@ public class PipelineCache implements MonitoredPoller {
       ObjectMapper objectMapper,
       @NonNull Front50Service front50,
       @NonNull OrcaService orca,
-      @NonNull Registry registry) {
+      @NonNull Registry registry,
+      @NonNull List<BaseTriggerEventHandler> triggerHandlers) {
     this.objectMapper = objectMapper;
     this.executorService = executorService;
     this.pollingIntervalMs = pollingIntervalMs;
@@ -103,6 +116,28 @@ public class PipelineCache implements MonitoredPoller {
     this.running = false;
     this.pipelines = null;
     this.triggersByType = null;
+
+    /**
+     * triggerHandlers are the main consumers of the pipelines here. Only query front50 for
+     * (enabled) pipelines with (enabled) triggers that these handlers support, as well as cron
+     * triggers, which PipelineConfigsPollingJob and MissedPipelineTriggerCompensationJob also
+     * consume. This handles the majority of cases, but there's one missing -- manual execution of
+     * pipelines. There's additional logic in ManualEventHandler to retrieve the pipeline in
+     * question for front50 when it's not present here in the cache.
+     */
+    Stream<String> triggerTypesStream =
+        triggerHandlers.stream()
+            .map(TriggerEventHandler::supportedTriggerTypes)
+            .flatMap(List<String>::stream);
+
+    // Sort to provide a predictable order which facilitates testing.
+    this.supportedTriggerTypes =
+        Stream.concat(triggerTypesStream, Stream.of(Trigger.Type.CRON.toString()))
+            .sorted()
+            .distinct()
+            .collect(Collectors.joining(","));
+
+    log.info("supportedTriggerTypes: {}", supportedTriggerTypes);
   }
 
   @PreDestroy
@@ -129,6 +164,15 @@ public class PipelineCache implements MonitoredPoller {
     PolledMeter.using(registry)
         .withName("front50.lastPoll")
         .monitorValue(this, PipelineCache::getDurationSeconds);
+  }
+
+  /**
+   * Accessor for whether we're filtering front50 pipelines or not. Yes, this information is
+   * available via PipelineCacheConfigurationProperties, but it seems cleaner to provide it directly
+   * this way, so users of PipelineCache don't need to care how we're configured. `
+   */
+  public boolean isFilterFront50Pipelines() {
+    return pipelineCacheConfigurationProperties.isFilterFront50Pipelines();
   }
 
   private Double getDurationSeconds() {
@@ -186,7 +230,14 @@ public class PipelineCache implements MonitoredPoller {
 
   private List<Map<String, Object>> fetchRawPipelines() {
     List<Map<String, Object>> rawPipelines =
-        AuthenticatedRequest.allowAnonymous(() -> front50.getPipelines());
+        AuthenticatedRequest.allowAnonymous(
+            () -> {
+              if (pipelineCacheConfigurationProperties.isFilterFront50Pipelines()) {
+                return front50.getPipelines(
+                    true /* enabledPipelines */, true /* enabledTriggers */, supportedTriggerTypes);
+              }
+              return front50.getPipelines();
+            });
     return (rawPipelines == null) ? Collections.emptyList() : rawPipelines;
   }
 
@@ -231,13 +282,15 @@ public class PipelineCache implements MonitoredPoller {
         .collect(Collectors.groupingBy(Trigger::getType));
   }
 
-  // looks up the latest version in front50 of a (potentially stale) pipeline config from the cache
-  // if anything fails during the refresh, we fall back to returning the cached version
+  /**
+   * Look up the latest version in front50 of a (potentially stale) pipeline config from the cache
+   * if anything fails during the refresh, we fall back to returning the cached version
+   */
   public Pipeline refresh(Pipeline cached) {
     try {
       Map<String, Object> pipeline = front50.getPipeline(cached.getId());
       Optional<Pipeline> processed = process(pipeline);
-      if (!processed.isPresent()) {
+      if (processed.isEmpty()) {
         log.warn(
             "Failed to process raw pipeline, falling back to cached={}\n  latestVersion={}",
             cached,
@@ -250,6 +303,52 @@ public class PipelineCache implements MonitoredPoller {
     } catch (Exception e) {
       log.error("Exception during pipeline refresh, falling back to cached={}", cached, e);
       return cached;
+    }
+  }
+
+  /**
+   * Look up the latest version in front50 of a pipeline id. If anything fails, return an empty
+   * Optional.
+   */
+  public Optional<Pipeline> getPipelineById(String id) {
+    try {
+      Map<String, Object> pipeline = front50.getPipeline(id);
+      Optional<Pipeline> processed = process(pipeline);
+      if (processed.isEmpty()) {
+        log.warn("Failed to process raw pipeline id {}, latestVersion={}", id, pipeline);
+        return Optional.empty();
+      }
+
+      // at this point, we are not updating the cache but just providing a fresh view
+      return processed;
+    } catch (Exception e) {
+      log.error("Exception during query of pipeline id {}", id, e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Look up the latest version in front50 of a pipeline application + name. If anything fails,
+   * return an empty Optional.
+   */
+  public Optional<Pipeline> getPipelineByName(String application, String name) {
+    try {
+      Map<String, Object> pipeline = front50.getPipelineByName(application, name);
+      Optional<Pipeline> processed = process(pipeline);
+      if (processed.isEmpty()) {
+        log.warn(
+            "Failed to process raw pipeline application {}, name {}, latestVersion={}",
+            application,
+            name,
+            pipeline);
+        return Optional.empty();
+      }
+
+      // at this point, we are not updating the cache but just providing a fresh view
+      return processed;
+    } catch (Exception e) {
+      log.error("Exception during query of pipeline application {} name {}", application, name, e);
+      return Optional.empty();
     }
   }
 

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheConfigurationProperties.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheConfigurationProperties.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pipelinetriggers;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties("pipeline-cache")
+public class PipelineCacheConfigurationProperties {
+  /** parallelism in the ForkJoinPool used to process pipelines from front50 */
+  private int parallelism = Runtime.getRuntime().availableProcessors();
+}

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheConfigurationProperties.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheConfigurationProperties.java
@@ -24,4 +24,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class PipelineCacheConfigurationProperties {
   /** parallelism in the ForkJoinPool used to process pipelines from front50 */
   private int parallelism = Runtime.getRuntime().availableProcessors();
+
+  /**
+   * If false, query front50 for all pipelines. If true, query front50 for only enabled pipelines
+   * with enabled triggers with types that echo requires.
+   */
+  private boolean filterFront50Pipelines;
 }

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheSpec.groovy
@@ -37,6 +37,7 @@ class PipelineCacheSpec extends Specification implements RetrofitStubs {
   def orca = Mock(OrcaService)
   def registry = new NoopRegistry()
   def objectMapper = EchoObjectMapper.getInstance()
+  def pipelineCacheConfigurationProperties = new PipelineCacheConfigurationProperties()
 
   @Shared
   def interval = 30
@@ -44,11 +45,8 @@ class PipelineCacheSpec extends Specification implements RetrofitStubs {
   @Shared
   def sleepMs = 100
 
-  @Shared
-  def parallelism = 8
-
   @Subject
-  def pipelineCache = new PipelineCache(Mock(ScheduledExecutorService), interval, sleepMs, parallelism, objectMapper, front50, orca, registry)
+  def pipelineCache = new PipelineCache(Mock(ScheduledExecutorService), interval, sleepMs, pipelineCacheConfigurationProperties, objectMapper, front50, orca, registry)
 
   def "keeps polling if Front50 returns an error"() {
     given:
@@ -164,4 +162,3 @@ class PipelineCacheSpec extends Specification implements RetrofitStubs {
     triggers.isEmpty()
   }
 }
-

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.echo.jackson.EchoObjectMapper
 import com.netflix.spinnaker.echo.model.Pipeline
 import com.netflix.spinnaker.echo.model.Trigger
+import com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.BaseTriggerEventHandler
 import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService
 import com.netflix.spinnaker.echo.services.Front50Service
 import com.netflix.spinnaker.echo.test.RetrofitStubs
@@ -39,6 +40,17 @@ class PipelineCacheSpec extends Specification implements RetrofitStubs {
   def objectMapper = EchoObjectMapper.getInstance()
   def pipelineCacheConfigurationProperties = new PipelineCacheConfigurationProperties()
 
+  /**
+   * To verify that PipelineCache passes the expected supportedTriggers
+   * to front50's getPipelines endpoint.
+   */
+  def supportedTrigger = "arbitrary"
+  def baseTriggerEventHandler = Mock(BaseTriggerEventHandler) {
+    supportedTriggerTypes() >> List.of(supportedTrigger)
+  }
+  def supportedTriggers = "${supportedTrigger},cron"
+  List<BaseTriggerEventHandler> triggerHandlers = List.of(baseTriggerEventHandler)
+
   @Shared
   def interval = 30
 
@@ -46,7 +58,7 @@ class PipelineCacheSpec extends Specification implements RetrofitStubs {
   def sleepMs = 100
 
   @Subject
-  def pipelineCache = new PipelineCache(Mock(ScheduledExecutorService), interval, sleepMs, pipelineCacheConfigurationProperties, objectMapper, front50, orca, registry)
+  def pipelineCache = new PipelineCache(Mock(ScheduledExecutorService), interval, sleepMs, pipelineCacheConfigurationProperties, objectMapper, front50, orca, registry, triggerHandlers)
 
   def "keeps polling if Front50 returns an error"() {
     given:
@@ -81,6 +93,64 @@ class PipelineCacheSpec extends Specification implements RetrofitStubs {
 
     then: 'we return the updated value'
     pipelineCache.getPipelines() == [pipeline]
+  }
+
+  def "filters front50 pipelines when configured to do so"() {
+    given:
+    pipelineCacheConfigurationProperties.filterFront50Pipelines = true
+
+    when:
+    pipelineCache.start()
+    pipelineCache.pollPipelineConfigs()
+
+    then:
+    1 * front50.getPipelines(true, true, supportedTriggers) >> [] // arbitrary return value
+  }
+
+  def "getPipelineById calls front50's getPipeline endpoint"() {
+    given:
+    def pipelineId = "my-pipeline-id"
+    def application = "application"
+    def pipelineName = "my-pipeline-name"
+    def pipelineMap = [
+      application: application,
+      name       : pipelineName,
+      id         : pipelineId
+    ]
+    def pipeline = Pipeline.builder().application(application).name(pipelineName).id(pipelineId).build()
+
+    when:
+    Optional<Pipeline> result = pipelineCache.getPipelineById(pipelineId)
+
+    then:
+    1 * front50.getPipeline(pipelineId) >> pipelineMap
+    0 * front50._
+
+    assert result.isPresent()
+    result.get() == pipeline
+  }
+
+  def "getPipelineByName calls front50's getPipelineByName endpoint"() {
+    given:
+    def pipelineId = "my-pipeline-id"
+    def application = "application"
+    def pipelineName = "my-pipeline-name"
+    def pipelineMap = [
+      application: application,
+      name       : pipelineName,
+      id         : pipelineId
+    ]
+    def pipeline = Pipeline.builder().application(application).name(pipelineName).id(pipelineId).build()
+
+    when:
+    Optional<Pipeline> result = pipelineCache.getPipelineByName(application, pipelineName)
+
+    then:
+    1 * front50.getPipelineByName(application, pipelineName) >> pipelineMap
+    0 * front50._
+
+    assert result.isPresent()
+    result.get() == pipeline
   }
 
   def "we can serialize pipelines with triggers that have a parent"() {

--- a/echo-pipelinetriggers/src/test/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheTest.java
+++ b/echo-pipelinetriggers/src/test/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.pipelinetriggers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spinnaker.echo.model.Trigger;
+import com.netflix.spinnaker.echo.pipelinetriggers.eventhandlers.BaseTriggerEventHandler;
+import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService;
+import com.netflix.spinnaker.echo.services.Front50Service;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.annotation.UserConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+public class PipelineCacheTest {
+  // minimal set of beans necessary to initialize PipelineCache, with additional
+  // BaseTriggerEventHandlers to verify behavior.
+  private final ApplicationContextRunner runner =
+      new ApplicationContextRunner()
+          .withBean(PipelineCache.class)
+          .withBean(PipelineCacheConfigurationProperties.class)
+          .withBean(ObjectMapper.class)
+          .withBean(NoopRegistry.class)
+          .withConfiguration(UserConfigurations.of(ConfigWithTriggerEventHandlers.class));
+
+  @Test
+  void testPipelineCacheSupportedTriggerTypes() {
+    runner.run(
+        ctx -> {
+          PipelineCache pipelineCache = ctx.getBean(PipelineCache.class);
+          assertThat(pipelineCache.getSupportedTriggerTypes())
+              .isEqualTo(Trigger.Type.CRON.toString() + ",trigger-type-one,trigger-type-two");
+        });
+  }
+
+  /**
+   * To exercise the logic in PipelineCache that determines supported trigger types from the
+   * available BeanTriggerEventHandler beans.
+   */
+  @TestConfiguration
+  static class ConfigWithTriggerEventHandlers {
+    @Bean
+    Front50Service front50Service() {
+      return mock(Front50Service.class);
+    }
+
+    @Bean
+    OrcaService orcaService() {
+      return mock(OrcaService.class);
+    }
+
+    @Bean
+    BaseTriggerEventHandler triggerEventHandlerOne() {
+      BaseTriggerEventHandler triggerEventHandler = mock(BaseTriggerEventHandler.class);
+      when(triggerEventHandler.supportedTriggerTypes()).thenReturn(List.of("trigger-type-one"));
+      return triggerEventHandler;
+    }
+
+    @Bean
+    BaseTriggerEventHandler triggerEventHandlerTwo() {
+      BaseTriggerEventHandler triggerEventHandler = mock(BaseTriggerEventHandler.class);
+      when(triggerEventHandler.supportedTriggerTypes()).thenReturn(List.of("trigger-type-two"));
+      return triggerEventHandler;
+    }
+
+    /** To verify that duplicates don't make it to the resulting comma-separated string */
+    @Bean
+    BaseTriggerEventHandler anotherTriggerEventHandlerTwo() {
+      BaseTriggerEventHandler triggerEventHandler = mock(BaseTriggerEventHandler.class);
+      when(triggerEventHandler.supportedTriggerTypes()).thenReturn(List.of("trigger-type-two"));
+      return triggerEventHandler;
+    }
+
+    /**
+     * To verify that cron only makes it once to the resulting comma-separated string, if there's
+     * ever an event handler for it.
+     */
+    @Bean
+    BaseTriggerEventHandler cronTriggerEventHandler() {
+      BaseTriggerEventHandler triggerEventHandler = mock(BaseTriggerEventHandler.class);
+      when(triggerEventHandler.supportedTriggerTypes())
+          .thenReturn(List.of(Trigger.Type.CRON.toString()));
+      return triggerEventHandler;
+    }
+  }
+}


### PR DESCRIPTION
when pipelineCache.filterFront50Pipelines is true.  Determine the specific types from the types that the available BaseTriggerEventHandler beans support, with cron triggers as well. Adjust the logic in ManualEventHandler to work when the cache only contains a subset of pipelines.

When pipelineCache.filterFront50Pipelines is false, retain the current behavior to query front50 for all pipelines.

Note that both before and after this change, when ManualEventHandler gets a pipeline from the cache, it queries front50 for a single pipeline by id to make sure what it's triggering is up to date.  As currently implemented, front50 queries its database by id to generate the response.

Currently, deck triggers by pipeline application + name.  See for example
https://github.com/spinnaker/deck/blob/8abafe5c6a6680953aef7752b1a56cac093ec9ba/packages/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx#L138 and
https://github.com/spinnaker/deck/blob/8abafe5c6a6680953aef7752b1a56cac093ec9ba/packages/core/src/domain/IPipeline.ts#L86.

With this PR, ManualEventHandler now queries a new endpoint in front50 by application and name when there's no cached pipeline corresponding to a trigger.  Front50's database query in this case is likely slightly more expensive that querying by id, but not enough to be significant, especially since we're dealing with human-initiated events.  If the query by application and name fails, ManualEventTrigger then queries by pipeline id, so triggers by pipeline id (if there are any) are less performant than before as they involve another round trip to front50 to query by application and name first.

It does seem feasible, though not totally trivial, to change deck to trigger manual execution by pipeline id.  If this happens, it would make sense to change the order of queries in ManualEventHandler to query by id first.  That would restore the performance of manual execution by deck what it was before this PR.

depends on https://github.com/spinnaker/front50/pull/1252