### PR TITLE
fix(ubuntu): add commands so apt-get can install libc

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
+RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
 RUN adduser --system --uid 10111 --group spinnaker
 COPY echo-web/build/install/echo /opt/echo
 RUN mkdir -p /opt/echo/plugins && chown -R spinnaker:nogroup /opt/echo/plugins


### PR DESCRIPTION
specifically:
```
rm /var/lib/dpkg/info/libc-bin.* && apt-get clean
```
to fix errors like
```
#9 97.43 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
#9 97.51 qemu: uncaught target signal 11 (Segmentation fault) - core dumped #9 97.90 Segmentation fault (core dumped)
#9 97.95 qemu: uncaught target signal 11 (Segmentation fault) - core dumped #9 98.32 Segmentation fault (core dumped)
#9 98.32 dpkg: error processing package libc-bin (--configure):
#9 98.32  installed libc-bin package post-installation script subprocess returned error exit status 139
```
from https://github.com/spinnaker/echo/actions/runs/13294114983/job/37121759834?pr=1472

suggestion from https://stackoverflow.com/a/78107622

similar to https://github.com/spinnaker/orca/pull/4834