### PR TITLE
fix(notifications): fix MicrosoftTeamsConfig which has unused retrofit1 parameters

### DIFF
--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/config/MicrosoftTeamsConfig.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/config/MicrosoftTeamsConfig.java
@@ -19,23 +19,18 @@ package com.netflix.spinnaker.echo.config;
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.echo.microsoftteams.MicrosoftTeamsService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import retrofit.RestAdapter;
-import retrofit.client.Client;
 
 @Configuration
 @ConditionalOnProperty("microsoftteams.enabled")
 @Slf4j
 public class MicrosoftTeamsConfig {
 
-  @Autowired OkHttp3ClientConfiguration okHttp3ClientConfiguration;
-
   @Bean
   public MicrosoftTeamsService microsoftTeamsService(
-      Client retrofitClient, RestAdapter.LogLevel retrofitLogLevel) {
+      OkHttp3ClientConfiguration okHttp3ClientConfiguration) {
     log.info("Microsoft Teams service loaded");
 
     return new MicrosoftTeamsService(okHttp3ClientConfiguration);

--- a/echo-notifications/src/test/java/com/netflix/spinnaker/echo/config/MicrosoftTeamsServiceTest.java
+++ b/echo-notifications/src/test/java/com/netflix/spinnaker/echo/config/MicrosoftTeamsServiceTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.echo.config;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.netflix.spinnaker.echo.microsoftteams.MicrosoftTeamsService;
+import com.netflix.spinnaker.echo.test.config.Retrofit2BasicLogTestConfig;
+import com.netflix.spinnaker.echo.test.config.Retrofit2TestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    classes = {
+      MicrosoftTeamsConfig.class,
+      Retrofit2TestConfig.class,
+      Retrofit2BasicLogTestConfig.class
+    },
+    properties = "microsoftteams.enabled=true")
+public class MicrosoftTeamsServiceTest {
+
+  @Autowired private MicrosoftTeamsService microsoftTeamsService;
+
+  @Test
+  void testMicrosoftTeamsServiceConfiguration() {
+    assertNotNull(microsoftTeamsService);
+  }
+}


### PR DESCRIPTION
- fixed MicrosoftTeamsConfig
- added a test to verify that MicrosoftTeamsService gets created now
