### PR TITLE
test(pipelinetriggers): demonstrate behavior of SpEL expression evaluation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,12 @@ subprojects {
         jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8189'
       }
     }
+
+    // This is required for some SpEL expressions to evaluate properly with java
+    // 17.  It works with java 11 as well, but isn't required there.
+    tasks.withType(Test).configureEach {
+      jvmArgs += '--add-opens=java.base/java.util=ALL-UNNAMED'
+    }
   }
 
   if (name != "echo-bom" && name != "echo-api") {


### PR DESCRIPTION
that uses a non-public constructor/method, and so requires special treatment under java 17.
