### PR TITLE
feat(pipelinetriggers): set pipeline-cache.filterFront50Pipelines to …

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheConfigurationProperties.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheConfigurationProperties.java
@@ -29,5 +29,5 @@ public class PipelineCacheConfigurationProperties {
    * If false, query front50 for all pipelines. If true, query front50 for only enabled pipelines
    * with enabled triggers with types that echo requires.
    */
-  private boolean filterFront50Pipelines;
+  private boolean filterFront50Pipelines = true;
 }


### PR DESCRIPTION
…true by default

so echo only queries for the pipelines it needs from front50 instead of all of them.

https://github.com/spinnaker/echo/pull/1292 introduced this feature on Apr 21, 2023, first released in version 1.31.0 of Spinnaker.  Enough time has passed to enable this by default.
