### PR TITLE
refactor(mysql): update mysql connector coordinate during upgrade to spring boot 2.7.x

### DIFF
--- a/echo-scheduler/echo-scheduler.gradle
+++ b/echo-scheduler/echo-scheduler.gradle
@@ -30,7 +30,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-sql"
 
   if (!rootProject.hasProperty("excludeSqlDrivers")) {
-    runtimeOnly "mysql:mysql-connector-java"
+    runtimeOnly "com.mysql:mysql-connector-j"
   }
 
   implementation "org.springframework:spring-context-support"


### PR DESCRIPTION
In spring boot 2.7.8 onwards mysql connector coordinate `mysql:mysql-connector-java` has been removed and only `com.mysql:mysql-connector-j` coordinate exist.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#mysql-jdbc-driver

So, updating the mysql connector coordinate as `com.mysql:mysql-connector-j` with spring boot upgrade to 2.7.18.

https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.18/spring-boot-dependencies-2.7.18.pom
