### PR TITLE
refactor(dependency): replace groovy coordinates during upgrade of groovy 4.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ subprojects {
       annotationProcessor "org.projectlombok:lombok"
       testAnnotationProcessor "org.projectlombok:lombok"
 
-      implementation "org.codehaus.groovy:groovy"
+      implementation "org.apache.groovy:groovy"
       implementation "com.github.ben-manes.caffeine:guava"
       implementation "com.netflix.spectator:spectator-api"
       implementation "org.slf4j:slf4j-api"

--- a/echo-core/echo-core.gradle
+++ b/echo-core/echo-core.gradle
@@ -44,5 +44,5 @@ dependencies {
 
     testImplementation "org.spockframework:spock-spring"
     testImplementation "org.springframework:spring-test"
-    testImplementation "org.codehaus.groovy:groovy-json"
+    testImplementation "org.apache.groovy:groovy-json"
 }

--- a/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
+++ b/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Trigger.java
@@ -26,7 +26,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.Value;
-import lombok.experimental.Wither;
+import lombok.With;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 @JsonDeserialize(builder = Trigger.TriggerBuilder.class)
 @Builder(toBuilder = true)
-@Wither
+@With
 @ToString(
     of = {
       "id",

--- a/echo-notifications/echo-notifications.gradle
+++ b/echo-notifications/echo-notifications.gradle
@@ -33,7 +33,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-freemarker"
   implementation "org.jsoup:jsoup:1.8.3"
   implementation "com.atlassian.commonmark:commonmark:0.9.0"
-  implementation "org.codehaus.groovy:groovy-json"
+  implementation "org.apache.groovy:groovy-json"
   implementation "io.cloudevents:cloudevents-http-basic:3.0.0"
   implementation "io.cloudevents:cloudevents-json-jackson:3.0.0"
   implementation ("dev.cdevents:cdevents-sdk-java:0.3.1")

--- a/echo-pipelinetriggers/echo-pipelinetriggers.gradle
+++ b/echo-pipelinetriggers/echo-pipelinetriggers.gradle
@@ -47,7 +47,7 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-starter-test"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.assertj:assertj-core"
-  testImplementation "org.codehaus.groovy:groovy-json"
+  testImplementation "org.apache.groovy:groovy-json"
 
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }


### PR DESCRIPTION
Replacing the groovy coordinates from `org.codehaus.groovy` to `org.apache.groovy` supported by groovy 4.x and above versions. Upgrading `@Wither` to `@With`, as suggested [here](https://projectlombok.org/features/With).
