### PR TITLE
refactor(tests): fix conflict of variable scope by renaming local variables during upgrade of groovy 3.x

### DIFF
--- a/echo-core/src/test/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgentSpec.groovy
+++ b/echo-core/src/test/groovy/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgentSpec.groovy
@@ -39,7 +39,7 @@ class AbstractEventNotificationAgentSpec extends Specification {
   @Unroll
   def "sends notifications based on status and configuration"() {
     given:
-    subclassMock.sendNotifications(*_) >> { notification, application, event, config, status_local -> }
+    subclassMock.sendNotifications(*_) >> { notification, application, event_local, config, status -> }
 
     when:
     agent.processEvent(event)


### PR DESCRIPTION
Rectification w.r.t variable named `event` in [PR](https://github.com/spinnaker/echo/pull/1341) of AbstractEventNotificationAgentSpec.groovy class.
