### PR TITLE
refactor(tests): fix conflict of variable scope by renaming local variables during upgrade of groovy 3.x

### DIFF
--- a/echo-core/src/test/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgentSpec.groovy
+++ b/echo-core/src/test/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgentSpec.groovy
@@ -39,7 +39,7 @@ class AbstractEventNotificationAgentSpec extends Specification {
   @Unroll
   def "sends notifications based on status and configuration"() {
     given:
-    subclassMock.sendNotifications(*_) >> { notification, application, event, config, status -> }
+    subclassMock.sendNotifications(*_) >> { notification, application, event, config, status_local -> }
 
     when:
     agent.processEvent(event)

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/GithubNotificationAgentSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/GithubNotificationAgentSpec.groovy
@@ -47,8 +47,8 @@ class GithubNotificationAgentSpec extends Specification {
   def "sets correct status check for #status status in pipeline events"() {
     given:
     def actualMessage = new BlockingVariable<GithubStatus>()
-    github.updateCheck(*_) >> { token, repo, sha, status ->
-      actualMessage.set(status)
+    github.updateCheck(*_) >> { token, repo, sha, status_local ->
+      actualMessage.set(status_local)
     }
     github.getCommit(*_) >> { token, repo, sha ->
       new Response("url", 200, "nothing", [], new TypedByteArray("application/json", "message".bytes))
@@ -96,8 +96,8 @@ class GithubNotificationAgentSpec extends Specification {
   def "sets correct status check for #status status in stage events"() {
     given:
     def actualMessage = new BlockingVariable<GithubStatus>()
-    github.updateCheck(*_) >> { token, repo, sha, status ->
-      actualMessage.set(status)
+    github.updateCheck(*_) >> { token, repo, sha, status_local ->
+      actualMessage.set(status_local)
     }
     github.getCommit(*_) >> { token, repo, sha ->
       new Response("url", 200, "nothing", [], new TypedByteArray("application/json", "message".bytes))

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/GoogleChatNotificationAgentSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/GoogleChatNotificationAgentSpec.groovy
@@ -60,8 +60,8 @@ public class GoogleChatNotificationAgentSpec extends Specification {
   def "appends custom message to #status message if present"() {
     given:
     def actualMessage = new BlockingVariable<GoogleChatMessage>()
-    googleChat.sendMessage(*_) >> { webhookURL, message ->
-      actualMessage.set(message)
+    googleChat.sendMessage(*_) >> { webhookURL_local, message_local ->
+      actualMessage.set(message_local)
     }
 
     when:
@@ -89,8 +89,8 @@ public class GoogleChatNotificationAgentSpec extends Specification {
   def "sends entirely custom message if customMessage field is present, performing text replacement if needed"() {
     given:
     def actualMessage = new BlockingVariable<GoogleChatMessage>()
-    googleChat.sendMessage(*_) >> { webhookURL, message ->
-      actualMessage.set(message)
+    googleChat.sendMessage(*_) >> { webhookURL_local, message_local ->
+      actualMessage.set(message_local)
     }
 
     when:

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgentSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgentSpec.groovy
@@ -33,7 +33,7 @@ class SlackNotificationAgentSpec extends Specification {
   def "sends correct message for #status status"() {
     given:
     def actualMessage = new BlockingVariable<SlackAttachment>()
-    slack.sendMessage(*_) >> { message, channel, asUser ->
+    slack.sendMessage(*_) >> { message, channel_local, asUser ->
       actualMessage.set(message)
     }
 
@@ -59,8 +59,8 @@ class SlackNotificationAgentSpec extends Specification {
   def "appends custom message to #status message if present"() {
     given:
     def actualMessage = new BlockingVariable<SlackAttachment>()
-    slack.sendMessage(*_) >> { message, channel, asUser ->
-      actualMessage.set(message)
+    slack.sendMessage(*_) >> { message_local, channel_local, asUser ->
+      actualMessage.set(message_local)
     }
 
     when:
@@ -88,7 +88,7 @@ class SlackNotificationAgentSpec extends Specification {
   def "sends entirely custom message if customMessage field is present, performing text replacement if needed"() {
     given:
     def actualMessage = new BlockingVariable<SlackAttachment>()
-    slack.sendMessage(*_) >> { message, channel, asUser ->
+    slack.sendMessage(*_) >> { message, channel_local, asUser ->
       actualMessage.set(message)
     }
 


### PR DESCRIPTION
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, encountered the following errors in groovy test compilation of echo-core and echo-notifications modules:
```
startup failed:
/echo/echo-core/src/test/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgentSpec.groovy: 42: The current scope already contains a variable of the name event
 @ line 42, column 43.
   Mock.sendNotifications(*_) >> { notifica
                                 ^
1 error
> Task :echo-core:compileTestGroovy FAILED
```

```
startup failed:
/echo/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/GithubNotificationAgentSpec.groovy: 50: The current scope already contains a variable of the name status
 @ line 50, column 31.
       github.updateCheck(*_) >> { token, repo, sha, status ->
                                 ^
1 error
> Task :echo-notifications:compileTestGroovy FAILED

startup failed:
/echo/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/GithubNotificationAgentSpec.groovy: 99: The current scope already contains a variable of the name status
 @ line 99, column 31.
       github.updateCheck(*_) >> { token, repo, sha, status ->
                                 ^
1 error
> Task :echo-notifications:compileTestGroovy FAILED
```

```
startup failed:
/echo/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/GoogleChatNotificationAgentSpec.groovy: 63: The current scope already contains a variable of the name webhookURL
 @ line 63, column 35.
       googleChat.sendMessage(*_) >> { webhookURL, message ->
                                     ^
/echo/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/GoogleChatNotificationAgentSpec.groovy: 63: The current scope already contains a variable of the name message
 @ line 63, column 35.
       googleChat.sendMessage(*_) >> { webhookURL, message ->
                                     ^
2 errors
> Task :echo-notifications:compileTestGroovy FAILED

> Task :echo-notifications:compileTestGroovy FAILED
startup failed:
/echo/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/GoogleChatNotificationAgentSpec.groovy: 92: The current scope already contains a variable of the name webhookURL
 @ line 92, column 35.
       googleChat.sendMessage(*_) >> { webhookURL, message ->
                                     ^
1 error
```

```
startup failed:
/echo/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgentSpec.groovy: 36: The current scope already contains a variable of the name channel
 @ line 36, column 30.
       slack.sendMessage(*_) >> { message, channel, asUser ->
                                ^
1 error
> Task :echo-notifications:compileTestGroovy FAILED

> Task :echo-notifications:compileTestGroovy FAILED
startup failed:
/echo/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgentSpec.groovy: 62: The current scope already contains a variable of the name message
 @ line 62, column 30.
       slack.sendMessage(*_) >> { message, channel, asUser ->
                                ^
/echo/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgentSpec.groovy: 62: The current scope already contains a variable of the name channel
 @ line 62, column 30.
       slack.sendMessage(*_) >> { message, channel, asUser ->
                                ^
2 errors

startup failed:
/echo/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/SlackNotificationAgentSpec.groovy: 91: The current scope already contains a variable of the name channel
 @ line 91, column 30.
       slack.sendMessage(*_) >> { message, channel, asUser ->
                                ^
1 error
> Task :echo-notifications:compileTestGroovy FAILED
```

To fix this issue renamed the local variables to avoid the scope conflict with global variables.