### PR TITLE
fix(pipelinetriggers): turn off pipeline filtering by default

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheConfigurationProperties.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheConfigurationProperties.java
@@ -28,6 +28,10 @@ public class PipelineCacheConfigurationProperties {
   /**
    * If false, query front50 for all pipelines. If true, query front50 for only enabled pipelines
    * with enabled triggers with types that echo requires.
+   *
+   * <p>DO NOT enable this if using cron/jenkins triggers. There's a known bug with this which
+   * impacts some downsream pipeline triggers. Pipeline Templated triggers ALSO break with this set
+   * on. Once tests & fixes are applied can set default.
    */
-  private boolean filterFront50Pipelines = true;
+  private boolean filterFront50Pipelines = false;
 }

--- a/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheSpec.groovy
+++ b/echo-pipelinetriggers/src/test/groovy/com/netflix/spinnaker/echo/pipelinetriggers/PipelineCacheSpec.groovy
@@ -72,7 +72,11 @@ class PipelineCacheSpec extends Specification implements RetrofitStubs {
     def pipeline = Pipeline.builder().application('application').name('Pipeline').id('P1').build()
 
     def initialLoad = []
-    front50.getPipelines(true, true, supportedTriggers) >> Calls.response(initialLoad) >> { throw unavailable() } >> Calls.response([pipelineMap])
+    if (pipelineCacheConfigurationProperties.isFilterFront50Pipelines()) {
+      front50.getPipelines(true, true, supportedTriggers) >> Calls.response(initialLoad) >> { throw unavailable() } >> Calls.response([pipelineMap])
+    } else {
+      front50.getPipelines() >> Calls.response(initialLoad) >> { throw unavailable() } >> Calls.response([pipelineMap])
+    }
     pipelineCache.start()
 
     expect: 'null pipelines when we have not polled yet'


### PR DESCRIPTION
until bugs are fixed.

For reference, https://github.com/spinnaker/echo/pull/1416 enabled pipeline filtering by default.
