### PR TITLE
chore(dependency): add explicit dependency of groovy-json in echo-core and echo-pipelinetriggers while upgrading groovy 3.x

### DIFF
--- a/echo-core/echo-core.gradle
+++ b/echo-core/echo-core.gradle
@@ -44,4 +44,5 @@ dependencies {
 
     testImplementation "org.spockframework:spock-spring"
     testImplementation "org.springframework:spring-test"
+    testImplementation "org.codehaus.groovy:groovy-json"
 }

--- a/echo-pipelinetriggers/echo-pipelinetriggers.gradle
+++ b/echo-pipelinetriggers/echo-pipelinetriggers.gradle
@@ -47,6 +47,7 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.assertj:assertj-core"
+  testImplementation "org.codehaus.groovy:groovy-json"
 
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, groovy-json is not part of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/2.0-groovy-3.0) and encounter below error during test compilation:
```
> Task :echo-core:compileTestGroovy
startup failed:
/echo/echo-core/src/test/groovy/com/netflix/spinnaker/echo/services/Front50ServiceSpec.groovy: 3: unable to resolve class groovy.json.JsonOutput
 @ line 3, column 1.
   import groovy.json.JsonOutput
   ^
1 error
> Task :echo-core:compileTestGroovy FAILED
```

```
> Task :echo-pipelinetriggers:compileTestGroovy
startup failed:
/echo/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/CDEventsWebhookHandlerSpec.groovy: 28: unable to resolve class groovy.json.JsonOutput
 @ line 28, column 1.
   import groovy.json.JsonOutput
   ^
/echo/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/PubsubEventHandlerSpec.groovy: 30: unable to resolve class groovy.json.JsonOutput
 @ line 30, column 1.
   import groovy.json.JsonOutput
   ^
2 errors
> Task :echo-pipelinetriggers:compileTestGroovy FAILED
```

So, adding explicit dependency of groovy-json in echo-core.gradle and echo-pipelinetriggers.gradle

With groovy 2.5.15 and spockframework 1.3-groovy-2.5, groovy-json appear as transitive dependency of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/1.3-groovy-2.5) as shown below:
```
$ ./gradlew echo-core:dI --dependency groovy-json --configuration testCompileClasspath

> Task :echo-core:dependencyInsight
org.codehaus.groovy:groovy-json:2.5.15
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy-json:2.5.15
\--- io.spinnaker.kork:kork-bom:7.190.0
     \--- testCompileClasspath

org.codehaus.groovy:groovy-json:2.5.4 -> 2.5.15
+--- org.spockframework:spock-core:1.3-groovy-2.5
|    +--- testCompileClasspath (requested org.spockframework:spock-core)
|    +--- io.spinnaker.kork:kork-bom:7.190.0
|    |    \--- testCompileClasspath
|    \--- org.spockframework:spock-spring:1.3-groovy-2.5
|         +--- testCompileClasspath (requested org.spockframework:spock-spring)
|         \--- io.spinnaker.kork:kork-bom:7.190.0 (*)
\--- org.spockframework:spock-spring:1.3-groovy-2.5 (*)
```

```
$ ./gradlew echo-pipelinetriggers:dI --dependency groovy-json --configuration testCompileClasspath

> Task :echo-pipelinetriggers:dependencyInsight
org.codehaus.groovy:groovy-json:2.5.15
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy-json:2.5.15
\--- io.spinnaker.kork:kork-bom:7.190.0
     \--- testCompileClasspath

org.codehaus.groovy:groovy-json:2.5.4 -> 2.5.15
+--- org.spockframework:spock-core:1.3-groovy-2.5
|    +--- testCompileClasspath (requested org.spockframework:spock-core)
|    +--- io.spinnaker.kork:kork-bom:7.190.0
|    |    \--- testCompileClasspath
|    \--- org.spockframework:spock-spring:1.3-groovy-2.5
|         +--- testCompileClasspath (requested org.spockframework:spock-spring)
|         \--- io.spinnaker.kork:kork-bom:7.190.0 (*)
\--- org.spockframework:spock-spring:1.3-groovy-2.5 (*)
```