### PR TITLE
fix(retrofit2):  fix `baseUrl must end in /` error

### DIFF
--- a/echo-artifacts/src/main/java/com/netflix/spinnaker/echo/config/KeelConfig.java
+++ b/echo-artifacts/src/main/java/com/netflix/spinnaker/echo/config/KeelConfig.java
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.echo.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.echo.services.KeelService;
+import com.netflix.spinnaker.echo.util.RetrofitUtils;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +23,7 @@ public class KeelConfig {
       @Value("${keel.base-url}") String keelBaseUrl,
       OkHttp3ClientConfiguration okHttpClientConfig) {
     return new Retrofit.Builder()
-        .baseUrl(keelBaseUrl)
+        .baseUrl(RetrofitUtils.getBaseUrl(keelBaseUrl))
         .client(okHttpClientConfig.createForRetrofit2().build())
         .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
         .addConverterFactory(JacksonConverterFactory.create(new ObjectMapper()))

--- a/echo-artifacts/src/main/java/com/netflix/spinnaker/echo/services/KeelService.java
+++ b/echo-artifacts/src/main/java/com/netflix/spinnaker/echo/services/KeelService.java
@@ -6,6 +6,6 @@ import retrofit2.http.Body;
 import retrofit2.http.POST;
 
 public interface KeelService {
-  @POST("/artifacts/events")
+  @POST("artifacts/events")
   Call<Void> sendArtifactEvent(@Body Map event);
 }

--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/services/Front50Service.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/services/Front50Service.java
@@ -12,12 +12,12 @@ import retrofit2.http.Path;
 import retrofit2.http.Query;
 
 public interface Front50Service {
-  @GET("/pipelines?restricted=false")
+  @GET("pipelines?restricted=false")
   @Headers("Accept: application/json")
   Call<List<Map<String, Object>>>
       getPipelines(); // Return Map here so we don't throw away MPT attributes.
 
-  @GET("/pipelines?restricted=false")
+  @GET("pipelines?restricted=false")
   @Headers("Accept: application/json")
   Call<List<Map<String, Object>>> getPipelines(
       @Query("enabledPipelines") Boolean enabledPipelines,
@@ -25,18 +25,18 @@ public interface Front50Service {
       @Query("triggerTypes")
           String triggerTypes); // Return Map here so we don't throw away MPT attributes.
 
-  @GET("/pipelines/{application}?refresh=false")
+  @GET("pipelines/{application}?refresh=false")
   @Headers("Accept: application/json")
   Call<List<Pipeline>> getPipelines(@Path("application") String application);
 
-  @GET("/pipelines/{pipelineId}/get")
+  @GET("pipelines/{pipelineId}/get")
   Call<Map<String, Object>> getPipeline(@Path("pipelineId") String pipelineId);
 
-  @GET("/pipelines/{application}/name/{name}?refresh=true")
+  @GET("pipelines/{application}/name/{name}?refresh=true")
   Call<Map<String, Object>> getPipelineByName(
       @Path("application") String application, @Path("name") String name);
 
-  @POST("/graphql")
+  @POST("graphql")
   @Headers("Accept: application/json")
   Call<GraphQLQueryResponse> query(@Body GraphQLQuery body);
 }

--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/services/IgorService.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/services/IgorService.java
@@ -30,64 +30,64 @@ import retrofit2.http.Path;
 import retrofit2.http.Query;
 
 public interface IgorService {
-  @GET("/builds/status/{buildNumber}/{master}/{job}")
+  @GET("builds/status/{buildNumber}/{master}/{job}")
   Call<Map<String, Object>> getBuild(
       @Path("buildNumber") Integer buildNumber,
       @Path("master") String master,
       @Path(value = "job", encoded = true) String job);
 
-  @GET("/builds/status/{buildNumber}/{master}")
+  @GET("builds/status/{buildNumber}/{master}")
   Call<Map<String, Object>> getBuildStatusWithJobQueryParameter(
       @NotNull @Path("buildNumber") Integer buildNumber,
       @NotNull @Path("master") String master,
       @NotNull @Query(value = "job") String job);
 
-  @GET("/builds/properties/{buildNumber}/{fileName}/{master}/{job}")
+  @GET("builds/properties/{buildNumber}/{fileName}/{master}/{job}")
   Call<Map<String, Object>> getPropertyFile(
       @Path("buildNumber") Integer buildNumber,
       @Path("fileName") String fileName,
       @Path("master") String master,
       @Path(value = "job", encoded = true) String job);
 
-  @GET("/builds/properties/{buildNumber}/{fileName}/{master}")
+  @GET("builds/properties/{buildNumber}/{fileName}/{master}")
   Call<Map<String, Object>> getPropertyFileWithJobQueryParameter(
       @Path("buildNumber") Integer buildNumber,
       @Path("fileName") String fileName,
       @Path("master") String master,
       @Query(value = "job") String job);
 
-  @GET("/builds/artifacts/{buildNumber}/{master}/{job}")
+  @GET("builds/artifacts/{buildNumber}/{master}/{job}")
   Call<List<Artifact>> getArtifacts(
       @Path("buildNumber") Integer buildNumber,
       @Query("propertyFile") String propertyFile,
       @Path("master") String master,
       @Path(value = "job", encoded = true) String job);
 
-  @GET("/builds/artifacts/{buildNumber}/{master}")
+  @GET("builds/artifacts/{buildNumber}/{master}")
   Call<List<Artifact>> getArtifactsWithJobQueryParameter(
       @Path("buildNumber") Integer buildNumber,
       @Query("propertyFile") String propertyFile,
       @Path("master") String master,
       @Query(value = "job") String job);
 
-  @GET("/artifacts/{provider}/{packageName}")
+  @GET("artifacts/{provider}/{packageName}")
   Call<List<String>> getVersions(
       @Path("provider") String provider, @Path("packageName") String packageName);
 
-  @GET("/artifacts/{provider}/{packageName}/{version}")
+  @GET("artifacts/{provider}/{packageName}/{version}")
   Call<Artifact> getArtifactByVersion(
       @Path("provider") String provider,
       @Path("packageName") String packageName,
       @Path("version") String version);
 
-  @PUT("/gcb/builds/{account}/{buildId}")
+  @PUT("gcb/builds/{account}/{buildId}")
   Call<ResponseBody> updateBuildStatus(
       @Path("account") String account,
       @Path("buildId") String buildId,
       @Query("status") String status,
       @Body TypedInput build);
 
-  @PUT("/gcb/artifacts/extract/{account}")
+  @PUT("gcb/artifacts/extract/{account}")
   Call<List<Artifact>> extractGoogleCloudBuildArtifacts(
       @Path("account") String account, @Body TypedInput build);
 }

--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/util/RetrofitUtils.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/util/RetrofitUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.util;
+
+import okhttp3.HttpUrl;
+
+public class RetrofitUtils {
+
+  /**
+   * Converts a given URL to a valid base URL for use in a {@link retrofit2.Retrofit} instance. If
+   * the URL is invalid, an {@link IllegalArgumentException} is thrown. If the URL does not end with
+   * a slash, a slash is appended to the end of the URL.
+   *
+   * @param suppliedBaseUrl the URL to convert
+   * @return a valid base URL for use in a Retrofit instance
+   */
+  public static String getBaseUrl(String suppliedBaseUrl) {
+    HttpUrl parsedUrl = HttpUrl.parse(suppliedBaseUrl);
+    if (parsedUrl == null) {
+      throw new IllegalArgumentException("Invalid URL: " + suppliedBaseUrl);
+    }
+    String baseUrl = parsedUrl.newBuilder().build().toString();
+    if (!baseUrl.endsWith("/")) {
+      baseUrl += "/";
+    }
+    return baseUrl;
+  }
+}

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/bearychat/BearychatService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/bearychat/BearychatService.groovy
@@ -26,14 +26,14 @@ import retrofit2.http.Query
 
 interface BearychatService {
 
-  @GET("/v1/user.list")
+  @GET("v1/user.list")
   Call<List<BearychatUserInfo>> getUserList(@Query("token") String token)
 
-  @POST("/v1/p2p.create")
+  @POST("v1/p2p.create")
   Call<CreateP2PChannelResponse> createp2pchannel(@Query("token") String token,
                                             @Body CreateP2PChannelPara para)
 
-  @POST("/v1/message.create")
+  @POST("v1/message.create")
   Call<Response<ResponseBody>> sendMessage(@Query("token") String token,
                                            @Body SendMessagePara para)
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/BearychatConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/BearychatConfig.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.config
 
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.echo.bearychat.BearychatService
+import com.netflix.spinnaker.echo.util.RetrofitUtils
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory
 import retrofit2.Retrofit
 import retrofit2.converter.jackson.JacksonConverterFactory
@@ -41,7 +42,7 @@ class BearychatConfig {
     log.info('bearychat service loaded')
 
     new Retrofit.Builder()
-      .baseUrl(BEARYCHAT_BASE_URL)
+      .baseUrl(RetrofitUtils.getBaseUrl(BEARYCHAT_BASE_URL))
       .client(okHttpClientConfig.createForRetrofit2().build())
       .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
       .addConverterFactory(JacksonConverterFactory.create())

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/GoogleChatConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/GoogleChatConfig.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.echo.config
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.echo.googlechat.GoogleChatService
 import com.netflix.spinnaker.echo.googlechat.GoogleChatClient
+import com.netflix.spinnaker.echo.util.RetrofitUtils
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -42,7 +43,7 @@ class GoogleChatConfig {
     log.info("Chat service loaded");
 
     def chatClient = new Retrofit.Builder()
-            .baseUrl(baseUrl)
+            .baseUrl(RetrofitUtils.getBaseUrl(baseUrl))
             .client(okHttpClientConfig.createForRetrofit2().build())
             .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
             .addConverterFactory(JacksonConverterFactory.create())

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/SlackConfig.groovy
@@ -21,9 +21,11 @@ import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.echo.slack.SlackAppService
 import com.netflix.spinnaker.echo.slack.SlackClient
 import com.netflix.spinnaker.echo.slack.SlackService
+import com.netflix.spinnaker.echo.util.RetrofitUtils
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import okhttp3.HttpUrl
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -54,7 +56,7 @@ class SlackConfig {
     log.info("Using Slack {}: {}.", config.useIncomingWebhook ? "incoming webhook" : "chat api", config.baseUrl)
 
     def slackClient =  new Retrofit.Builder()
-        .baseUrl(config.baseUrl)
+        .baseUrl(RetrofitUtils.getBaseUrl(config.baseUrl))
         .client(okHttpClientConfig.createForRetrofit2().build())
         .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
         .addConverterFactory(JacksonConverterFactory.create())
@@ -79,7 +81,7 @@ class SlackConfig {
   SlackAppService slackAppService(@Qualifier("slackAppConfig") SlackAppProperties config,
                                   OkHttp3ClientConfiguration okHttpClientConfig) {
     def slackClient = new Retrofit.Builder()
-      .baseUrl(config.baseUrl)
+      .baseUrl(RetrofitUtils.getBaseUrl(config.baseUrl))
       .client(okHttpClientConfig.createForRetrofit2().build())
       .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
       .addConverterFactory(JacksonConverterFactory.create())

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/TwilioConfig.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/config/TwilioConfig.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.echo.config
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.echo.jackson.EchoObjectMapper
 import com.netflix.spinnaker.echo.twilio.TwilioService
+import com.netflix.spinnaker.echo.util.RetrofitUtils
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -52,7 +53,7 @@ class TwilioConfig {
         BasicAuthRequestInterceptor interceptor = new BasicAuthRequestInterceptor(auth);
 
         new Retrofit.Builder()
-                .baseUrl(twilioBaseUrl)
+                .baseUrl(RetrofitUtils.getBaseUrl(twilioBaseUrl))
                 .client(okHttpClientConfig.createForRetrofit2().addInterceptor(interceptor).build())
                 .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
                 .addConverterFactory(JacksonConverterFactory.create(EchoObjectMapper.getInstance()))

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/InteractiveNotificationCallbackHandler.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/notification/InteractiveNotificationCallbackHandler.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.echo.notification;
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.echo.api.Notification;
 import com.netflix.spinnaker.echo.api.Notification.InteractiveActionCallback
+import com.netflix.spinnaker.echo.util.RetrofitUtils
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
@@ -126,7 +127,7 @@ class InteractiveNotificationCallbackHandler {
       spinnakerServices.put(
         serviceId,
         new Retrofit.Builder()
-          .baseUrl(baseUrl)
+          .baseUrl(RetrofitUtils.getBaseUrl(baseUrl))
           .client(okHttp3ClientConfiguration.createForRetrofit2().build())
           .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
           .addConverterFactory(JacksonConverterFactory.create())
@@ -139,7 +140,7 @@ class InteractiveNotificationCallbackHandler {
   }
 
   interface SpinnakerService {
-    @POST("/notifications/callback")
+    @POST("notifications/callback")
     Call<ResponseBody> notificationCallback(
         @Body InteractiveActionCallback callback, @Header("X-SPINNAKER-USER") String user);
   }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/pagerduty/PagerDutyService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/pagerduty/PagerDutyService.groovy
@@ -23,7 +23,7 @@ import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface PagerDutyService {
-  @POST('/generic/2010-04-15/create_event.json')
+  @POST('generic/2010-04-15/create_event.json')
   Call<Map> createEvent(@Header("Authorization") String authorization, @Body PagerDutyCreateEvent pagerDutyCreateEvent)
 
   static class PagerDutyCreateEvent {

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackClient.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackClient.groovy
@@ -37,7 +37,7 @@ interface SlackClient {
    * One note: linkUserNames according to slack API is a boolean. But guess what? It doesn't work, it must be an int 0 or 1
    */
   @FormUrlEncoded
-  @POST('/api/chat.postMessage')
+  @POST('api/chat.postMessage')
   Call<ResponseBody> sendMessage(
     @Field('token') String token,
     @Field('attachments') String attachments,
@@ -48,7 +48,7 @@ interface SlackClient {
   /**
    * Documentation: https://api.slack.com/incoming-webhooks
    */
-  @POST('/{token}')
+  @POST('{token}')
   Call<ResponseBody> sendUsingIncomingWebHook(
     @Path(value = "token", encoded = true) String token,
     @Body SlackRequest slackRequest)
@@ -56,7 +56,7 @@ interface SlackClient {
   /**
    * Documentation: https://api.slack.com/methods/users.info
    */
-  @GET('/api/users.info')
+  @GET('api/users.info')
   Call<SlackService.SlackUserInfo> getUserInfo(
     @Query('token') String token,
     @Query('user') String userId

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackInteractiveNotificationService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/slack/SlackInteractiveNotificationService.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.echo.api.Notification
 import com.netflix.spinnaker.echo.notification.InteractiveNotificationService
 import com.netflix.spinnaker.echo.notification.NotificationTemplateEngine
+import com.netflix.spinnaker.echo.util.RetrofitUtils
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
@@ -164,7 +165,7 @@ class SlackInteractiveNotificationService extends SlackNotificationService imple
   private SlackHookService getSlackHookService(OkHttp3ClientConfiguration okHttp3ClientConfiguration) {
     log.info("Slack hook service loaded")
     new Retrofit.Builder()
-      .baseUrl(SLACK_WEBHOOK_BASE_URL)
+      .baseUrl(RetrofitUtils.getBaseUrl(SLACK_WEBHOOK_BASE_URL))
       .client(okHttp3ClientConfiguration.createForRetrofit2().build())
       .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
       .addConverterFactory(JacksonConverterFactory.create())
@@ -173,7 +174,7 @@ class SlackInteractiveNotificationService extends SlackNotificationService imple
   }
 
   interface SlackHookService {
-    @POST('/{path}')
+    @POST('{path}')
     Call<ResponseBody> respondToMessage(@Path(value = "path", encoded = true) path, @Body Map content)
   }
 }

--- a/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/twilio/TwilioService.groovy
+++ b/echo-notifications/src/main/groovy/com/netflix/spinnaker/echo/twilio/TwilioService.groovy
@@ -28,7 +28,7 @@ import retrofit2.Call
 interface TwilioService {
 
     @FormUrlEncoded
-    @POST("/2010-04-01/Accounts/{account}/Messages.json")
+    @POST("2010-04-01/Accounts/{account}/Messages.json")
     Call<ResponseBody> sendMessage(@Path('account') String account,
                                    @Field('From') String from,
                                    @Field('To') String to,

--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/cdevents/CDEventsSenderClient.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/cdevents/CDEventsSenderClient.java
@@ -24,7 +24,7 @@ import retrofit2.http.POST;
 import retrofit2.http.Path;
 
 public interface CDEventsSenderClient {
-  @POST("/{brokerUrl}")
+  @POST("{brokerUrl}")
   Call<Response<ResponseBody>> sendCDEvent(
       @Body String cdEvent, @Path(value = "brokerUrl", encoded = true) String brokerUrl);
 }

--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/cdevents/CDEventsSenderService.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/cdevents/CDEventsSenderService.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.echo.cdevents;
 
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
+import com.netflix.spinnaker.echo.util.RetrofitUtils;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
@@ -50,7 +51,7 @@ public class CDEventsSenderService {
 
     CDEventsSenderClient cdEventsSenderClient =
         new Retrofit.Builder()
-            .baseUrl(getEndpointUrl(eventsBrokerUrl))
+            .baseUrl(RetrofitUtils.getBaseUrl(getEndpointUrl(eventsBrokerUrl)))
             .client(okHttpClientConfig.createForRetrofit2().addInterceptor(authInterceptor).build())
             .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
             .addConverterFactory(converterFactory)

--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/config/DryRunConfig.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/config/DryRunConfig.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.echo.notification.DryRunNotificationAgent;
 import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService;
 import com.netflix.spinnaker.echo.services.Front50Service;
+import com.netflix.spinnaker.echo.util.RetrofitUtils;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import java.util.List;
 import lombok.Data;
@@ -45,7 +46,7 @@ public class DryRunConfig {
     log.info("Pipeline dry runs will execute at {}", properties.getBaseUrl());
     OrcaService orca =
         new Retrofit.Builder()
-            .baseUrl(properties.getBaseUrl())
+            .baseUrl(RetrofitUtils.getBaseUrl(properties.getBaseUrl()))
             .client(
                 clientProvider.getClient(
                     new DefaultServiceEndpoint("orca", properties.getBaseUrl())))

--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/config/GithubConfig.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/config/GithubConfig.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.config;
 
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.echo.github.GithubService;
+import com.netflix.spinnaker.echo.util.RetrofitUtils;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,7 +44,7 @@ public class GithubConfig {
     log.info("Github service loaded");
 
     return new Retrofit.Builder()
-        .baseUrl(endpoint)
+        .baseUrl(RetrofitUtils.getBaseUrl(endpoint))
         .client(okHttpClientConfig.createForRetrofit2().build())
         .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
         .addConverterFactory(JacksonConverterFactory.create())

--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/config/JiraConfig.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/config/JiraConfig.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.echo.config;
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.echo.jira.JiraProperties;
 import com.netflix.spinnaker.echo.jira.JiraService;
+import com.netflix.spinnaker.echo.util.RetrofitUtils;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import java.io.IOException;
 import okhttp3.Interceptor;
@@ -62,7 +63,7 @@ public class JiraConfig {
     }
 
     return new Retrofit.Builder()
-        .baseUrl(jiraProperties.getBaseUrl())
+        .baseUrl(RetrofitUtils.getBaseUrl(jiraProperties.getBaseUrl()))
         .client(okHttpClient)
         .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
         .addConverterFactory(JacksonConverterFactory.create())

--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/config/PagerDutyConfig.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/config/PagerDutyConfig.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.config;
 
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.echo.pagerduty.PagerDutyService;
+import com.netflix.spinnaker.echo.util.RetrofitUtils;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +42,7 @@ public class PagerDutyConfig {
     log.info("Pager Duty service loaded");
 
     return new Retrofit.Builder()
-        .baseUrl(pagerDutyProps.getEndpoint())
+        .baseUrl(RetrofitUtils.getBaseUrl(pagerDutyProps.getEndpoint()))
         .client(okHttpClientConfig.createForRetrofit2().build())
         .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
         .addConverterFactory(JacksonConverterFactory.create())

--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/github/GithubService.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/github/GithubService.java
@@ -26,14 +26,14 @@ import retrofit2.http.POST;
 import retrofit2.http.Path;
 
 public interface GithubService {
-  @POST("/repos/{repo}/statuses/{sha}")
+  @POST("repos/{repo}/statuses/{sha}")
   Call<Response<ResponseBody>> updateCheck(
       @Header("Authorization") String token,
       @Path(value = "repo", encoded = true) String repo,
       @Path("sha") String sha,
       @Body GithubStatus status);
 
-  @GET("/repos/{repo}/commits/{sha}")
+  @GET("repos/{repo}/commits/{sha}")
   Call<GithubCommit> getCommit(
       @Header("Authorization") String token,
       @Path(value = "repo", encoded = true) String repo,

--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/googlechat/GoogleChatClient.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/googlechat/GoogleChatClient.java
@@ -23,7 +23,7 @@ import retrofit2.http.POST;
 import retrofit2.http.Path;
 
 public interface GoogleChatClient {
-  @POST("/v1/spaces/{address}")
+  @POST("v1/spaces/{address}")
   Call<ResponseBody> sendMessage(
       @Path(value = "address", encoded = true) String webhook, @Body GoogleChatMessage message);
 }

--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/jira/JiraService.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/jira/JiraService.java
@@ -28,18 +28,18 @@ import retrofit2.http.POST;
 import retrofit2.http.Path;
 
 public interface JiraService {
-  @POST("/rest/api/2/issue/")
+  @POST("rest/api/2/issue/")
   Call<CreateIssueResponse> createIssue(@Body CreateIssueRequest createIssueRequest);
 
-  @GET("/rest/api/2/issue/{issueIdOrKey}/transitions")
+  @GET("rest/api/2/issue/{issueIdOrKey}/transitions")
   Call<IssueTransitions> getIssueTransitions(@Path("issueIdOrKey") String issueIdOrKey);
 
-  @POST("/rest/api/2/issue/{issueIdOrKey}/transitions")
+  @POST("rest/api/2/issue/{issueIdOrKey}/transitions")
   Call<ResponseBody> transitionIssue(
       @Path("issueIdOrKey") String issueIdOrKey,
       @Body TransitionIssueRequest transitionIssueRequest);
 
-  @POST("/rest/api/2/issue/{issueIdOrKey}/comment")
+  @POST("rest/api/2/issue/{issueIdOrKey}/comment")
   Call<ResponseBody> addComment(
       @Path("issueIdOrKey") String issueIdOrKey, @Body CommentIssueRequest commentIssueRequest);
 

--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsClient.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsClient.java
@@ -23,7 +23,7 @@ import retrofit2.http.POST;
 import retrofit2.http.Path;
 
 public interface MicrosoftTeamsClient {
-  @POST("/{webhookUrl}")
+  @POST("{webhookUrl}")
   Call<ResponseBody> sendMessage(
       @Path(value = "webhookUrl", encoded = true) String webhook,
       @Body MicrosoftTeamsMessage message);

--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsService.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/microsoftteams/MicrosoftTeamsService.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.echo.microsoftteams;
 
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
+import com.netflix.spinnaker.echo.util.RetrofitUtils;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
@@ -41,7 +42,7 @@ public class MicrosoftTeamsService {
     // the incoming webhook base URL and path may be different for each Teams channel
     MicrosoftTeamsClient microsoftTeamsClient =
         new Retrofit.Builder()
-            .baseUrl(webhookUrl)
+            .baseUrl(RetrofitUtils.getBaseUrl(webhookUrl))
             .client(okHttp3ClientConfiguration.createForRetrofit2().build())
             .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
             .addConverterFactory(JacksonConverterFactory.create())

--- a/echo-notifications/src/test/java/com/netflix/spinnaker/echo/config/SlackConfigTest.java
+++ b/echo-notifications/src/test/java/com/netflix/spinnaker/echo/config/SlackConfigTest.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.echo.config;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.echo.test.config.Retrofit2BasicLogTestConfig;
@@ -42,10 +41,9 @@ public class SlackConfigTest {
     slackLegacyProperties.setBaseUrl(
         "http://localhost/slack"); // baseUrl having one / but not ending with /
     SlackConfig slackConfig = new SlackConfig();
-    assertThrows(
-        IllegalArgumentException.class,
+    assertDoesNotThrow(
         () -> slackConfig.slackService(slackLegacyProperties, okHttpClientConfig),
-        "Expected IllegalArgumentException when baseUrl does not end with /");
+        "Trailing / is handled and hence no exception is thrown");
   }
 
   @Test

--- a/echo-notifications/src/test/java/com/netflix/spinnaker/echo/config/SlackConfigTest.java
+++ b/echo-notifications/src/test/java/com/netflix/spinnaker/echo/config/SlackConfigTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.config;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
+import com.netflix.spinnaker.echo.test.config.Retrofit2BasicLogTestConfig;
+import com.netflix.spinnaker.echo.test.config.Retrofit2TestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    classes = {
+      Retrofit2TestConfig.class,
+      Retrofit2BasicLogTestConfig.class,
+    })
+public class SlackConfigTest {
+
+  @Autowired OkHttp3ClientConfiguration okHttpClientConfig;
+
+  @Test
+  void testSlackServiceConfiguration_noTrailingSlash() {
+    SlackLegacyProperties slackLegacyProperties = new SlackLegacyProperties();
+    slackLegacyProperties.setBaseUrl(
+        "http://localhost/slack"); // baseUrl having one / but not ending with /
+    SlackConfig slackConfig = new SlackConfig();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> slackConfig.slackService(slackLegacyProperties, okHttpClientConfig),
+        "Expected IllegalArgumentException when baseUrl does not end with /");
+  }
+
+  @Test
+  void testSlackServiceConfiguration_noSlash() {
+    SlackLegacyProperties slackLegacyProperties = new SlackLegacyProperties();
+    slackLegacyProperties.setBaseUrl("http://localhost");
+    SlackConfig slackConfig = new SlackConfig();
+    assertDoesNotThrow(
+        () -> slackConfig.slackService(slackLegacyProperties, okHttpClientConfig),
+        "It's OK for baseUrl to not end with trailing / if there is no / in the middle");
+  }
+}

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/IgorConfig.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/config/IgorConfig.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.config;
 
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.echo.services.IgorService;
+import com.netflix.spinnaker.echo.util.RetrofitUtils;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,7 +39,7 @@ public class IgorConfig {
       OkHttp3ClientConfiguration okHttp3ClientConfiguration) {
     log.info("igor service loaded");
     return new Retrofit.Builder()
-        .baseUrl(igorBaseUrl)
+        .baseUrl(RetrofitUtils.getBaseUrl(igorBaseUrl))
         .client(okHttp3ClientConfiguration.createForRetrofit2().build())
         .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
         .addConverterFactory(JacksonConverterFactory.create())

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaService.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/orca/OrcaService.java
@@ -33,19 +33,19 @@ import retrofit2.http.Query;
 
 public interface OrcaService {
 
-  @POST("/orchestrate")
+  @POST("orchestrate")
   Call<TriggerResponse> trigger(@Body Pipeline pipeline);
 
-  @POST("/fail")
+  @POST("fail")
   Call<ResponseBody> recordFailure(@Body Pipeline pipeline);
 
-  @POST("/plan")
+  @POST("plan")
   Call<Map> plan(@Body Map pipelineConfig, @Query("resolveArtifacts") boolean resolveArtifacts);
 
-  @POST("/v2/pipelineTemplates/plan")
+  @POST("v2/pipelineTemplates/plan")
   Call<Map<String, Object>> v2Plan(@Body Map pipelineConfig);
 
-  @GET("/pipelines")
+  @GET("pipelines")
   Call<Collection<PipelineResponse>> getLatestPipelineExecutions(
       @Query("pipelineConfigIds") Collection<String> pipelineIds, @Query("limit") Integer limit);
 

--- a/echo-rest/src/main/java/com/netflix/spinnaker/echo/config/RestConfig.java
+++ b/echo-rest/src/main/java/com/netflix/spinnaker/echo/config/RestConfig.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.config.DefaultServiceEndpoint;
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import com.netflix.spinnaker.echo.rest.RestService;
+import com.netflix.spinnaker.echo.util.RetrofitUtils;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -116,7 +117,7 @@ public class RestConfig {
 
       Retrofit.Builder retrofitBuilder =
           new Retrofit.Builder()
-              .baseUrl(endpoint.getUrl())
+              .baseUrl(RetrofitUtils.getBaseUrl(endpoint.getUrl()))
               .client(okHttpClient)
               .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
               .addConverterFactory(JacksonConverterFactory.create());

--- a/echo-rest/src/main/java/com/netflix/spinnaker/echo/rest/RestService.java
+++ b/echo-rest/src/main/java/com/netflix/spinnaker/echo/rest/RestService.java
@@ -24,6 +24,6 @@ import retrofit2.http.POST;
 
 public interface RestService {
 
-  @POST("/")
+  @POST(".")
   Call<ResponseBody> recordEvent(@Body Map<String, Object> event);
 }

--- a/echo-rest/src/test/java/com/netflix/spinnaker/echo/rest/RestServiceTest.java
+++ b/echo-rest/src/test/java/com/netflix/spinnaker/echo/rest/RestServiceTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.rest;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.netflix.spinnaker.echo.util.RetrofitUtils;
+import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
+import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
+import java.util.Map;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import retrofit2.Call;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+import retrofit2.http.Body;
+import retrofit2.http.POST;
+
+public class RestServiceTest {
+  WireMockServer wireMockServer;
+  int port;
+  RestService restService;
+  String baseUrl = "http://localhost:PORT/api";
+
+  @BeforeEach
+  void setUp() {
+    wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+    wireMockServer.start();
+    port = wireMockServer.port();
+    WireMock.configureFor("localhost", port);
+
+    stubFor(post(urlEqualTo("/api/")).willReturn(aResponse().withStatus(200)));
+
+    stubFor(post(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
+
+    baseUrl = baseUrl.replaceFirst("PORT", String.valueOf(port));
+
+    restService =
+        new Retrofit.Builder()
+            .baseUrl(RetrofitUtils.getBaseUrl(baseUrl))
+            .client(new OkHttpClient())
+            .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
+            .addConverterFactory(JacksonConverterFactory.create())
+            .build()
+            .create(RestService.class);
+  }
+
+  @AfterEach
+  void tearDown() {
+    wireMockServer.stop();
+  }
+
+  @Test
+  void testRetService_withPostMappingSingleSlash() {
+
+    Retrofit2SyncCall.execute(restService.recordEvent(Map.of()));
+
+    verify(0, postRequestedFor(urlEqualTo("/api/")));
+
+    // @POST("/") wrongly results in calling "http://localhost:<port>/"
+    verify(1, postRequestedFor(urlEqualTo("/")));
+  }
+
+  @Test
+  void testRetService_withPostMappingDot() {
+
+    Retrofit2SyncCall.execute(restService.recordEvent2(Map.of()));
+
+    // @POST(".") rightly results in calling "http://localhost:<port>/api/"
+    verify(1, postRequestedFor(urlEqualTo("/api/")));
+    verify(0, postRequestedFor(urlEqualTo("/")));
+  }
+
+  private interface RestService {
+    @POST("/")
+    Call<Void> recordEvent(@Body Map<String, Object> event);
+
+    @POST(".")
+    Call<Void> recordEvent2(@Body Map<String, Object> event);
+  }
+}

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/config/TelemetryConfig.kt
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/config/TelemetryConfig.kt
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.config.okhttp3.DefaultOkHttpClientBuilderProvider
 import com.netflix.spinnaker.echo.config.TelemetryConfig.TelemetryConfigProps
 import com.netflix.spinnaker.echo.telemetry.TelemetryService
+import com.netflix.spinnaker.echo.util.RetrofitUtils
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory
 import com.netflix.spinnaker.okhttp.OkHttpClientConfigurationProperties
 import de.huxhorn.sulky.ulid.ULID
@@ -52,7 +53,7 @@ open class TelemetryConfig {
     val clientProvider = DefaultOkHttpClientBuilderProvider(okHttpClient, clientProps)
     log.info("Telemetry service loaded")
     return Retrofit.Builder()
-      .baseUrl(configProps.endpoint)
+      .baseUrl(RetrofitUtils.getBaseUrl(configProps.endpoint))
       .client(clientProvider.get(DefaultServiceEndpoint("telemetry", configProps.endpoint)).build())
       .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
       .addConverterFactory(JacksonConverterFactory.create())

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryService.kt
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryService.kt
@@ -22,6 +22,6 @@ import retrofit2.http.POST
 import retrofit2.Call
 
 interface TelemetryService {
-  @POST("/log")
+  @POST("log")
   fun log(@Body body: RequestBody): Call<ResponseBody>
 }

--- a/echo-web/src/main/java/com/netflix/spinnaker/echo/config/Front50Config.java
+++ b/echo-web/src/main/java/com/netflix/spinnaker/echo/config/Front50Config.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.echo.config;
 
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.echo.services.Front50Service;
+import com.netflix.spinnaker.echo.util.RetrofitUtils;
 import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,7 +38,7 @@ public class Front50Config {
     log.info("front50 service loaded");
 
     return new Retrofit.Builder()
-        .baseUrl(front50BaseUrl)
+        .baseUrl(RetrofitUtils.getBaseUrl(front50BaseUrl))
         .client(okHttp3ClientConfiguration.createForRetrofit2().build())
         .addCallAdapterFactory(ErrorHandlingExecutorCallAdapterFactory.getInstance())
         .addConverterFactory(JacksonConverterFactory.create())


### PR DESCRIPTION
Retrofit2 client configuration doesn't allow baseUrl without tailing slash(`/`) if there is a slash in the middle. As a result  `https://somehost` and `https://somehost:3333` becomes valid but `https://somehost/api` throws `java.lang.IllegalArgumentException: baseUrl must end in /`. 

This PR addresses the issue by checking and adding trailing `/` if missing and removing the leading `/` from the endpoint.

