### PR TITLE
fix(jenkins): Enable properties and artifacts with job name as query parameter

### DIFF
--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/build/BuildInfoService.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/build/BuildInfoService.java
@@ -93,7 +93,12 @@ public class BuildInfoService {
     }
     String propertyFileFinal = propertyFile;
     if (StringUtils.isNoneEmpty(master, job, propertyFile)) {
-      return retry(() -> igorService.getPropertyFile(buildNumber, propertyFileFinal, master, job));
+      return retry(
+          () ->
+              igorConfigurationProperties.isJobNameAsQueryParameter()
+                  ? igorService.getPropertyFileWithJobQueryParameter(
+                      buildNumber, propertyFileFinal, master, job)
+                  : igorService.getPropertyFile(buildNumber, propertyFileFinal, master, job));
     }
     return Collections.emptyMap();
   }
@@ -103,7 +108,12 @@ public class BuildInfoService {
     String job = event.getContent().getProject().getName();
     int buildNumber = event.getBuildNumber();
     if (StringUtils.isNoneEmpty(master, job, propertyFile)) {
-      return retry(() -> igorService.getArtifacts(buildNumber, propertyFile, master, job));
+      return retry(
+          () ->
+              igorConfigurationProperties.isJobNameAsQueryParameter()
+                  ? igorService.getArtifactsWithJobQueryParameter(
+                      buildNumber, propertyFile, master, job)
+                  : igorService.getArtifacts(buildNumber, propertyFile, master, job));
     }
     return Collections.emptyList();
   }

--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/services/IgorService.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/services/IgorService.java
@@ -44,12 +44,26 @@ public interface IgorService {
       @Path("master") String master,
       @Path(value = "job", encode = false) String job);
 
+  @GET("/builds/properties/{buildNumber}/{fileName}/{master}")
+  Map<String, Object> getPropertyFileWithJobQueryParameter(
+      @Path("buildNumber") Integer buildNumber,
+      @Path("fileName") String fileName,
+      @Path("master") String master,
+      @Query(value = "job") String job);
+
   @GET("/builds/artifacts/{buildNumber}/{master}/{job}")
   List<Artifact> getArtifacts(
       @Path("buildNumber") Integer buildNumber,
       @Query("propertyFile") String propertyFile,
       @Path("master") String master,
       @Path(value = "job", encode = false) String job);
+
+  @GET("/builds/artifacts/{buildNumber}/{master}")
+  List<Artifact> getArtifactsWithJobQueryParameter(
+      @Path("buildNumber") Integer buildNumber,
+      @Query("propertyFile") String propertyFile,
+      @Path("master") String master,
+      @Query(value = "job") String job);
 
   @GET("/artifacts/{provider}/{packageName}")
   List<String> getVersions(


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/6928

The implementation of: 
```
        feature:
          igor:
            jobNameAsQueryParameter: true
```
did not include the support  for Jenkins artifacts and property files leading to failures on Manual triggers and rerun's of a Spinnaker pipeline retrieving BuildInfo from the sub-folder Jenkins job.
