### PR TITLE
fix(retrofit): address remnants of retrofit1 like TypedInput, TypedByteArray etc

### DIFF
--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/services/IgorService.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/services/IgorService.java
@@ -19,9 +19,9 @@ package com.netflix.spinnaker.echo.services;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.List;
 import java.util.Map;
+import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import org.jetbrains.annotations.NotNull;
-import retrofit.mime.TypedInput;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
@@ -85,9 +85,9 @@ public interface IgorService {
       @Path("account") String account,
       @Path("buildId") String buildId,
       @Query("status") String status,
-      @Body TypedInput build);
+      @Body RequestBody build);
 
   @PUT("gcb/artifacts/extract/{account}")
   Call<List<Artifact>> extractGoogleCloudBuildArtifacts(
-      @Path("account") String account, @Body TypedInput build);
+      @Path("account") String account, @Body RequestBody build);
 }

--- a/echo-core/src/test/java/com/netflix/spinnaker/echo/services/IgorServiceTest.java
+++ b/echo-core/src/test/java/com/netflix/spinnaker/echo/services/IgorServiceTest.java
@@ -34,22 +34,24 @@ import com.netflix.spinnaker.kork.retrofit.ErrorHandlingExecutorCallAdapterFacto
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
 import java.nio.charset.StandardCharsets;
 import okhttp3.OkHttpClient;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import retrofit.mime.TypedByteArray;
 import retrofit.mime.TypedInput;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
 public class IgorServiceTest {
-  WireMockServer wireMockServer;
-  int port;
-  IgorService igorService;
-  String baseUrl = "http://localhost:PORT";
+  private static WireMockServer wireMockServer;
+  private static int port;
+  private static IgorService igorService;
+  private static String baseUrl = "http://localhost:PORT";
 
-  @BeforeEach
-  void setUp() {
+  @BeforeAll
+  static void setUpOnce() {
     wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
     wireMockServer.start();
     port = wireMockServer.port();
@@ -67,8 +69,13 @@ public class IgorServiceTest {
             .create(IgorService.class);
   }
 
-  @AfterEach
-  void tearDown() {
+  @BeforeEach
+  void setup(TestInfo testInfo) {
+    System.out.println("--------------- Test " + testInfo.getDisplayName());
+  }
+
+  @AfterAll
+  static void tearDown() {
     wireMockServer.stop();
   }
 

--- a/echo-core/src/test/resources/logback-test.xml
+++ b/echo-core/src/test/resources/logback-test.xml
@@ -1,0 +1,32 @@
+<!--
+
+    Copyright 2025 Salesforce, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+    <!-- see https://java.testcontainers.org/supported_docker_environment/logging_config/ -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="wiremock.org.eclipse.jetty" level="INFO"/>
+</configuration>

--- a/echo-notifications/src/main/java/com/netflix/spinnaker/echo/notification/GoogleCloudBuildNotificationAgent.java
+++ b/echo-notifications/src/main/java/com/netflix/spinnaker/echo/notification/GoogleCloudBuildNotificationAgent.java
@@ -22,12 +22,12 @@ import com.netflix.spinnaker.echo.model.pubsub.MessageDescription;
 import com.netflix.spinnaker.echo.services.IgorService;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
-import retrofit.mime.TypedByteArray;
 
 /**
  * Handles Google Cloud Build notifications by forwarding information on the completed build to
@@ -54,11 +54,9 @@ public class GoogleCloudBuildNotificationAgent implements EventListener {
                           messageDescription.getSubscriptionName(),
                           messageDescription.getMessageAttributes().get("buildId"),
                           messageDescription.getMessageAttributes().get("status"),
-                          new TypedByteArray(
-                              "application/json",
-                              messageDescription
-                                  .getMessagePayload()
-                                  .getBytes(StandardCharsets.UTF_8)))),
+                          RequestBody.create(
+                              messageDescription.getMessagePayload(),
+                              MediaType.parse("application/json")))),
           5,
           2000,
           false);

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/GoogleCloudBuildNotificationSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/notification/GoogleCloudBuildNotificationSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.echo.jackson.EchoObjectMapper
 import com.netflix.spinnaker.echo.model.pubsub.MessageDescription
 import com.netflix.spinnaker.echo.services.IgorService
 import com.netflix.spinnaker.kork.core.RetrySupport
+import okhttp3.RequestBody
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -60,7 +61,7 @@ class GoogleCloudBuildNotificationSpec extends Specification {
     notificationAgent.processEvent(event)
 
     then:
-    1 * igorService.updateBuildStatus(ACCOUNT_NAME, BUILD_ID, BUILD_STATUS, { it -> it.in().text == PAYLOAD })
+    1 * igorService.updateBuildStatus(ACCOUNT_NAME, BUILD_ID, BUILD_STATUS, { it -> itToString(it) == PAYLOAD })
     0 * igorService._
   }
 
@@ -72,7 +73,7 @@ class GoogleCloudBuildNotificationSpec extends Specification {
     notificationAgent.processEvent(event)
 
     then:
-    2 * igorService.updateBuildStatus(ACCOUNT_NAME, BUILD_ID, BUILD_STATUS, { it -> it.in().text == PAYLOAD }) >>
+    2 * igorService.updateBuildStatus(ACCOUNT_NAME, BUILD_ID, BUILD_STATUS, { it -> itToString(it) == PAYLOAD }) >>
       { throw new RuntimeException() } >> { }
     0 * igorService._
   }
@@ -96,5 +97,11 @@ class GoogleCloudBuildNotificationSpec extends Specification {
     event.setContent(content)
     event.setDetails(details)
     return event
+  }
+
+  private static String itToString(RequestBody body) {
+    def buffer = new okio.Buffer()
+    body.writeTo(buffer)
+    return buffer.readUtf8()
   }
 }

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackServiceSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/slack/SlackServiceSpec.groovy
@@ -22,14 +22,9 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.RequestEntity
-import retrofit.client.Response
-import retrofit.mime.TypedByteArray
-import retrofit.mime.TypedOutput
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.util.concurrent.BlockingVariable
-
-import static java.util.Collections.emptyList
 
 @SpringBootTest(classes = [Retrofit2TestConfig, Retrofit2BasicLogTestConfig],
   properties = ["slack.enabled=true"],
@@ -213,15 +208,5 @@ class SlackServiceSpec extends Specification {
 
   def static parseJson(String value) {
     new JsonSlurper().parseText(value)
-  }
-
-  static Response mockResponse() {
-    new Response("url", 200, "nothing", emptyList(), new TypedByteArray("application/json", "response".bytes))
-  }
-
-  static String getString(TypedOutput typedOutput) {
-    OutputStream os = new ByteArrayOutputStream()
-    typedOutput.writeTo(os)
-    new String(os.toByteArray(), "UTF-8")
   }
 }

--- a/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GoogleCloudBuildArtifactExtractor.java
+++ b/echo-pubsub-google/src/main/java/com/netflix/spinnaker/echo/pubsub/google/GoogleCloudBuildArtifactExtractor.java
@@ -22,16 +22,15 @@ import com.netflix.spinnaker.kork.artifacts.parsing.ArtifactExtractor;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-import retrofit.mime.TypedByteArray;
-import retrofit.mime.TypedInput;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
@@ -54,8 +53,7 @@ public class GoogleCloudBuildArtifactExtractor implements ArtifactExtractor {
 
   @Override
   public List<Artifact> getArtifacts(String messagePayload) {
-    TypedInput build =
-        new TypedByteArray("application/json", messagePayload.getBytes(StandardCharsets.UTF_8));
+    RequestBody build = RequestBody.create(messagePayload, MediaType.parse("application/json"));
     try {
       return retrySupport.retry(
           () ->

--- a/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryEventListener.java
+++ b/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryEventListener.java
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.echo.api.events.EventListener;
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +31,6 @@ import okhttp3.RequestBody;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-import retrofit.mime.TypedString;
 
 @Slf4j
 @Component
@@ -119,22 +117,6 @@ public class TelemetryEventListener implements EventListener {
           cnpe.getMessage());
     } catch (Exception e) {
       log.debug("Could not send Telemetry event {}", event, e);
-    }
-  }
-
-  static class TypedJsonString extends TypedString {
-    TypedJsonString(String body) {
-      super(body);
-    }
-
-    @Override
-    public String mimeType() {
-      return "application/json";
-    }
-
-    @Override
-    public String toString() {
-      return new String(getBytes(), StandardCharsets.UTF_8);
     }
   }
 }


### PR DESCRIPTION
- Added a test to demonstrate the issue of remnants of retrofit1 still being present while retrofit2 client is used. 
- Fixed the issue by replacing the retrofit1 objects with appropriate retrofit2 counter parts.