### PR TITLE
refactor(retrofit): replace OkClient with Ok3Client

### DIFF
--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/JiraConfig.java
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/JiraConfig.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.config;
 
 import static retrofit.Endpoints.newFixedEndpoint;
 
+import com.jakewharton.retrofit.Ok3Client;
 import com.netflix.spinnaker.echo.jackson.EchoObjectMapper;
 import com.netflix.spinnaker.echo.jira.JiraProperties;
 import com.netflix.spinnaker.echo.jira.JiraService;
@@ -32,7 +33,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import retrofit.RestAdapter;
 import retrofit.client.Client;
-import retrofit.client.OkClient;
 import retrofit.converter.JacksonConverter;
 
 @Configuration
@@ -42,7 +42,7 @@ public class JiraConfig {
   private static Logger LOGGER = LoggerFactory.getLogger(JiraConfig.class);
 
   @Autowired(required = false)
-  private OkClient x509ConfiguredClient;
+  private Ok3Client x509ConfiguredClient;
 
   @Bean
   JiraService jiraService(

--- a/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/config/SchedulerConfiguration.groovy
+++ b/echo-scheduler/src/main/groovy/com/netflix/spinnaker/echo/config/SchedulerConfiguration.groovy
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.echo.scheduler.actions.pipeline.QuartzDiscoveryActi
 import com.netflix.spinnaker.echo.scheduler.actions.pipeline.TriggerConverter
 import com.netflix.spinnaker.echo.scheduler.actions.pipeline.TriggerListener
 import com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration
-import com.squareup.okhttp.OkHttpClient
 import org.quartz.JobDetail
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
@@ -34,8 +33,6 @@ import org.springframework.context.annotation.Import
 import org.springframework.scheduling.quartz.JobDetailFactoryBean
 import org.springframework.scheduling.quartz.SchedulerFactoryBean
 import org.springframework.scheduling.quartz.SimpleTriggerFactoryBean
-import retrofit.client.Client
-import retrofit.client.OkClient
 
 import javax.sql.DataSource
 import java.util.concurrent.TimeUnit

--- a/echo-telemetry/echo-telemetry.gradle
+++ b/echo-telemetry/echo-telemetry.gradle
@@ -25,6 +25,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-proto"
   implementation "io.spinnaker.kork:kork-security"
   implementation 'io.spinnaker.kork:kork-web'
+  implementation 'com.jakewharton.retrofit:retrofit1-okhttp3-client'
   implementation 'com.squareup.retrofit:retrofit'
   implementation 'com.squareup.retrofit:converter-jackson'
   implementation 'de.huxhorn.sulky:de.huxhorn.sulky.ulid'

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/config/TelemetryConfig.kt
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/config/TelemetryConfig.kt
@@ -15,13 +15,14 @@
  */
 package com.netflix.spinnaker.echo.config
 
+import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spinnaker.echo.config.TelemetryConfig.TelemetryConfigProps
 import com.netflix.spinnaker.echo.telemetry.TelemetryService
 import com.netflix.spinnaker.retrofit.RetrofitConfigurationProperties
 import com.netflix.spinnaker.retrofit.Slf4jRetrofitLogger
-import com.squareup.okhttp.OkHttpClient
 import de.huxhorn.sulky.ulid.ULID
 import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -29,7 +30,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import retrofit.RestAdapter
-import retrofit.client.OkClient
 import retrofit.converter.JacksonConverter
 
 @Configuration
@@ -57,11 +57,12 @@ open class TelemetryConfig {
       .create(TelemetryService::class.java)
   }
 
-  private fun telemetryOkClient(configProps: TelemetryConfigProps): OkClient {
-    val httpClient = OkHttpClient()
-    httpClient.setConnectTimeout(configProps.connectionTimeoutMillis.toLong(), TimeUnit.MILLISECONDS)
-    httpClient.setReadTimeout(configProps.readTimeoutMillis.toLong(), TimeUnit.MILLISECONDS)
-    return OkClient(httpClient)
+  private fun telemetryOkClient(configProps: TelemetryConfigProps): Ok3Client {
+    val httpClient = OkHttpClient.Builder()
+      .connectTimeout(configProps.connectionTimeoutMillis.toLong(), TimeUnit.MILLISECONDS)
+      .readTimeout(configProps.readTimeoutMillis.toLong(), TimeUnit.MILLISECONDS)
+      .build()
+    return Ok3Client(httpClient)
   }
 
   @ConfigurationProperties(prefix = "stats")


### PR DESCRIPTION
Moving away from `com.squareup.okhttp.OkHttpClient` to `okhttp3.OkHttpClient` to avoid any unwanted dependency conflicts.

okhttp3.OkHttpClient for retrofit1 is provided by [Ok3Client](https://github.com/JakeWharton/retrofit1-okhttp3-client)
